### PR TITLE
Fix sqitch deploy to pass SQITCH_TARGET

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,7 +10,7 @@ deploy_schema() {
     echo "Deploying database schema..."
     if [ -n "$SQITCH_TARGET" ]; then
         echo "Using sqitch target: ${SQITCH_TARGET%:*}:****"
-        if sqitch deploy; then
+        if sqitch deploy "$SQITCH_TARGET"; then
             echo "Database schema deployed successfully"
         else
             echo "Warning: Database schema deployment failed"


### PR DESCRIPTION
sqitch deploy was running without a target argument, falling back to sqitch.conf's dev target (local socket). Now passes $SQITCH_TARGET so it connects to the Render database.