### PR TITLE
Buttons use heading font (Chelsea Market)

### DIFF
--- a/public/css/components.css
+++ b/public/css/components.css
@@ -125,6 +125,7 @@ body[data-layout="workflow"] .theme-toggle:hover {
     padding: 1.2rem 3rem;
     font-size: 1.3rem;
     font-family: 'Chelsea Market', cursive;
+    letter-spacing: 0.5px;
     border-radius: 12px;
     cursor: pointer;
     font-weight: bold;
@@ -180,6 +181,7 @@ section[data-component="workflow-content"] .button {
     border: none;
     padding: 1rem 2rem;
     font-size: 1rem;
+    font-family: 'Chelsea Market', cursive;
     border-radius: 12px;
     cursor: pointer;
     font-weight: bold;

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -37,7 +37,7 @@
   justify-content: center;
   gap: var(--space-2);
   padding: var(--space-3) var(--space-6);
-  font-family: inherit;
+  font-family: 'Chelsea Market', cursive;
   font-size: var(--font-size-base);
   font-weight: var(--font-weight-medium);
   line-height: 1;


### PR DESCRIPTION
CTAs and form buttons should have the same energy as headings, not body copy.