### PR TITLE
Rebrand for Tiny Art Empire (NCECA launch)

### DIFF
--- a/templates/index.html.ep
+++ b/templates/index.html.ep
@@ -1,11 +1,11 @@
 % layout 'default';
-% title 'Registry - After-School Program Management Made Simple';
+% title 'Tiny Art Empire - Streamline Your Art Teaching Business';
 % stash no_container => 1;
 
 % content_for 'head' => begin
   <!-- SEO Meta Tags -->
-  <meta name="description" content="Streamline your after-school programs with Registry. Manage registrations, track attendance, handle payments, and communicate with families. 30-day free trial.">
-  <meta name="keywords" content="after-school programs, registration software, program management, student tracking, attendance, payments, school administration, enrollment system">
+  <meta name="description" content="Build your Tiny Art Empire. Manage enrollment, payments, scheduling, and attendance for your after-school art programs so you can get back to the studio.">
+  <meta name="keywords" content="after-school art programs, art teaching business, ceramics classes, pottery workshops, art education, enrollment management, NCECA, program management">
   <meta name="robots" content="index, follow">
   <meta name="language" content="en-US">
   <link rel="canonical" href="<%= url_for('/')->to_abs %>">
@@ -13,21 +13,19 @@
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
   <meta property="og:url" content="<%= url_for('/')->to_abs %>">
-  <meta property="og:title" content="Registry - After-School Program Management Software">
-  <meta property="og:description" content="Complete solution for managing after-school programs. Registration, attendance, payments, and parent communication in one platform.">
+  <meta property="og:title" content="Tiny Art Empire - Streamline Your Art Teaching Business">
+  <meta property="og:description" content="You already teach art. Now streamline the business side so you can spend more time in the studio.">
   <meta property="og:image" content="<%= url_for('/images/registry-social-preview.png')->to_abs %>">
 
   <!-- Twitter -->
   <meta property="twitter:card" content="summary_large_image">
   <meta property="twitter:url" content="<%= url_for('/')->to_abs %>">
-  <meta property="twitter:title" content="Registry - After-School Program Management">
-  <meta property="twitter:description" content="Streamline your after-school programs with comprehensive management tools.">
+  <meta property="twitter:title" content="Tiny Art Empire - More Studio Time, Less Paperwork">
+  <meta property="twitter:description" content="Manage enrollment, payments, and attendance for your art programs. Built for working artists.">
   <meta property="twitter:image" content="<%= url_for('/images/registry-twitter-card.png')->to_abs %>">
 
   <!-- Performance optimizations -->
   <link rel="preconnect" href="https://js.stripe.com" crossorigin>
-  <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 
   <!-- Note: All landing page styles now in /css/design-system.css and /css/components.css -->
 
@@ -36,39 +34,30 @@
   {
     "@context": "https://schema.org",
     "@type": "SoftwareApplication",
-    "name": "Registry",
-    "description": "Complete after-school program management software solution",
+    "name": "Tiny Art Empire",
+    "description": "Program management software for art educators running after-school programs",
     "url": "<%= url_for('/')->to_abs %>",
     "applicationCategory": "BusinessApplication",
     "operatingSystem": "Web Browser",
     "offers": {
       "@type": "Offer",
-      "price": "200.00",
+      "price": "0",
       "priceCurrency": "USD",
-      "priceValidUntil": "2025-12-31",
-      "availability": "https://schema.org/InStock",
-      "description": "Monthly subscription with 30-day free trial"
+      "description": "30-day free trial"
     },
     "provider": {
       "@type": "Organization",
-      "name": "Registry",
-      "url": "<%= url_for('/')->to_abs %>",
-      "contactPoint": {
-        "@type": "ContactPoint",
-        "email": "support@registry.com",
-        "contactType": "Customer Support"
-      }
+      "name": "Super Awesome Cool Pottery",
+      "url": "<%= url_for('/')->to_abs %>"
     },
     "featureList": [
-      "Student Registration Management",
-      "Attendance Tracking",
+      "Online Enrollment",
       "Payment Processing",
-      "Parent Communication",
+      "Attendance Tracking",
+      "Schedule Management",
       "Waitlist Management",
-      "Staff Scheduling",
-      "Reporting and Analytics"
-    ],
-    "screenshot": "<%= url_for('/images/registry-screenshot.png')->to_abs %>"
+      "Parent Communication"
+    ]
   }
   </script>
 % end
@@ -83,91 +72,90 @@
 
   <!-- Navigation -->
   <nav class="landing-nav">
-    <div class="landing-logo">Registry</div>
+    <div class="landing-logo">Tiny Art Empire</div>
     <button class="landing-theme-toggle" onclick="toggleLandingTheme()" aria-label="Toggle theme">
-      <span id="landing-theme-icon">🌙</span>
+      <span id="landing-theme-icon">&#x1F319;</span>
     </button>
   </nav>
 
   <!-- Hero Section -->
   <section class="landing-hero" role="banner" aria-labelledby="hero-title">
-    <h1 id="hero-title">After-School Program Management Made Simple</h1>
+    <h1 id="hero-title">Build Your Tiny Art Empire</h1>
     <p class="landing-hero-subtitle">
-      Streamline registrations, track attendance, manage payments, and communicate with families—all in one powerful platform designed specifically for after-school programs.
+      You already teach art. Now streamline the business side -- enrollment, payments,
+      scheduling, attendance -- so you can spend the other half of your time in the studio.
     </p>
     <div class="landing-cta-container">
       <a href="<%= url_for('workflow_start', workflow => 'tenant-signup') %>" class="landing-cta-button" data-variant="success">
-        Get Started Free - No Setup Fees
-      </a>
-      <a href="#features" class="landing-cta-button landing-cta-secondary" data-variant="secondary">
-        Explore Features
+        Start Your Tiny Art Empire
       </a>
     </div>
-    <p class="landing-trial-info">30-day free trial • No credit card • Cancel anytime • Setup in 5 minutes</p>
-    <div class="landing-social-proof">
-      <p>
-        <strong>Join 500+ programs</strong> already transforming their management with Registry
-        <span style="margin-left: 1rem;">⭐ 4.9/5 from program directors</span>
-      </p>
-    </div>
+    <p class="landing-trial-info">30-day free trial &#x2022; No credit card required &#x2022; Setup in 5 minutes</p>
   </section>
 
   <!-- Features Section -->
   <section id="features" class="landing-features" role="main" aria-labelledby="features-title">
     <div class="landing-features-container">
-      <h2 id="features-title">Everything You Need to Run Successful Programs</h2>
+      <h2 id="features-title">What Tiny Art Empire Handles For You</h2>
       <div class="landing-features-grid">
         <article class="landing-feature-card">
-          <span class="landing-feature-icon" aria-hidden="true">📝</span>
-          <h3 class="landing-feature-title">Easy Registration</h3>
-          <p class="landing-feature-subtitle">Streamlined Workflows</p>
+          <span class="landing-feature-icon" aria-hidden="true">&#x1F4CB;</span>
+          <h3 class="landing-feature-title">Enrollment Made Simple</h3>
           <p class="landing-feature-description">
-            Streamlined registration workflows that handle complex family structures, multiple children, and custom program requirements.
+            Parents sign up online. You get notified. No more paper forms,
+            phone tag, or lost registrations.
           </p>
         </article>
         <article class="landing-feature-card">
-          <span class="landing-feature-icon" aria-hidden="true">💳</span>
-          <h3 class="landing-feature-title">Payment Processing</h3>
-          <p class="landing-feature-subtitle">Secure Transactions</p>
+          <span class="landing-feature-icon" aria-hidden="true">&#x1F4B3;</span>
+          <h3 class="landing-feature-title">Get Paid On Time</h3>
           <p class="landing-feature-description">
-            Secure payment processing with flexible pricing plans, automatic billing, and comprehensive financial reporting.
+            Families pay online. You get paid automatically.
+            No more chasing checks.
           </p>
         </article>
         <article class="landing-feature-card">
-          <span class="landing-feature-icon" aria-hidden="true">📊</span>
-          <h3 class="landing-feature-title">Attendance Tracking</h3>
-          <p class="landing-feature-subtitle">Real-Time Monitoring</p>
+          <span class="landing-feature-icon" aria-hidden="true">&#x2705;</span>
+          <h3 class="landing-feature-title">Know Who Shows Up</h3>
           <p class="landing-feature-description">
-            Real-time attendance management with mobile-friendly interfaces for staff and automated parent notifications.
+            Track attendance with a tap. Parents get notified
+            automatically. You always know who is in your classroom.
           </p>
         </article>
         <article class="landing-feature-card">
-          <span class="landing-feature-icon" aria-hidden="true">💬</span>
-          <h3 class="landing-feature-title">Family Communication</h3>
-          <p class="landing-feature-subtitle">Built-in Messaging</p>
+          <span class="landing-feature-icon" aria-hidden="true">&#x1F4C5;</span>
+          <h3 class="landing-feature-title">Your Schedule, Organized</h3>
           <p class="landing-feature-description">
-            Built-in messaging system to keep families informed with program updates, announcements, and direct communication.
-          </p>
-        </article>
-        <article class="landing-feature-card">
-          <span class="landing-feature-icon" aria-hidden="true">📋</span>
-          <h3 class="landing-feature-title">Waitlist Management</h3>
-          <p class="landing-feature-subtitle">Automated Processing</p>
-          <p class="landing-feature-description">
-            Automated waitlist processing with email notifications and seamless enrollment when spots become available.
-          </p>
-        </article>
-        <article class="landing-feature-card">
-          <span class="landing-feature-icon" aria-hidden="true">👥</span>
-          <h3 class="landing-feature-title">Staff Management</h3>
-          <p class="landing-feature-subtitle">Role-Based Access</p>
-          <p class="landing-feature-description">
-            Role-based access control for administrators, staff, and instructors with customizable permissions and workflows.
+            Manage classes, waitlists, and capacity in one place.
+            Fill every spot without the headache.
           </p>
         </article>
       </div>
     </div>
   </section>
+
+  <!-- Studio Time Section -->
+  <section class="landing-features" aria-labelledby="studio-title">
+    <div class="landing-features-container" style="text-align: center;">
+      <h2 id="studio-title">More Time in the Studio</h2>
+      <p style="max-width: 700px; margin: 0 auto 2rem; font-size: 1.25rem; line-height: 1.8; color: var(--landing-text-secondary);">
+        You got into teaching art because you love it. But the business side --
+        enrollment spreadsheets, payment reminders, attendance tracking -- eats
+        into your studio time. Tiny Art Empire handles all of that so you can
+        get back to making art.
+      </p>
+      <div class="landing-cta-container">
+        <a href="<%= url_for('workflow_start', workflow => 'tenant-signup') %>" class="landing-cta-button" data-variant="success">
+          Start Your Tiny Art Empire
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <!-- Footer -->
+  <footer style="text-align: center; padding: 2rem; color: var(--landing-text-secondary); font-size: 0.875rem;">
+    <p>A <strong>Super Awesome Cool Pottery</strong> project</p>
+  </footer>
 </div>
 
 <script>
@@ -181,7 +169,7 @@
     // Set theme on both landing-page and body for proper CSS variable inheritance
     landingPage.setAttribute('data-landing-theme', newTheme);
     document.body.setAttribute('data-theme', newTheme);
-    icon.textContent = newTheme === 'light' ? '🌙' : '☀️';
+    icon.textContent = newTheme === 'light' ? '\u{1F319}' : '\u2600\uFE0F';
 
     // Save preference
     localStorage.setItem('landing-theme', newTheme);
@@ -201,33 +189,33 @@
       // Set theme on both landing-page and body for proper CSS variable inheritance
       landingPage.setAttribute('data-landing-theme', theme);
       document.body.setAttribute('data-theme', theme);
-      icon.textContent = theme === 'light' ? '🌙' : '☀️';
+      icon.textContent = theme === 'light' ? '\u{1F319}' : '\u2600\uFE0F';
     }
 
     // Listen for system theme changes (only if user hasn't manually set a preference)
     window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function(e) {
       if (!localStorage.getItem('landing-theme')) {
-        const newTheme = e.matches ? 'dark' : 'light';
+        var newTheme = e.matches ? 'dark' : 'light';
         if (landingPage && icon) {
           // Set theme on both landing-page and body for proper CSS variable inheritance
           landingPage.setAttribute('data-landing-theme', newTheme);
           document.body.setAttribute('data-theme', newTheme);
-          icon.textContent = newTheme === 'light' ? '🌙' : '☀️';
+          icon.textContent = newTheme === 'light' ? '\u{1F319}' : '\u2600\uFE0F';
         }
       }
     });
   });
 
   // Add optimized parallax effect to floating shapes using requestAnimationFrame
-  let ticking = false;
+  var ticking = false;
   window.addEventListener('scroll', function() {
     if (!ticking) {
       window.requestAnimationFrame(function() {
-        const scrolled = window.pageYOffset;
-        const shapes = document.querySelectorAll('.landing-shape');
+        var scrolled = window.pageYOffset;
+        var shapes = document.querySelectorAll('.landing-shape');
 
         shapes.forEach(function(shape, index) {
-          const speed = index === 0 ? 0.5 : 0.3;
+          var speed = index === 0 ? 0.5 : 0.3;
           shape.style.transform = 'translateY(' + (scrolled * speed) + 'px)';
         });
         ticking = false;
@@ -235,19 +223,4 @@
       ticking = true;
     }
   });
-
-  // Smooth scroll for anchor links
-  document.querySelectorAll('a[href^="#"]').forEach(function(anchor) {
-    anchor.addEventListener('click', function(e) {
-      const href = this.getAttribute('href');
-      if (href !== '#') {
-        e.preventDefault();
-        const target = document.querySelector(href);
-        if (target) {
-          target.scrollIntoView({ behavior: 'smooth' });
-        }
-      }
-    });
-  });
 </script>
-

--- a/templates/layouts/default.html.ep
+++ b/templates/layouts/default.html.ep
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <title><%= title || 'Registry' %></title>
+    <title><%= title || 'Tiny Art Empire' %></title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 

--- a/templates/layouts/workflow.html.ep
+++ b/templates/layouts/workflow.html.ep
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <title><%= title || 'Registry Workflow' %></title>
+    <title><%= title || 'Tiny Art Empire' %></title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
@@ -17,7 +17,7 @@
 <body data-layout="workflow" data-theme="light">
     <!-- Navigation bar -->
     <nav class="workflow-nav">
-        <div class="workflow-logo">REGISTRY</div>
+        <div class="workflow-logo">TINY ART EMPIRE</div>
         <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">
             <span id="theme-icon">🌙</span>
         </button>

--- a/templates/tenant-signup/index.html.ep
+++ b/templates/tenant-signup/index.html.ep
@@ -1,10 +1,10 @@
 % layout 'workflow';
-% title 'Welcome to Registry - Let\'s Get Started!';
+% title 'Welcome to Tiny Art Empire';
 
 <div class="welcome-section">
     <div class="welcome-header">
-        <h2>Welcome to Registry!</h2>
-        <p class="lead">You're about to set up your organization's after-school program management system. This quick setup process will have you up and running in just a few minutes.</p>
+        <h2>Welcome to Tiny Art Empire!</h2>
+        <p class="lead">Let's set up your program management so you can get back to the studio. This quick process takes about 5 minutes.</p>
     </div>
 
     <div class="process-overview">
@@ -13,104 +13,69 @@
             <div class="step">
                 <div class="step-number">1</div>
                 <div class="step-content">
-                    <h4>Welcome & Overview</h4>
-                    <p>You are here - understanding the setup process</p>
+                    <h4>Welcome</h4>
+                    <p>You are here</p>
                 </div>
             </div>
             <div class="step">
                 <div class="step-number">2</div>
                 <div class="step-content">
-                    <h4>Organization Profile</h4>
-                    <p>Basic information about your organization and billing</p>
+                    <h4>Your Program</h4>
+                    <p>Name, description, and billing details</p>
                 </div>
             </div>
             <div class="step">
                 <div class="step-number">3</div>
                 <div class="step-content">
-                    <h4>Team Setup</h4>
-                    <p>Create your admin account and invite team members</p>
+                    <h4>Your Account</h4>
+                    <p>Create your login and invite any team members</p>
                 </div>
             </div>
             <div class="step">
                 <div class="step-number">4</div>
                 <div class="step-content">
-                    <h4>Complete Setup</h4>
-                    <p>Finalize your account and start your free trial</p>
+                    <h4>You're Live</h4>
+                    <p>Start your free trial and begin enrolling students</p>
                 </div>
             </div>
-        </div>
-        <div class="time-estimate">
-            <strong>⏱️ Estimated time:</strong> 5-10 minutes
-        </div>
-    </div>
-
-    <div class="deployment-options">
-        <h3>About Your Registry Setup</h3>
-        <div class="option-note">
-            <p><strong>You're setting up a hosted account</strong> with our managed service. This includes:</p>
-            <ul>
-                <li>✓ 30-day free trial with full features</li>
-                <li>✓ Automatic updates and maintenance</li>
-                <li>✓ 24/7 hosting and support</li>
-                <li>✓ SSL certificates and security</li>
-                <li>✓ Daily backups and disaster recovery</li>
-            </ul>
-        </div>
-        
-        <div class="self-hosting-note">
-            <p><strong>💡 Did you know?</strong> Registry is also available for self-hosting!</p>
-            <p>Download the open-source version for complete data control, unlimited customization, and no monthly fees.</p>
-            <a href="https://github.com/perigrin/Registry" target="_blank" rel="noopener" class="self-hosting-link">
-                Learn about self-hosting options →
-            </a>
         </div>
     </div>
 
     <div class="trial-info">
-        <h3>What Happens Next</h3>
+        <h3>What You Get</h3>
         <div class="trial-features">
             <div class="feature-grid">
                 <div class="feature">
-                    <span class="icon">✅</span>
-                    <strong>Full access</strong> to all Registry features
+                    <span class="icon">&#x2705;</span>
+                    <strong>Full access</strong> to all features for 30 days
                 </div>
                 <div class="feature">
-                    <span class="icon">💳</span>
+                    <span class="icon">&#x1F4B3;</span>
                     <strong>No credit card</strong> required to start
                 </div>
                 <div class="feature">
-                    <span class="icon">🔄</span>
-                    <strong>Cancel anytime</strong> during your trial
+                    <span class="icon">&#x1F3A8;</span>
+                    <strong>Your own enrollment page</strong> for parents to find you
                 </div>
                 <div class="feature">
-                    <span class="icon">📞</span>
-                    <strong>Support included</strong> to help you get started
+                    <span class="icon">&#x1F4B0;</span>
+                    <strong>Payment processing</strong> built right in
                 </div>
             </div>
         </div>
         <p class="trial-terms">
-            <small>After your 30-day trial, your subscription will be $200/month. You can cancel at any time before the trial ends with no charges.</small>
+            <small>After your 30-day trial, plans start at $200/month. Cancel anytime before the trial ends with no charges.</small>
         </p>
     </div>
 
-    <div class="support-info">
-        <h3>Need Help?</h3>
-        <p>Our team is here to help you every step of the way.</p>
-        <ul class="support-options">
-            <li>📧 Email: <a href="mailto:support@registry.com">support@registry.com</a></li>
-        </ul>
-    </div>
-
     <div class="getting-started">
-        <h3>Ready to Transform Your Program Management?</h3>
-        <p>Registry is designed to streamline your after-school programs, improve family communication, and boost operational efficiency.</p>
-        
+        <h3>Ready to Build Your Empire?</h3>
+        <p>Tiny Art Empire handles enrollment, payments, scheduling, and attendance so you can focus on teaching art.</p>
+
         <form method="POST" action="<%= $action %>" class="start-form">
             <button type="submit" class="btn btn-primary btn-xl">
-                Let's Get Started →
+                Let's Build Your Empire &#x2192;
             </button>
         </form>
     </div>
 </div>
-
-<!-- CSS moved to registry.css for proper caching -->


### PR DESCRIPTION
## Summary
Landing page and signup flow rebranded for TinyArtEmpire.com, targeting NCECA conference (Wednesday).

- Landing page copy rewritten for working artists wanting to streamline art teaching businesses
- "Build Your Tiny Art Empire" hero with studio-time messaging
- 4 focused feature cards, "More Time in the Studio" section
- Removed fake social proof
- Tenant signup welcome page rebranded
- All layout titles/logos updated
- Cyberpunk visual design kept as-is

## Test plan
- [x] CSS tests pass (t/css/)
- [x] Tenant signup tests pass
- [ ] Visual check on production after deploy