### PR TITLE
Fix workflow stay behavior for next_step pattern

### DIFF
--- a/lib/Registry/DAO/WorkflowRun.pm
+++ b/lib/Registry/DAO/WorkflowRun.pm
@@ -100,7 +100,10 @@ class Registry::DAO::WorkflowRun :isa(Registry::DAO::Object) {
 
         # Handle stay: persist any domain data but do NOT advance the step
         # pointer. Return the step result so the controller can detect stay.
-        my $wants_stay = $step_result->{stay};
+        # Detect both explicit `stay => 1` and the older convention of
+        # returning `next_step => $self->id` (step wants to re-render itself).
+        my $wants_stay = $step_result->{stay}
+            || (defined $step_result->{next_step} && $step_result->{next_step} eq $step->id);
 
         # Strip transient control-flow keys so only domain data is persisted.
         my %to_persist = %$step_result;

--- a/lib/Registry/DAO/WorkflowRun.pm
+++ b/lib/Registry/DAO/WorkflowRun.pm
@@ -121,9 +121,12 @@ class Registry::DAO::WorkflowRun :isa(Registry::DAO::Object) {
             }
             # Return stay signal plus template_data so the controller can
             # render the step directly with the step's output data.
+            # Steps using the older next_step convention return rendering
+            # data under 'data'; the controller expects 'template_data'.
             my %stay_result = ( stay => 1 );
             $stay_result{template_data} = $step_result->{template_data}
-                if $step_result->{template_data};
+                                       || $step_result->{data}
+                if ($step_result->{template_data} || $step_result->{data});
             $stay_result{errors} = $step_result->{errors}
                 if $step_result->{errors};
             return \%stay_result;

--- a/lib/Registry/DAO/WorkflowSteps/PricingPlanSelection.pm
+++ b/lib/Registry/DAO/WorkflowSteps/PricingPlanSelection.pm
@@ -20,9 +20,14 @@ class Registry::DAO::WorkflowSteps::PricingPlanSelection :isa(Registry::DAO::Wor
             my $pricing_data = $self->prepare_pricing_data($db);
             my $pricing_plans = $pricing_data->{pricing_plans} || [];
 
-            # Auto-select only when explicitly requested AND we have plans available
-            if (exists $form_data->{__auto_select_plan} && @$pricing_plans) {
-                # Auto-select the first plan for testing purposes
+            # When no plans are configured, skip this step entirely --
+            # there is nothing for the user to select.
+            unless (@$pricing_plans) {
+                return {};
+            }
+
+            # Auto-select the first plan when explicitly requested
+            if (exists $form_data->{__auto_select_plan}) {
                 $form_data->{selected_plan_id} = $pricing_plans->[0]->{id};
                 # Continue processing with auto-selected plan
             } else {

--- a/t/controller/camp-registration-new-parent.t
+++ b/t/controller/camp-registration-new-parent.t
@@ -144,8 +144,10 @@ subtest 'Account check - create new account' => sub {
 
 # === Step 3: Select children ===
 # Pre-create child via DAO because the "stay" semantics for add_child
-# don't work at the HTTP layer (controller always advances to next step).
-# TODO: Fix "stay" behavior in WorkflowRun::process / Controller
+# don't work at the HTTP layer yet.  WorkflowRun::process now handles
+# stay correctly (#153), but the controller's stay rendering path needs
+# work to properly re-render SelectChildren with the updated children
+# list after an add_child action.
 
 my $user = Registry::DAO::User->find($dao->db, { username => 'maria.martinez' });
 my $child = Registry::DAO::Family->add_child($dao->db, $user->id, {

--- a/t/controller/tenant-signup-data-flow.t
+++ b/t/controller/tenant-signup-data-flow.t
@@ -95,7 +95,7 @@ subtest 'profile data persists through workflow and appears on review step' => s
     # GET the pricing page
     $t->get_ok($pricing_url)->status_is(200);
 
-    # Submit pricing step (no plan to select since none are configured)
+    # Submit pricing step (skips when no plans are configured)
     $t->post_ok($pricing_url => form => {})
       ->status_is(302);
 

--- a/t/dao/tenant-on-boarding.t
+++ b/t/dao/tenant-on-boarding.t
@@ -67,8 +67,8 @@ Registry::DAO::Template->import_from_file( $dao, $_ )
         }
     );
     is $run->next_step( $dao->db )->slug, 'pricing', 'Next step is pricing';
-    # Process pricing selection - select the first available plan
-    $run->process( $dao->db, $run->next_step( $dao->db ), { selected_plan => 'basic' } );
+    # Process pricing selection - skips when no plans are configured
+    $run->process( $dao->db, $run->next_step( $dao->db ), {} );
     is $run->next_step( $dao->db )->slug, 'review', 'Next step is review';
     $run->process( $dao->db, $run->next_step( $dao->db ), {} );
     is $run->next_step( $dao->db )->slug, 'payment', 'Next step is payment';

--- a/t/dao/workflow-stay-behavior.t
+++ b/t/dao/workflow-stay-behavior.t
@@ -61,5 +61,37 @@ subtest 'next_step => step id treated as stay (does not advance)' => sub {
     my $run_after = Registry::DAO::WorkflowRun->find($dao->db, { id => $run->id });
     is $run_after->latest_step($dao->db)->id, $step->id,
        'latest_step_id did not advance';
+};
 
+subtest 'stay result forwards rendering data from "data" key' => sub {
+    # Steps using the older next_step convention return rendering data
+    # under 'data'.  The stay return must forward this as template_data
+    # so the controller can render the step with the step's output.
+    my $step_row = $dao->db->insert('workflow_steps', {
+        workflow_id => $workflow->id,
+        slug        => 'data-forward-test',
+        description => 'Step for testing data forwarding',
+        metadata    => undef,
+        class       => 'Registry::DAO::WorkflowStep',
+    }, { returning => '*' })->expand->hash;
+
+    my $step = Registry::DAO::WorkflowStep->new(%$step_row);
+
+    my $run = Registry::DAO::WorkflowRun->create($dao->db, {
+        workflow_id    => $workflow->id,
+        latest_step_id => $step->id,
+        data           => '{}',
+    });
+
+    # Simulate a step returning next_step + data (the older convention)
+    my $result = $run->process($dao->db, $step, {
+        next_step => $step->id,
+        data      => { pricing_plans => ['plan_a', 'plan_b'] },
+    });
+
+    ok $result->{stay}, 'Result has stay signal';
+    ok $result->{template_data}, 'template_data is present in stay result';
+    is ref($result->{template_data}), 'HASH', 'template_data is a hashref';
+    is scalar @{$result->{template_data}{pricing_plans}}, 2,
+       'Rendering data forwarded from "data" key to template_data';
 };

--- a/t/dao/workflow-stay-behavior.t
+++ b/t/dao/workflow-stay-behavior.t
@@ -1,0 +1,65 @@
+#!/usr/bin/env perl
+# ABOUTME: Tests that WorkflowRun::process handles the "stay" signal correctly.
+# ABOUTME: Validates both explicit stay => 1 and implicit next_step => $self->id.
+
+use 5.42.0;
+use lib qw(lib t/lib);
+use experimental qw(defer);
+use Test::More import => [qw(done_testing is ok subtest)];
+defer { done_testing };
+
+use Test::Registry::DB;
+use Registry::DAO;
+use Registry::DAO::Workflow;
+use Registry::DAO::WorkflowStep;
+use Registry::DAO::WorkflowRun;
+
+my $test_db = Test::Registry::DB->new;
+my $dao = $test_db->db;
+
+$dao->import_workflows(['workflows/tenant-signup.yml']);
+
+my $workflow = $dao->find('Registry::DAO::Workflow', { slug => 'tenant-signup' });
+ok $workflow, 'Found tenant-signup workflow';
+
+subtest 'next_step => step id treated as stay (does not advance)' => sub {
+    # Insert a test step that uses the base WorkflowStep class.
+    # The base class process() returns $data directly, so we pass
+    # next_step pointing to the step's own ID to trigger the stay path.
+    my $step_row = $dao->db->insert('workflow_steps', {
+        workflow_id => $workflow->id,
+        slug        => 'stay-test-step',
+        description => 'Step for testing stay behavior',
+        metadata    => undef,
+        class       => 'Registry::DAO::WorkflowStep',
+    }, { returning => '*' })->expand->hash;
+
+    my $step = Registry::DAO::WorkflowStep->new(%$step_row);
+    ok $step, 'Created test step';
+
+    # Create a run positioned at this step
+    my $run = Registry::DAO::WorkflowRun->create($dao->db, {
+        workflow_id    => $workflow->id,
+        latest_step_id => $step->id,
+        data           => '{}',
+    });
+    ok $run, 'Created run at test step';
+
+    # Process the step with form data that includes next_step => step's own ID.
+    # The base WorkflowStep::process returns $data as-is, so next_step will be
+    # in the result and WorkflowRun::process should detect it as a stay.
+    my $result = $run->process($dao->db, $step, {
+        next_step => $step->id,
+        some_data => 'preserved',
+    });
+
+    # The result should signal a stay
+    ok ref($result) eq 'HASH', 'Result is a hashref';
+    ok $result->{stay}, 'Result has stay signal';
+
+    # Re-read the run -- latest_step_id should NOT have changed
+    my $run_after = Registry::DAO::WorkflowRun->find($dao->db, { id => $run->id });
+    is $run_after->latest_step($dao->db)->id, $step->id,
+       'latest_step_id did not advance';
+
+};


### PR DESCRIPTION
## Summary
- `WorkflowRun::process` now recognizes `next_step => $self->id` as equivalent to `stay => 1`
- `PricingPlanSelection` skips when no plans are configured (instead of staying on empty page)
- Updated `tenant-on-boarding.t` and `tenant-signup-data-flow.t` that were relying on the broken behavior

## Context
Many workflow steps (Payment, GenerateEvents, SelectProgram, TenantPayment, PricingPlanSelection) return `next_step => $self->id` to signal "re-render this step." The engine was ignoring this and always advancing, which masked bugs and required workarounds (e.g. camp-registration-new-parent.t pre-creating children via DAO).

## Test plan
- [x] New test: `t/dao/workflow-stay-behavior.t` validates the stay detection
- [x] Full suite: 186 files, 1823 tests, 0 failures

Closes #153