### PR TITLE
Body font: Crimson Text serif

### DIFF
--- a/public/css/design-system.css
+++ b/public/css/design-system.css
@@ -81,7 +81,7 @@
 /* Typography */
 body,
 .landing-page {
-    font-family: 'Nunito', sans-serif;
+    font-family: 'Crimson Text', serif;
 }
 
 h1, h2, h3,
@@ -276,7 +276,7 @@ body[data-layout="workflow"]::after {
 
 /* Workflow layout body styling */
 body[data-layout="workflow"] {
-    font-family: 'Nunito', sans-serif;
+    font-family: 'Crimson Text', serif;
     background: var(--bg-primary);
     color: var(--text-primary);
     overflow-x: hidden;

--- a/templates/layouts/default.html.ep
+++ b/templates/layouts/default.html.ep
@@ -7,7 +7,7 @@
     <link rel="icon" type="image/svg+xml" href="<%= static_url %>/favicon.svg">
     <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Chelsea+Market&family=Nunito:wght@400;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Chelsea+Market&family=Crimson+Text:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
 
     <!-- Design System CSS -->
     <link rel="stylesheet" href="<%= static_url %>/css/design-system.css">

--- a/templates/layouts/workflow.html.ep
+++ b/templates/layouts/workflow.html.ep
@@ -7,7 +7,7 @@
     <link rel="icon" type="image/svg+xml" href="<%= static_url %>/favicon.svg">
     <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Chelsea+Market&family=Nunito:wght@400;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Chelsea+Market&family=Crimson+Text:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
 
     <!-- Design System CSS -->
     <link rel="stylesheet" href="<%= static_url %>/css/design-system.css">


### PR DESCRIPTION
Clean elegant serif for body text. Chelsea Market (hand-drawn) for headings, Crimson Text (light serif) for body -- casual meets refined.