### PR TITLE
Fix timeline step layout on tenant signup

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -903,6 +903,13 @@ textarea.error {
   border-radius: var(--radius-lg);
 }
 
+.step {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+  margin-bottom: 1rem;
+}
+
 .step-number {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Step numbers were stacking above content instead of sitting beside it. Added flex display to .step container.