### PR TITLE
Body font: Cormorant light serif

### DIFF
--- a/public/css/design-system.css
+++ b/public/css/design-system.css
@@ -81,7 +81,9 @@
 /* Typography */
 body,
 .landing-page {
-    font-family: 'Crimson Text', serif;
+    font-family: 'Cormorant', serif;
+    font-weight: 300;
+    font-size: 1.1rem;
 }
 
 h1, h2, h3,
@@ -276,7 +278,7 @@ body[data-layout="workflow"]::after {
 
 /* Workflow layout body styling */
 body[data-layout="workflow"] {
-    font-family: 'Crimson Text', serif;
+    font-family: 'Cormorant', serif;
     background: var(--bg-primary);
     color: var(--text-primary);
     overflow-x: hidden;

--- a/templates/layouts/default.html.ep
+++ b/templates/layouts/default.html.ep
@@ -7,7 +7,7 @@
     <link rel="icon" type="image/svg+xml" href="<%= static_url %>/favicon.svg">
     <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Chelsea+Market&family=Crimson+Text:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Chelsea+Market&family=Cormorant:ital,wght@0,300;0,400;0,700;1,300;1,400&display=swap" rel="stylesheet">
 
     <!-- Design System CSS -->
     <link rel="stylesheet" href="<%= static_url %>/css/design-system.css">

--- a/templates/layouts/workflow.html.ep
+++ b/templates/layouts/workflow.html.ep
@@ -7,7 +7,7 @@
     <link rel="icon" type="image/svg+xml" href="<%= static_url %>/favicon.svg">
     <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Chelsea+Market&family=Crimson+Text:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Chelsea+Market&family=Cormorant:ital,wght@0,300;0,400;0,700;1,300;1,400&display=swap" rel="stylesheet">
 
     <!-- Design System CSS -->
     <link rel="stylesheet" href="<%= static_url %>/css/design-system.css">


### PR DESCRIPTION
Cormorant at 300 weight for body text. Thin and elegant, pairs well with Chelsea Market headings. Bumped base font size to 1.1rem for readability at light weight.