### PR TITLE
Fix sqitch deploy URI scheme conversion

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,9 +8,13 @@ set -e
 # Function to deploy database schema (only for web service)
 deploy_schema() {
     echo "Deploying database schema..."
-    if [ -n "$SQITCH_TARGET" ]; then
-        echo "Using sqitch target: ${SQITCH_TARGET%:*}:****"
-        if sqitch deploy "$SQITCH_TARGET"; then
+    # Use SQITCH_TARGET if set, otherwise derive from DB_URL.
+    # Sqitch requires db:pg:// URIs, not postgresql:// — convert if needed.
+    local target="${SQITCH_TARGET:-$DB_URL}"
+    target="${target/#postgresql:/db:pg:}"
+    if [ -n "$target" ]; then
+        echo "Using sqitch target: ${target%%@*}@****"
+        if sqitch deploy "$target"; then
             echo "Database schema deployed successfully"
         else
             echo "Warning: Database schema deployment failed"

--- a/render.yaml
+++ b/render.yaml
@@ -5,10 +5,7 @@ envVarGroups:
         fromDatabase:
           name: registry-db
           property: connectionString
-      - key: SQITCH_TARGET
-        fromDatabase:
-          name: registry-db
-          property: connectionString
+
 
 databases:
   - name: registry-db


### PR DESCRIPTION
Sqitch requires db:pg:// URIs but Render provides postgresql:// connection strings. The entrypoint now converts automatically and derives from DB_URL, eliminating the need for a separate SQITCH_TARGET env var.