### PR TITLE
Add dashboard layout with role-aware navigation

### DIFF
--- a/t/controller/dashboard-navigation.t
+++ b/t/controller/dashboard-navigation.t
@@ -1,0 +1,59 @@
+#!/usr/bin/env perl
+# ABOUTME: Tests that the dashboard layout provides role-aware navigation.
+# ABOUTME: Validates admin, staff, and parent users see appropriate nav links.
+
+BEGIN { $ENV{EMAIL_SENDER_TRANSPORT} = 'Test' }
+
+use 5.42.0;
+use lib qw(lib t/lib);
+use experimental qw(defer);
+use Test::More import => [qw(done_testing ok subtest)];
+defer { done_testing };
+
+use Test::Registry::DB;
+use Test::Registry::Mojo;
+use Test::Registry::Helpers qw(authenticate_as import_all_workflows);
+
+my $test_db = Test::Registry::DB->new;
+my $dao = $test_db->db;
+$ENV{DB_URL} = $test_db->uri;
+
+import_all_workflows($dao);
+
+my $t = Test::Registry::Mojo->new('Registry');
+$t->app->helper(dao => sub { $dao });
+
+# Create users with different roles
+my $admin = $dao->create(User => { username => 'nav_admin', user_type => 'admin', name => 'Admin User', email => 'admin@test.com' });
+my $staff = $dao->create(User => { username => 'nav_teacher', user_type => 'staff', name => 'Teacher User', email => 'teacher@test.com' });
+
+subtest 'admin sees full navigation on dashboard' => sub {
+    authenticate_as($t, $admin);
+
+    $t->get_ok('/admin/dashboard')
+      ->status_is(200)
+      ->element_exists('nav.dashboard-nav', 'Dashboard has navigation bar')
+      ->element_exists('nav.dashboard-nav a[href="/admin/dashboard"]', 'Nav has admin dashboard link')
+      ->element_exists('nav.dashboard-nav a[href="/program-creation"]', 'Nav has program creation link')
+      ->element_exists('nav.dashboard-nav a[href="/admin/templates"]', 'Nav has template editor link')
+      ->element_exists('nav.dashboard-nav a[href="/teacher/"]', 'Nav has teacher dashboard link')
+      ->element_exists('nav.dashboard-nav a[href="/admin/domains"]', 'Nav has domain management link');
+};
+
+subtest 'teacher sees limited navigation on teacher dashboard' => sub {
+    authenticate_as($t, $staff);
+
+    $t->get_ok('/teacher/')
+      ->status_is(200)
+      ->element_exists('nav.dashboard-nav', 'Dashboard has navigation bar')
+      ->element_exists('nav.dashboard-nav a[href="/admin/dashboard"]', 'Nav has admin dashboard link')
+      ->element_exists('nav.dashboard-nav a[href="/teacher/"]', 'Nav has teacher dashboard link');
+};
+
+subtest 'navigation shows current user context' => sub {
+    authenticate_as($t, $admin);
+
+    $t->get_ok('/admin/dashboard')
+      ->status_is(200)
+      ->content_like(qr/Admin User/, 'Shows current user name');
+};

--- a/t/lib/Test/Registry/Helpers.pm
+++ b/t/lib/Test/Registry/Helpers.pm
@@ -75,6 +75,12 @@ package Test::Registry::Helpers {
         }
     }
 
+    # NOTE: This registers a permanent before_dispatch hook. Calling
+    # authenticate_as multiple times accumulates hooks, but the guards
+    # (unless session/stash already set) ensure only the first takes
+    # effect per request. This is a test-only approximation -- the
+    # stash hash is built manually and may drift from the production
+    # user_to_stash closure in Registry.pm.
     sub authenticate_as ($t, $user) {
         $t->get_ok('/');  # prime the session cookie
         $t->app->hook(before_dispatch => sub ($c) {

--- a/t/lib/Test/Registry/Helpers.pm
+++ b/t/lib/Test/Registry/Helpers.pm
@@ -78,7 +78,22 @@ package Test::Registry::Helpers {
     sub authenticate_as ($t, $user) {
         $t->get_ok('/');  # prime the session cookie
         $t->app->hook(before_dispatch => sub ($c) {
-            $c->session(user_id => $user->id) unless $c->session('user_id');
+            unless ($c->session('user_id')) {
+                $c->session(user_id => $user->id);
+            }
+            # Set current_user stash so require_role and templates
+            # see the user on this request (the app's own before_dispatch
+            # hook already ran and found no session).
+            unless ($c->stash('current_user')) {
+                $c->stash(current_user => {
+                    id        => $user->id,
+                    username  => $user->username,
+                    name      => $user->name,
+                    email     => $user->email,
+                    user_type => $user->user_type,
+                    role      => $user->user_type,
+                });
+            }
         });
     }
 

--- a/templates/admin-dashboard/dashboard-overview.html.ep
+++ b/templates/admin-dashboard/dashboard-overview.html.ep
@@ -1,5 +1,6 @@
-% layout 'default';
+% layout 'dashboard';
 % title 'Admin Dashboard';
+% stash active_nav => 'admin';
 % my $step_url = url_for('workflow_step', workflow => 'admin-dashboard', run => $run->id, step => 'dashboard-overview');
 
 <div class="admin-dashboard">

--- a/templates/admin-drop-approval/admin-decision.html.ep
+++ b/templates/admin-drop-approval/admin-decision.html.ep
@@ -1,5 +1,6 @@
-% layout 'default';
+% layout 'dashboard';
 % title 'Admin Decision';
+% stash active_nav => 'admin';
 
 <h1>Admin Decision</h1>
 

--- a/templates/admin-drop-approval/complete.html.ep
+++ b/templates/admin-drop-approval/complete.html.ep
@@ -1,5 +1,6 @@
-% layout 'default';
+% layout 'dashboard';
 % title 'Drop Request Processed';
+% stash active_nav => 'admin';
 
 <h1>Drop Request Processed</h1>
 

--- a/templates/admin-drop-approval/load-request.html.ep
+++ b/templates/admin-drop-approval/load-request.html.ep
@@ -1,5 +1,6 @@
-% layout 'default';
+% layout 'dashboard';
 % title 'Loading Drop Request';
+% stash active_nav => 'admin';
 
 <h1>Loading Drop Request</h1>
 

--- a/templates/admin-drop-approval/review-request.html.ep
+++ b/templates/admin-drop-approval/review-request.html.ep
@@ -1,5 +1,6 @@
-% layout 'default';
+% layout 'dashboard';
 % title 'Review Drop Request';
+% stash active_nav => 'admin';
 
 <h1>Review Drop Request</h1>
 

--- a/templates/admin-transfer-approval/admin-decision.html.ep
+++ b/templates/admin-transfer-approval/admin-decision.html.ep
@@ -1,5 +1,6 @@
-% layout 'default';
+% layout 'dashboard';
 % title 'Admin Decision';
+% stash active_nav => 'admin';
 
 <h1>Admin Decision</h1>
 

--- a/templates/admin-transfer-approval/complete.html.ep
+++ b/templates/admin-transfer-approval/complete.html.ep
@@ -1,5 +1,6 @@
-% layout 'default';
+% layout 'dashboard';
 % title 'Transfer Request Processed';
+% stash active_nav => 'admin';
 
 <h1>Transfer Request Processed</h1>
 

--- a/templates/admin-transfer-approval/load-request.html.ep
+++ b/templates/admin-transfer-approval/load-request.html.ep
@@ -1,5 +1,6 @@
-% layout 'default';
+% layout 'dashboard';
 % title 'Loading Transfer Request';
+% stash active_nav => 'admin';
 
 <h1>Loading Transfer Request</h1>
 

--- a/templates/admin-transfer-approval/review-request.html.ep
+++ b/templates/admin-transfer-approval/review-request.html.ep
@@ -1,5 +1,6 @@
-% layout 'default';
+% layout 'dashboard';
 % title 'Review Transfer Request';
+% stash active_nav => 'admin';
 
 <h1>Review Transfer Request</h1>
 

--- a/templates/admin/domains/index.html.ep
+++ b/templates/admin/domains/index.html.ep
@@ -1,7 +1,8 @@
 %# ABOUTME: Admin template for tenant custom domain management.
 %# ABOUTME: Lists domains with status indicators, add-domain form, and DNS instructions.
-% layout 'default';
+% layout 'dashboard';
 % title 'Custom Domains';
+% stash active_nav => 'domains';
 
 <div class="container">
     <div class="admin-header">

--- a/templates/layouts/dashboard.html.ep
+++ b/templates/layouts/dashboard.html.ep
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title><%= title || 'Dashboard' %> - Tiny Art Empire</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="icon" type="image/svg+xml" href="<%= static_url %>/favicon.svg">
+    <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Alegreya+Sans:wght@300;500;700&family=Chelsea+Market&display=swap" rel="stylesheet">
+
+    <!-- CSS -->
+    <link rel="stylesheet" href="<%= static_url %>/css/theme.css">
+    <link rel="stylesheet" href="<%= static_url %>/css/app.css">
+
+    <meta name="csrf-token" content="<%= csrf_token %>">
+    <script src="https://unpkg.com/htmx.org@2.0.3"></script>
+    <%= content 'head' %>
+</head>
+<body data-layout="dashboard" data-theme="light">
+    <%# Role-aware navigation bar %>
+    <% my $user = stash('current_user') || {}; %>
+    <% my $role = $user->{role} || 'parent'; %>
+    <nav class="dashboard-nav">
+        <div class="dashboard-nav-brand">
+            <a href="/">TINY ART EMPIRE</a>
+        </div>
+        <div class="dashboard-nav-links">
+            <% if ($role eq 'admin' || $role eq 'staff') { %>
+                <a href="/admin/dashboard"
+                   class="dashboard-nav-link<%= stash('active_nav') && stash('active_nav') eq 'admin' ? ' active' : '' %>">
+                    Dashboard
+                </a>
+                <a href="/program-creation"
+                   class="dashboard-nav-link<%= stash('active_nav') && stash('active_nav') eq 'programs' ? ' active' : '' %>">
+                    New Program
+                </a>
+                <a href="/teacher/"
+                   class="dashboard-nav-link<%= stash('active_nav') && stash('active_nav') eq 'teacher' ? ' active' : '' %>">
+                    Attendance
+                </a>
+                <a href="/admin/templates"
+                   class="dashboard-nav-link<%= stash('active_nav') && stash('active_nav') eq 'templates' ? ' active' : '' %>">
+                    Templates
+                </a>
+            <% } %>
+            <% if ($role eq 'admin') { %>
+                <a href="/admin/domains"
+                   class="dashboard-nav-link<%= stash('active_nav') && stash('active_nav') eq 'domains' ? ' active' : '' %>">
+                    Domains
+                </a>
+            <% } %>
+            <% if ($role eq 'parent') { %>
+                <a href="/parent/dashboard"
+                   class="dashboard-nav-link<%= stash('active_nav') && stash('active_nav') eq 'parent' ? ' active' : '' %>">
+                    My Dashboard
+                </a>
+            <% } %>
+        </div>
+        <div class="dashboard-nav-user">
+            <% if ($user->{name}) { %>
+                <span class="dashboard-nav-username"><%= $user->{name} %></span>
+            <% } %>
+            <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">
+                <span id="theme-icon">&#x1F319;</span>
+            </button>
+        </div>
+    </nav>
+
+    <main class="dashboard-content">
+        <%= content %>
+    </main>
+
+    <script>
+        // Inject CSRF token into forms (including dynamically loaded ones)
+        function injectCsrfTokens() {
+            var token = document.querySelector('meta[name="csrf-token"]');
+            if (!token) return;
+            var tokenValue = token.getAttribute('content');
+            document.querySelectorAll('form').forEach(function(form) {
+                if (!form.querySelector('input[name="csrf_token"]')) {
+                    var input = document.createElement('input');
+                    input.type = 'hidden';
+                    input.name = 'csrf_token';
+                    input.value = tokenValue;
+                    form.appendChild(input);
+                }
+            });
+        }
+        document.addEventListener('DOMContentLoaded', injectCsrfTokens);
+        document.addEventListener('htmx:afterSwap', injectCsrfTokens);
+
+        // Configure HTMX to include CSRF token in all requests
+        document.addEventListener('htmx:configRequest', function(event) {
+            var token = document.querySelector('meta[name="csrf-token"]');
+            if (token) {
+                event.detail.headers['X-CSRF-Token'] = token.getAttribute('content');
+            }
+        });
+    </script>
+    <script>
+        // Theme toggle functionality
+        function toggleTheme() {
+            const body = document.body;
+            const currentTheme = body.getAttribute('data-theme');
+            const newTheme = currentTheme === 'light' ? 'dark' : 'light';
+
+            body.setAttribute('data-theme', newTheme);
+            localStorage.setItem('theme', newTheme);
+
+            const icon = document.getElementById('theme-icon');
+            if (icon) {
+                icon.textContent = newTheme === 'light' ? '\u{1F319}' : '\u2600\uFE0F';
+            }
+        }
+
+        window.addEventListener('DOMContentLoaded', function() {
+            const savedTheme = localStorage.getItem('theme');
+            const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+            const theme = savedTheme || (systemPrefersDark ? 'dark' : 'light');
+
+            document.body.setAttribute('data-theme', theme);
+            const icon = document.getElementById('theme-icon');
+            if (icon) {
+                icon.textContent = theme === 'light' ? '\u{1F319}' : '\u2600\uFE0F';
+            }
+
+            window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function(e) {
+                if (!localStorage.getItem('theme')) {
+                    const newTheme = e.matches ? 'dark' : 'light';
+                    document.body.setAttribute('data-theme', newTheme);
+                    const icon = document.getElementById('theme-icon');
+                    if (icon) {
+                        icon.textContent = newTheme === 'light' ? '\u{1F319}' : '\u2600\uFE0F';
+                    }
+                }
+            });
+        });
+    </script>
+    <%= content 'javascript' %>
+</body>
+</html>

--- a/templates/layouts/dashboard.html.ep
+++ b/templates/layouts/dashboard.html.ep
@@ -1,3 +1,5 @@
+%# ABOUTME: Dashboard layout with role-aware navigation for admin, staff, and parent users.
+%# ABOUTME: Provides persistent nav bar, CSRF protection, theme toggle, and HTMX integration.
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/templates/parent_dashboard/index.html.ep
+++ b/templates/parent_dashboard/index.html.ep
@@ -1,5 +1,6 @@
-% layout 'default';
+% layout 'dashboard';
 % title 'Parent Dashboard';
+% stash active_nav => 'parent';
 
 <div class="min-h-screen bg-gray-50">
     <!-- Header -->

--- a/templates/teacher/attendance.html.ep
+++ b/templates/teacher/attendance.html.ep
@@ -1,5 +1,6 @@
-% layout 'teacher';
+% layout 'dashboard';
 % title 'Take Attendance';
+% stash active_nav => 'teacher';
 
 <style>
     .event-info {

--- a/templates/teacher/dashboard.html.ep
+++ b/templates/teacher/dashboard.html.ep
@@ -1,5 +1,6 @@
-% layout 'teacher';
+% layout 'dashboard';
 % title 'Teacher Dashboard';
+% stash active_nav => 'teacher';
 
 <style>
     .section {

--- a/templates/template-editor/editor.html.ep
+++ b/templates/template-editor/editor.html.ep
@@ -1,5 +1,6 @@
-% layout 'default';
+% layout 'dashboard';
 % title 'Template Editor';
+% stash active_nav => 'templates';
 % my $view = stash('view') // 'list';
 % my $editing_template = stash('editing_template');
 % my $flash = stash('flash');


### PR DESCRIPTION
## Summary
- New `layouts/dashboard.html.ep` with persistent role-aware nav bar
- 15 templates switched from `default` to `dashboard` layout
- Nav shows role-appropriate links (admin sees everything, staff sees admin+teacher, parent sees their dashboard)
- Shows current user name in nav bar
- Fixed `authenticate_as()` helper to set stash directly

## What this enables
- Jordan can navigate from admin dashboard to program creation, template editor, and domains
- Teachers can navigate between admin dashboard and attendance
- Parents see their dashboard link
- All dashboard contexts share consistent navigation

## Test plan
- [x] New test: `t/controller/dashboard-navigation.t` validates role-based nav rendering
- [x] Full suite: 188 files, 1829 tests, 0 failures