### PR TITLE
Fix admin program location assignment workflow + smoke test

### DIFF
--- a/docs/specs/admin-program-setup.md
+++ b/docs/specs/admin-program-setup.md
@@ -1,0 +1,321 @@
+# Admin Program Setup Specification
+
+## Overview
+
+Victoria (SACP program manager) needs to build out the upcoming school year's programs, sessions, and pricing through the Registry admin interface by **May 14, 2026** (kindergarten round-up at Dr Phillips). This spec covers the admin-facing workflows for creating, configuring, and publishing programs that parents can then register for.
+
+## Architecture
+
+### Orchestrator + Sub-Workflow Pattern
+
+A parent workflow (`program-setup`) orchestrates the full setup flow using `callcc` continuations to chain independent sub-workflows. Each sub-workflow is also accessible independently for editing existing records.
+
+```
+program-setup (orchestrator)
+  |-- callcc --> program-type-management (select existing or create new)
+  |-- callcc --> program-creation (curriculum, requirements, schedule patterns)
+  |-- callcc --> location-management (select existing or create new)
+  |-- callcc --> program-location-assignment (assign program to locations, generate sessions/events)
+  |-- callcc --> pricing-plan-creation (set pricing for sessions)
+  |-- publish step (publish program, then individual sessions)
+```
+
+Each sub-workflow:
+- Works standalone (accessible via direct URL and nav/dashboard links)
+- Works as a callcc target from the orchestrator
+- Supports both "create new" and "edit existing" modes via a "select or create" entry point
+
+### Existing Workflows to Reuse
+
+These workflows already exist and have step classes + templates:
+
+| Workflow | Slug | Status |
+|----------|------|--------|
+| Program Creation | `program-creation` | Steps + templates exist, needs "select existing" entry point |
+| Program Location Assignment | `program-location-assignment` | Steps + templates exist, needs testing |
+| Pricing Plan Creation | `pricing-plan-creation` | Steps + templates exist, needs testing |
+| Session Creation | `session-creation` | Old template naming convention, needs update |
+| Event Creation | `event-creation` | Old template naming convention, needs update |
+
+### New Workflows Needed
+
+| Workflow | Slug | Purpose |
+|----------|------|---------|
+| Program Setup | `program-setup` | Orchestrator - chains sub-workflows via callcc |
+| Program Type Management | `program-type-management` | Create/edit program types |
+| Location Management | `location-management` | Create/edit locations |
+
+## Data Model
+
+### Program Type
+- `name` (string, required) - e.g., "Summer Camp", "Art Class", "After-School Program"
+- `slug` (string, auto-generated from name)
+- `config` (jsonb) - type-specific configuration
+
+Existing table: `program_types`. Verify schema supports CRUD.
+
+### Location
+- `name` (string, required) - e.g., "Dr Phillips Elementary"
+- `address` (string, required)
+- `capacity` (integer, required) - max students per session at this location
+- `contact_person_id` (FK to `users`, required) - the person responsible for this location
+
+Existing table: `locations`. Verify schema includes `contact_person_id`; add migration if missing. The contact person is a user account, so the Location Management workflow needs to support selecting an existing user or creating a new one (via callcc to account creation if needed).
+
+### Program (Project)
+- `name` (string, required)
+- `program_type_slug` (FK to program_types, required)
+- `notes` (text) - description
+- `metadata` (jsonb) - curriculum, requirements, schedule patterns
+- `published` (boolean, default false) **-- NEW FIELD**
+
+Existing table: `projects`. Add `published` column via migration.
+
+### Session
+- `project_id` (FK to projects, required)
+- `location_id` (FK to locations, required)
+- `name` (string, required)
+- `capacity` (integer, required)
+- `status` (enum: upcoming/active/completed/cancelled)
+- `published` (boolean, default false) **-- NEW FIELD**
+
+Existing table: `sessions`. Add `published` column via migration.
+
+### Publish Rules
+1. A program must be published before any of its sessions can be published
+2. Parents only see published sessions under published programs in the storefront
+3. Unpublishing a program hides all its sessions from parents (regardless of session publish state)
+
+## Workflow Specifications
+
+### 1. Program Type Management (`program-type-management`)
+
+**Steps:**
+1. **list-or-create** - Show existing program types with edit links; "Create New" button
+2. **type-details** - Name, description, configuration options
+3. **complete** - Confirmation with link back to list or to orchestrator return
+
+**Step Classes Needed:**
+- `Registry::DAO::WorkflowSteps::ProgramTypeList`
+- `Registry::DAO::WorkflowSteps::ProgramTypeDetails`
+
+### 2. Location Management (`location-management`)
+
+**Steps:**
+1. **list-or-create** - Show existing locations with edit links; "Create New" button
+2. **location-details** - Name, address, capacity
+3. **select-contact** - Select existing user as contact person, or callcc to create a new account
+4. **complete** - Confirmation with link back to list or to orchestrator return
+
+**Step Classes Needed:**
+- `Registry::DAO::WorkflowSteps::LocationList`
+- `Registry::DAO::WorkflowSteps::LocationDetails`
+- `Registry::DAO::WorkflowSteps::LocationContact`
+
+### 3. Program Creation (`program-creation`) -- EXISTING, MODIFY
+
+**Current Steps:**
+1. `program-type-selection` - Select program type (add "create new type" callcc link)
+2. `curriculum-details` - Name, description, curriculum
+3. `requirements-and-patterns` - Age/grade requirements, schedule patterns
+4. `review-and-create` - Review and create/update
+
+**Changes Needed:**
+- Add "select existing program to edit" as alternative entry path
+- Add "create new type" callcc link in step 1
+- Support edit mode (pre-populate fields from existing program)
+
+### 4. Program Location Assignment (`program-location-assignment`) -- EXISTING, VERIFY
+
+**Current Steps:**
+1. `select-program` - Select which program to assign
+2. `choose-locations` - Choose locations (add "create new location" callcc link)
+3. `configure-location` - Per-location schedule, capacity overrides
+4. `generate-events` - Generate sessions and events from schedule pattern
+5. `complete` - Summary of created sessions/events
+
+**Changes Needed:**
+- Add "create new location" callcc link in step 2
+- Verify end-to-end functionality
+
+### 5. Pricing Plan Creation (`pricing-plan-creation`) -- EXISTING, VERIFY
+
+**Current Steps:**
+1. `plan-basics` - Name, description, target program/session
+2. `pricing-model` - Pricing model configuration
+3. `resource-allocation` - Resource allocation definitions
+4. `requirements-rules` - Eligibility rules
+5. `review-activate` - Review and activate
+
+**Changes Needed:**
+- Verify end-to-end functionality
+- Ensure it can target specific sessions created in the previous step
+- Pre-seed common pricing templates Victoria can select from
+
+### 6. Program Setup Orchestrator (`program-setup`)
+
+**Steps:**
+1. **start** - "Set Up a Program" landing page. Two paths:
+   - "Create New Program" - starts the full flow
+   - "Continue Setting Up [existing program]" - shows in-progress programs
+2. **select-or-create-type** - callcc to `program-type-management`, returns selected type
+3. **create-program** - callcc to `program-creation`, returns created/selected program
+4. **assign-locations** - callcc to `program-location-assignment`, returns created sessions
+5. **set-pricing** - callcc to `pricing-plan-creation`, returns pricing plan
+6. **publish** - Publish controls:
+   - Toggle program published state
+   - List sessions with individual publish toggles
+   - "Preview as Parent" button for each
+7. **complete** - Summary with links to manage individual pieces
+
+**Step Class Needed:**
+- `Registry::DAO::WorkflowSteps::ProgramSetupStart`
+- `Registry::DAO::WorkflowSteps::ProgramPublish`
+
+Most intermediate steps are thin wrappers that launch callcc and store return values.
+
+### 7. Preview as Parent
+
+- Available from the publish step and from individual program/session views
+- Renders the storefront `program-listing` template filtered to show only the selected program
+- Ignores publish state for preview (shows the program/session as if it were published)
+- Clearly marked as "PREVIEW - Not visible to parents" with a visual indicator
+
+## Navigation Changes
+
+### Dashboard Nav Bar (admin/staff role)
+
+Current: Dashboard | New Program | Attendance | Templates | Domains
+
+Updated: Dashboard | Programs | Locations | Attendance | Templates | Domains
+
+Where:
+- **Programs** links to the program setup orchestrator (`/program-setup`)
+- **Locations** links to location management (`/location-management`)
+
+### Admin Dashboard
+
+Add management links/buttons in the dashboard:
+- "Program Overview" section: add "Set Up New Program" button, "Manage Programs" link
+- New "Locations" card or section with "Manage Locations" link
+- "Pricing" link from program cards to manage pricing for that program
+
+## Database Migrations
+
+### Migration: Add published columns
+
+```sql
+ALTER TABLE projects ADD COLUMN published BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE sessions ADD COLUMN published BOOLEAN NOT NULL DEFAULT false;
+```
+
+### Migration: Add location contact person (if missing)
+
+Verify `locations` table schema. If `contact_person_id` is missing:
+
+```sql
+ALTER TABLE locations ADD COLUMN contact_person_id INTEGER REFERENCES users(id);
+```
+
+## Storefront Changes
+
+The `ProgramListing` step must filter to only show published programs with published sessions. Update the query in `Registry::DAO::WorkflowSteps::ProgramListing` to add:
+
+```sql
+WHERE p.published = true AND s.published = true
+```
+
+## Seeded Data
+
+Pre-seed the following for Victoria's initial use:
+
+### Program Types
+- After-School Program
+- Summer Camp
+- Art Class
+- Workshop (single-day)
+
+### Locations
+- Dr Phillips Elementary (with address and contact info from Victoria)
+
+### Pricing Templates
+- Flat fee (single payment)
+- Per-session pricing
+- Sibling discount template (nice-to-have)
+
+## Error Handling
+
+- All form submissions validate required fields server-side before proceeding
+- Database errors during creation display user-friendly messages with "try again" option
+- callcc returns handle the case where the user cancels the sub-workflow (return to orchestrator without advancing)
+- Publish step validates that required data exists before allowing publish:
+  - Program has at least one session
+  - Session has events generated
+  - Session has pricing set
+  - Display clear messages about what's missing
+
+## Testing Plan
+
+### Phase 1: Smoke Test Existing Workflows
+
+Before writing new code, verify what currently works:
+
+1. **Program Creation workflow** - Can an admin navigate through all 4 steps and create a project record?
+2. **Program Location Assignment workflow** - Can it load programs, select locations, generate sessions?
+3. **Pricing Plan Creation workflow** - Can it create a pricing plan and associate it with a session?
+4. **Session Creation workflow** - Does it render with the old template naming?
+5. **Admin Dashboard** - Does it load without errors for an admin user?
+
+### Phase 2: Unit Tests for New Step Classes
+
+For each new workflow step class:
+- Test `process()` with valid form data
+- Test `process()` with missing/invalid form data
+- Test `prepare_template_data()` returns expected structure
+- Test edit mode (pre-populated from existing record)
+
+### Phase 3: Integration Tests
+
+Test the orchestrator flow end-to-end:
+1. Start program-setup workflow
+2. Create a program type (via callcc)
+3. Create a program (via callcc)
+4. Create a location (via callcc)
+5. Assign program to location and generate sessions (via callcc)
+6. Set pricing (via callcc)
+7. Publish program and sessions
+8. Verify program appears in storefront catalog
+9. Verify unpublished sessions do not appear
+
+### Phase 4: Storefront Verification
+
+1. Published program + published sessions appear in catalog
+2. Published program + unpublished sessions do not show sessions
+3. Unpublished program does not appear regardless of session state
+4. Preview shows unpublished program/sessions correctly
+
+### Phase 5: Edit/Management Tests
+
+1. Navigate to existing program via program-type-management and edit
+2. Navigate to existing location via location-management and edit
+3. Edit program details via program-creation workflow in edit mode
+4. Publish/unpublish toggles work correctly
+
+## Priority Order for May 14
+
+### Must Have
+1. Smoke test existing workflows (find out what's broken)
+2. Database migrations (published columns, location contact fields)
+3. Program Type Management workflow (create/edit types)
+4. Location Management workflow (create/edit locations)
+5. Fix any broken existing workflows (program creation, location assignment, pricing)
+6. Publish step (program + session level publish, storefront filtering)
+7. Program Setup orchestrator (callcc chain)
+8. Nav and dashboard links
+9. Seed data (program types, Dr Phillips location)
+
+### Nice to Have
+1. Preview as Parent
+2. Setup checklist on dashboard
+3. Complex pricing templates (sibling discounts, installments)
+4. Bulk session publish/unpublish

--- a/lib/Registry/DAO/Location.pm
+++ b/lib/Registry/DAO/Location.pm
@@ -20,6 +20,19 @@ class Registry::DAO::Location :isa(Registry::DAO::Object) {
 
     sub table { 'locations' }
 
+    # List all locations, ordered by name.
+    sub list ($class, $db) {
+        $db = $db->db if $db isa Registry::DAO;
+        my $results = $db->select(
+            $class->table,
+            '*',
+            {},
+            { order_by => 'name' }
+        )->expand->hashes;
+
+        return [ map { $class->new(%$_) } @$results ];
+    }
+
     sub create ( $class, $db, $data ) {
         for my $field (qw(address_info metadata contact_info facilities)) {
             next unless exists $data->{$field};

--- a/lib/Registry/DAO/Project.pm
+++ b/lib/Registry/DAO/Project.pm
@@ -17,6 +17,23 @@ class Registry::DAO::Project :isa(Registry::DAO::Object) {
 
     sub table { 'projects' }
 
+    # Description alias for the notes field, used by workflow steps that
+    # expect a description accessor (e.g. SelectProgram).
+    method description { $notes }
+
+    # List all projects, ordered by name.
+    sub list ($class, $db) {
+        $db = $db->db if $db isa Registry::DAO;
+        my $results = $db->select(
+            $class->table,
+            '*',
+            {},
+            { order_by => 'name' }
+        )->expand->hashes;
+
+        return [ map { $class->new(%$_) } @$results ];
+    }
+
     ADJUST {
         # Decode JSON metadata if it's a string
         if (defined $metadata && !ref $metadata) {

--- a/lib/Registry/DAO/Schedule.pm
+++ b/lib/Registry/DAO/Schedule.pm
@@ -47,10 +47,10 @@ method check_conflicts ($db, $teacher_id, $proposed_event) {
     
     my $existing_events = $db->select('events', '*', {
         teacher_id => $teacher_id,
-        -and => [
-            \'time >= ?', $check_start->epoch,
-            \'time <= ?', $check_end->epoch
-        ]
+        time       => {
+            '>=' => \[ 'to_timestamp(?)', $check_start->epoch ],
+            '<=' => \[ 'to_timestamp(?)', $check_end->epoch ],
+        },
     })->hashes;
     
     for my $event ($existing_events->each) {
@@ -151,11 +151,15 @@ method calculate_distance ($lat1, $lon1, $lat2, $lon2) {
 }
 
 method get_travel_time_config ($db) {
-    # Check for tenant-specific configuration
-    my $config = $db->select('tenant_profiles', ['travel_time_minutes'], 
-                            {}, { limit => 1 })->hash;
-    
-    return $config->{travel_time_minutes} // 15; # Default 15 minutes
+    # Check for tenant-specific configuration. Fall back to the default
+    # when the column or table isn't present (legacy schemas, tests).
+    my $config = eval {
+        $db->select('tenant_profiles', ['travel_time_minutes'],
+                    {}, { limit => 1 })->hash;
+    };
+    return 15 if $@ || !$config; # Default 15 minutes
+
+    return $config->{travel_time_minutes} // 15;
 }
 
 method assign_teacher ($db, $event_id, $teacher_id, $options = {}) {

--- a/lib/Registry/DAO/Session.pm
+++ b/lib/Registry/DAO/Session.pm
@@ -21,7 +21,12 @@ class Registry::DAO::Session :isa(Registry::DAO::Object) {
     field $capacity :param :reader = undef;
 
     sub table { 'sessions' }
-    
+
+    # project_id and location_id are stored inside metadata (see create())
+    # because the sessions table has no dedicated columns for them.
+    method project_id  { $metadata->{project_id} }
+    method location_id { $metadata->{location_id} }
+
     ADJUST {
         # Decode JSON metadata if it's a string
         if (defined $metadata && !ref $metadata) {

--- a/lib/Registry/DAO/WorkflowSteps/ChooseLocations.pm
+++ b/lib/Registry/DAO/WorkflowSteps/ChooseLocations.pm
@@ -16,10 +16,10 @@ method process ($db, $form_data, $run = undef) {
         # Validate all locations exist
         my @locations;
         for my $location_id (@location_ids) {
-            my $location = Registry::DAO::Location->new(
+            my $location = Registry::DAO::Location->find($db, {
                 id => $location_id
-            )->load($db);
-            
+            });
+
             unless ($location) {
                 return {
                     next_step => $self->id,

--- a/lib/Registry/DAO/WorkflowSteps/GenerateEvents.pm
+++ b/lib/Registry/DAO/WorkflowSteps/GenerateEvents.pm
@@ -8,7 +8,6 @@ use Registry::DAO::Event;
 use Registry::DAO::Session;
 use Registry::DAO::Schedule;
 use Registry::DAO::User;
-use Mojo::JSON qw(encode_json);
 use DateTime;
 
 method process ($db, $form_data, $run = undef) {

--- a/lib/Registry/DAO/WorkflowSteps/GenerateEvents.pm
+++ b/lib/Registry/DAO/WorkflowSteps/GenerateEvents.pm
@@ -73,15 +73,15 @@ method create_session_for_location ($db, $project_data, $location, $params, $tea
             project_id => $project_data->{project_id},
             location_id => $location->{id},
             name => "$project_data->{project_name} at $location->{name}",
-            description => $project_data->{project_description},
+            notes => $project_data->{project_description},
             capacity => $location->{capacity},
-            status => 'upcoming',
-            metadata => encode_json({
+            status => 'draft',
+            metadata => {
                 program_assignment => 'generated',
                 schedule => $location->{schedule},
                 pricing_override => $location->{pricing_override},
                 notes => $location->{notes}
-            })
+            }
         });
         
         # Generate events based on pattern
@@ -125,22 +125,21 @@ method generate_events_for_session ($db, $session, $location, $params, $teacher_
             # Create event with teacher assignment if provided
             my $event_data = {
                 session_id => $session->id,
-                time => $event_date->epoch,
+                time => $event_date->iso8601,
                 duration => 60, # Default 1 hour duration
                 location_id => $location->{id},
                 project_id => $session->project_id,
-                status => 'scheduled',
-                metadata => encode_json({
+                metadata => {
                     generated_from => 'location_assignment',
                     week_number => $week + 1,
                     day_name => $day_name
-                })
+                }
             };
-            
+
             # Add teacher assignment if provided
             if ($teacher_id) {
                 $event_data->{teacher_id} = $teacher_id;
-                
+
                 # Check for conflicts if teacher assignment is specified
                 my $schedule_dao = Registry::DAO::Schedule->new();
                 my $conflicts = $schedule_dao->check_conflicts($db, $teacher_id, {
@@ -148,13 +147,10 @@ method generate_events_for_session ($db, $session, $location, $params, $teacher_
                     duration => 60,
                     location_id => $location->{id}
                 });
-                
+
                 if (@$conflicts) {
                     # For now, continue with assignment but add conflict info to metadata
-                    $event_data->{metadata} = encode_json({
-                        %{decode_json($event_data->{metadata})},
-                        teacher_conflicts => $conflicts
-                    });
+                    $event_data->{metadata}{teacher_conflicts} = $conflicts;
                 }
             }
             

--- a/lib/Registry/DAO/WorkflowSteps/SelectProgram.pm
+++ b/lib/Registry/DAO/WorkflowSteps/SelectProgram.pm
@@ -12,10 +12,10 @@ method process ($db, $form_data, $run = undef) {
     # If form was submitted
     if ($form_data->{project_id}) {
         # Validate project exists
-        my $project = Registry::DAO::Project->new(
+        my $project = Registry::DAO::Project->find($db, {
             id => $form_data->{project_id}
-        )->load($db);
-        
+        });
+
         unless ($project) {
             return {
                 next_step => $self->id,

--- a/t/dao/admin-workflow-smoke.t
+++ b/t/dao/admin-workflow-smoke.t
@@ -386,6 +386,31 @@ subtest 'Location Assignment: GenerateEvents step' => sub {
     }
     elsif ($result && $result->{next_step} && $result->{next_step} ne $step->id) {
         is($result->{next_step}, 'complete', 'advances to complete');
+
+        # Verify DB side effects: a session and four weekly events (two days
+        # per week for four weeks = 8 events) actually got written with the
+        # correct shape.
+        my $session_count = $db->query(
+            'SELECT COUNT(*) FROM sessions WHERE name LIKE ?',
+            '%Dr Phillips Elementary%'
+        )->array->[0];
+        is($session_count, 1, 'session row written');
+
+        my $event_count = $db->query(
+            'SELECT COUNT(*) FROM events WHERE location_id = ? AND teacher_id = ?',
+            $location->id, $admin->id
+        )->array->[0];
+        is($event_count, 8, '8 events written (2 days/week x 4 weeks)');
+
+        # Events should have the correct teacher, location, and project.
+        my $sample_event = $db->query(
+            'SELECT teacher_id, location_id, project_id, status FROM events
+             WHERE location_id = ? LIMIT 1',
+            $location->id
+        )->hash;
+        is($sample_event->{teacher_id},  $admin->id,    'event has teacher_id');
+        is($sample_event->{location_id}, $location->id, 'event has location_id');
+        ok($sample_event->{project_id}, 'event has project_id');
     }
     else {
         fail('GenerateEvents did not advance');

--- a/t/dao/admin-workflow-smoke.t
+++ b/t/dao/admin-workflow-smoke.t
@@ -1,0 +1,510 @@
+#!/usr/bin/env perl
+# ABOUTME: Smoke test for admin program setup workflows.
+# ABOUTME: Exercises each workflow step's process() method end-to-end to find breakage.
+use 5.42.0;
+use warnings;
+use lib qw(lib t/lib);
+use Test::More;
+use Test::Registry::DB;
+use Test::Registry::Fixtures;
+use Registry::DAO::Workflow;
+use Registry::DAO::WorkflowStep;
+use Registry::DAO::User;
+use Registry::DAO::Project;
+use Registry::DAO::ProgramType;
+use Registry::DAO::Location;
+use Registry::DAO::Session;
+use Registry::DAO::Event;
+use Mojo::JSON qw(encode_json decode_json);
+
+my $test_db = Test::Registry::DB->new;
+my $dao     = $test_db->db;
+
+# Create test tenant and set up schema
+my $tenant = Test::Registry::Fixtures::create_tenant($dao->db, {
+    name => 'Smoke Test Tenant',
+    slug => 'smoke_test_admin',
+});
+$dao->db->query('SELECT clone_schema(?)', 'smoke_test_admin');
+
+# Switch to tenant schema
+$dao = Registry::DAO->new(url => $test_db->uri, schema => 'smoke_test_admin');
+my $db = $dao->db;
+
+# -- Seed data ---------------------------------------------------------------
+
+my $admin = Registry::DAO::User->create($db, {
+    name     => 'Victoria Admin',
+    username => 'victoria',
+    email    => 'victoria@example.com',
+    user_type => 'staff',
+    password => 'test123',
+});
+
+my $program_type = Registry::DAO::ProgramType->create($db, {
+    name   => 'After School Program',
+    slug   => 'after-school',
+    config => encode_json({
+        description      => 'After-school enrichment',
+        default_capacity => 15,
+        session_pattern  => 'weekly',
+    }),
+});
+
+my $location = Registry::DAO::Location->create($db, {
+    name         => 'Dr Phillips Elementary',
+    address_info => {
+        street_address => '123 School Rd',
+        city           => 'Orlando',
+        state          => 'FL',
+        postal_code    => '32819',
+    },
+    capacity => 20,
+    metadata => {},
+});
+
+# -- 1. Program Creation Workflow ---------------------------------------------
+
+subtest 'Program Creation: ProgramTypeSelection step' => sub {
+    require Registry::DAO::WorkflowSteps::ProgramTypeSelection;
+
+    my $workflow = Registry::DAO::Workflow->create($db, {
+        name       => 'Program Creation Smoke',
+        slug       => 'program_creation_smoke',
+        description => 'Smoke test',
+        first_step => 'program-type-selection',
+    });
+
+    $workflow->add_step($db, { slug => 'program-type-selection', description => 'Select type',
+        class => 'Registry::DAO::WorkflowSteps::ProgramTypeSelection' });
+    $workflow->add_step($db, { slug => 'curriculum-details', description => 'Curriculum',
+        class => 'Registry::DAO::WorkflowSteps::CurriculumDetails' });
+    $workflow->add_step($db, { slug => 'requirements-and-patterns', description => 'Requirements',
+        class => 'Registry::DAO::WorkflowSteps::RequirementsAndPatterns' });
+    $workflow->add_step($db, { slug => 'review-and-create', description => 'Review',
+        class => 'Registry::DAO::WorkflowSteps::ReviewAndCreate' });
+    $workflow->add_step($db, { slug => 'complete', description => 'Done',
+        class => 'Registry::DAO::WorkflowStep' });
+
+    my $run  = $workflow->new_run($db);
+    my $step = Registry::DAO::WorkflowSteps::ProgramTypeSelection->find($db, {
+        workflow_id => $workflow->id,
+        slug        => 'program-type-selection',
+    });
+    ok($step, 'ProgramTypeSelection step found');
+
+    # Test prepare_template_data
+    my $template_data = eval { $step->prepare_template_data($db, $run) };
+    ok(!$@, 'prepare_template_data does not crash') or diag("Error: $@");
+    ok($template_data->{program_types}, 'template data includes program_types');
+
+    # Test process with no selection (should stay)
+    my $result = eval { $step->process($db, {}, $run) };
+    ok(!$@, 'process with empty data does not crash') or diag("Error: $@");
+    ok($result->{stay}, 'stays on step with no selection');
+
+    # Test process with valid selection
+    $result = eval { $step->process($db, { program_type_slug => 'after-school' }, $run) };
+    ok(!$@, 'process with valid selection does not crash') or diag("Error: $@");
+    is($result->{program_type_slug}, 'after-school', 'returns selected slug');
+
+    # Merge result into run data for next steps
+    $run->update_data($db, $result);
+};
+
+subtest 'Program Creation: CurriculumDetails step' => sub {
+    require Registry::DAO::WorkflowSteps::CurriculumDetails;
+
+    # Reuse the workflow from previous subtest by finding the run
+    my $workflow = Registry::DAO::Workflow->find($db, { slug => 'program_creation_smoke' });
+    my $run = $workflow->latest_run($db);
+    my $step = Registry::DAO::WorkflowSteps::CurriculumDetails->find($db, {
+        workflow_id => $workflow->id,
+        slug        => 'curriculum-details',
+    });
+    ok($step, 'CurriculumDetails step found');
+
+    # Test validation - missing required fields
+    my $result = eval { $step->process($db, {}, $run) };
+    ok(!$@, 'process with empty data does not crash') or diag("Error: $@");
+    ok($result->{errors}, 'returns errors for missing fields');
+
+    # Test with valid data
+    $result = eval {
+        $step->process($db, {
+            name        => 'Art Adventures',
+            description => 'A creative after-school art program',
+            learning_objectives => 'Color theory, mixed media',
+        }, $run);
+    };
+    ok(!$@, 'process with valid data does not crash') or diag("Error: $@");
+    ok($result->{curriculum}, 'returns curriculum data');
+    is($result->{curriculum}{name}, 'Art Adventures', 'curriculum name correct');
+
+    $run->update_data($db, $result);
+};
+
+subtest 'Program Creation: RequirementsAndPatterns step' => sub {
+    require Registry::DAO::WorkflowSteps::RequirementsAndPatterns;
+
+    my $workflow = Registry::DAO::Workflow->find($db, { slug => 'program_creation_smoke' });
+    my $run = $workflow->latest_run($db);
+    my $step = Registry::DAO::WorkflowSteps::RequirementsAndPatterns->find($db, {
+        workflow_id => $workflow->id,
+        slug        => 'requirements-and-patterns',
+    });
+    ok($step, 'RequirementsAndPatterns step found');
+
+    # Test with no data (should stay)
+    my $result = eval { $step->process($db, {}, $run) };
+    ok(!$@, 'process with empty data does not crash') or diag("Error: $@");
+    ok($result->{stay}, 'stays when no min_age submitted');
+
+    # Test with valid data
+    $result = eval {
+        $step->process($db, {
+            min_age                  => 5,
+            max_age                  => 12,
+            min_grade                => 'K',
+            max_grade                => '6',
+            duration_weeks           => 10,
+            sessions_per_week        => 2,
+            session_duration_minutes => 90,
+        }, $run);
+    };
+    ok(!$@, 'process with valid data does not crash') or diag("Error: $@");
+    ok($result->{requirements}, 'returns requirements');
+    ok($result->{schedule_pattern}, 'returns schedule_pattern');
+
+    # Test validation - min > max age
+    $result = eval { $step->process($db, { min_age => 12, max_age => 5 }, $run) };
+    ok(!$@, 'process with invalid age range does not crash') or diag("Error: $@");
+    ok($result->{errors}, 'returns errors for invalid age range');
+
+    $run->update_data($db, {
+        requirements     => $result->{requirements} // { min_age => 5, max_age => 12 },
+        schedule_pattern => $result->{schedule_pattern} // { duration_weeks => 10 },
+    });
+};
+
+subtest 'Program Creation: ReviewAndCreate step' => sub {
+    require Registry::DAO::WorkflowSteps::ReviewAndCreate;
+
+    my $workflow = Registry::DAO::Workflow->find($db, { slug => 'program_creation_smoke' });
+    my $run = $workflow->latest_run($db);
+    my $step = Registry::DAO::WorkflowSteps::ReviewAndCreate->find($db, {
+        workflow_id => $workflow->id,
+        slug        => 'review-and-create',
+    });
+    ok($step, 'ReviewAndCreate step found');
+
+    # Test prepare_template_data
+    my $template_data = eval { $step->prepare_template_data($db, $run) };
+    ok(!$@, 'prepare_template_data does not crash') or diag("Error: $@");
+
+    # Test without confirmation (should stay)
+    my $result = eval { $step->process($db, {}, $run) };
+    ok(!$@, 'process without confirm does not crash') or diag("Error: $@");
+    ok($result->{stay}, 'stays without confirmation');
+
+    # Test with confirmation - creates the project
+    $result = eval { $step->process($db, { confirm => 1 }, $run) };
+    ok(!$@, 'process with confirm does not crash') or diag("Error: $@");
+    ok($result->{created_project_id}, 'project was created') or diag(explain($result));
+
+    # Verify project exists in database
+    if ($result->{created_project_id}) {
+        my $project = Registry::DAO::Project->find($db, { id => $result->{created_project_id} });
+        ok($project, 'project exists in database');
+        is($project->name, 'Art Adventures', 'project has correct name');
+    }
+};
+
+# -- 2. Program Location Assignment Workflow ----------------------------------
+
+subtest 'Location Assignment: SelectProgram step' => sub {
+    require Registry::DAO::WorkflowSteps::SelectProgram;
+
+    my $workflow = Registry::DAO::Workflow->create($db, {
+        name        => 'Location Assignment Smoke',
+        slug        => 'location_assignment_smoke',
+        description => 'Smoke test',
+        first_step  => 'select-program',
+    });
+
+    $workflow->add_step($db, { slug => 'select-program', description => 'Select program',
+        class => 'Registry::DAO::WorkflowSteps::SelectProgram' });
+    $workflow->add_step($db, { slug => 'choose-locations', description => 'Choose locations',
+        class => 'Registry::DAO::WorkflowSteps::ChooseLocations' });
+    $workflow->add_step($db, { slug => 'configure-location', description => 'Configure',
+        class => 'Registry::DAO::WorkflowSteps::ConfigureLocation' });
+    $workflow->add_step($db, { slug => 'generate-events', description => 'Generate',
+        class => 'Registry::DAO::WorkflowSteps::GenerateEvents' });
+    $workflow->add_step($db, { slug => 'complete', description => 'Done',
+        class => 'Registry::DAO::WorkflowStep' });
+
+    my $run  = $workflow->new_run($db);
+    my $step = Registry::DAO::WorkflowSteps::SelectProgram->find($db, {
+        workflow_id => $workflow->id,
+        slug        => 'select-program',
+    });
+    ok($step, 'SelectProgram step found');
+
+    # Test prepare_data - calls Project->list() which may not exist
+    my $data = eval { $step->prepare_data($db) };
+    ok(!$@, 'prepare_data does not crash (Project->list)') or diag("Error: $@");
+
+    # Create a project directly for this test in case ReviewAndCreate failed
+    my $project = Registry::DAO::Project->find($db, { name => 'Art Adventures' });
+    unless ($project) {
+        $project = Registry::DAO::Project->create($db, {
+            name              => 'Smoke Test Program',
+            program_type_slug => 'after-school',
+            notes             => 'Created for smoke test',
+        });
+    }
+    ok($project, 'test project exists');
+
+    # Test process with project selection - calls Project->new(...)->load()
+    my $result = eval { $step->process($db, { project_id => $project->id }, $run) };
+    ok(!$@, 'process with project_id does not crash (Project->load)') or diag("Error: $@");
+
+    if ($result && !$@) {
+        is($result->{next_step}, 'choose-locations', 'advances to choose-locations');
+    }
+};
+
+subtest 'Location Assignment: ChooseLocations step' => sub {
+    require Registry::DAO::WorkflowSteps::ChooseLocations;
+
+    my $workflow = Registry::DAO::Workflow->find($db, { slug => 'location_assignment_smoke' });
+    my $run  = $workflow->latest_run($db);
+    my $step = Registry::DAO::WorkflowSteps::ChooseLocations->find($db, {
+        workflow_id => $workflow->id,
+        slug        => 'choose-locations',
+    });
+    ok($step, 'ChooseLocations step found');
+
+    # Test prepare_data - calls Location->list() which does not exist
+    my $data = eval { $step->prepare_data($db) };
+    ok(!$@, 'prepare_data does not crash (Location->list)') or diag("Error: $@");
+
+    # Test process with location selection - calls Location->new(...)->load()
+    my $result = eval {
+        $step->process($db, { location_ids => [$location->id] }, $run);
+    };
+    ok(!$@, 'process with location_ids does not crash (Location->load)') or diag("Error: $@");
+
+    if (!$@) {
+        is($result->{next_step}, 'configure-location', 'advances to configure-location');
+    }
+};
+
+subtest 'Location Assignment: ConfigureLocation step' => sub {
+    require Registry::DAO::WorkflowSteps::ConfigureLocation;
+
+    my $workflow = Registry::DAO::Workflow->find($db, { slug => 'location_assignment_smoke' });
+    my $run  = $workflow->latest_run($db);
+    my $step = Registry::DAO::WorkflowSteps::ConfigureLocation->find($db, {
+        workflow_id => $workflow->id,
+        slug        => 'configure-location',
+    });
+    ok($step, 'ConfigureLocation step found');
+
+    # Ensure run data has selected_locations from previous step
+    my $selected = $run->data->{selected_locations};
+    unless ($selected && @$selected) {
+        fail('run has selected_locations data - previous step failed');
+        return;
+    }
+    pass('run has selected_locations data');
+
+    my $location_id = $selected->[0]{id};
+
+    # Test process with configuration
+    my $result = eval {
+        $step->process($db, {
+            location_configs => {
+                $location_id => {
+                    capacity => 20,
+                    schedule => { tuesday => '15:30', thursday => '15:30' },
+                    notes    => 'Main art room',
+                },
+            },
+        }, $run);
+    };
+    ok(!$@, 'process with config does not crash') or diag("Error: $@");
+
+    if (!$@) {
+        is($result->{next_step}, 'generate-events', 'advances to generate-events');
+    }
+};
+
+subtest 'Location Assignment: GenerateEvents step' => sub {
+    require Registry::DAO::WorkflowSteps::GenerateEvents;
+
+    my $workflow = Registry::DAO::Workflow->find($db, { slug => 'location_assignment_smoke' });
+    my $run  = $workflow->latest_run($db);
+    my $step = Registry::DAO::WorkflowSteps::GenerateEvents->find($db, {
+        workflow_id => $workflow->id,
+        slug        => 'generate-events',
+    });
+    ok($step, 'GenerateEvents step found');
+
+    # Ensure run data has configured_locations
+    my $configured = $run->data->{configured_locations};
+    unless ($configured && @$configured) {
+        fail('run has configured_locations data - previous step failed');
+        return;
+    }
+    pass('run has configured_locations data');
+
+    # Test prepare_data
+    my $data = eval { $step->prepare_data($db) };
+    ok(!$@, 'prepare_data does not crash') or diag("Error: $@");
+
+    # Test event generation
+    my $start_epoch = time() + 86400 * 7; # one week from now
+    my $result = eval {
+        $step->process($db, {
+            confirm_generation   => 1,
+            generation_params    => {
+                start_date     => $start_epoch,
+                duration_weeks => 4,
+            },
+        }, $run);
+    };
+    ok(!$@, 'process with generation params does not crash') or diag("Error: $@");
+
+    if ($result && $result->{next_step}) {
+        is($result->{next_step}, 'complete', 'advances to complete');
+    }
+    elsif ($result && $result->{errors}) {
+        diag("Generation errors: @{$result->{errors}}");
+    }
+};
+
+# -- 3. Pricing Plan Creation Workflow ----------------------------------------
+
+subtest 'Pricing: PricingPlanBasics step' => sub {
+    require Registry::DAO::WorkflowSteps::PricingPlanBasics;
+    require Registry::DAO::PricingPlan;
+
+    my $workflow = Registry::DAO::Workflow->create($db, {
+        name        => 'Pricing Smoke',
+        slug        => 'pricing_smoke',
+        description => 'Smoke test',
+        first_step  => 'plan-basics',
+    });
+
+    $workflow->add_step($db, { slug => 'plan-basics', description => 'Plan basics',
+        class => 'Registry::DAO::WorkflowSteps::PricingPlanBasics' });
+    $workflow->add_step($db, { slug => 'pricing-model', description => 'Pricing model',
+        class => 'Registry::DAO::WorkflowStep' });
+    $workflow->add_step($db, { slug => 'resource-allocation', description => 'Resources',
+        class => 'Registry::DAO::WorkflowStep' });
+    $workflow->add_step($db, { slug => 'requirements-rules', description => 'Rules',
+        class => 'Registry::DAO::WorkflowStep' });
+    $workflow->add_step($db, { slug => 'review-activate', description => 'Review',
+        class => 'Registry::DAO::WorkflowStep' });
+
+    my $run  = $workflow->new_run($db);
+    my $step = Registry::DAO::WorkflowSteps::PricingPlanBasics->find($db, {
+        workflow_id => $workflow->id,
+        slug        => 'plan-basics',
+    });
+    ok($step, 'PricingPlanBasics step found');
+
+    # Test prepare_template_data
+    my $template_data = eval { $step->prepare_template_data($db, $run) };
+    ok(!$@, 'prepare_template_data does not crash') or diag("Error: $@");
+    ok($template_data->{plan_types}, 'returns plan_types');
+
+    # Test validation - missing required fields
+    my $result = eval { $step->process($db, {}, $run) };
+    ok(!$@, 'process with empty data does not crash') or diag("Error: $@");
+    ok($result->{stay}, 'stays on step with missing fields');
+    ok($result->{errors}, 'returns validation errors');
+
+    # Test with valid data
+    $result = eval {
+        $step->process($db, {
+            plan_name        => 'After School Standard',
+            plan_description => 'Standard pricing for after school programs',
+            plan_type        => 'one_time',
+            target_audience  => 'individual',
+            plan_scope       => 'customer',
+        }, $run);
+    };
+    ok(!$@, 'process with valid data does not crash') or diag("Error: $@");
+
+    if ($result && !$result->{stay}) {
+        ok($result->{next_step}, 'advances to next step');
+    }
+    else {
+        diag('PricingPlanBasics did not advance: ' . explain($result));
+    }
+};
+
+# -- 4. Session Creation Workflow (old-style) ---------------------------------
+
+subtest 'Session Creation: CreateSession step' => sub {
+    require Registry::DAO::WorkflowSteps::CreateSession;
+
+    ok(Registry::DAO::WorkflowSteps::CreateSession->isa('Registry::DAO::WorkflowStep'),
+       'CreateSession inherits from WorkflowStep');
+    can_ok('Registry::DAO::WorkflowSteps::CreateSession', 'process');
+};
+
+# -- 5. Event Creation Workflow (old-style) -----------------------------------
+
+subtest 'Event Creation: CreateEvent step' => sub {
+    require Registry::DAO::WorkflowSteps::CreateEvent;
+
+    ok(Registry::DAO::WorkflowSteps::CreateEvent->isa('Registry::DAO::WorkflowStep'),
+       'CreateEvent inherits from WorkflowStep');
+    can_ok('Registry::DAO::WorkflowSteps::CreateEvent', 'process');
+};
+
+# -- 6. Method existence checks -----------------------------------------------
+
+subtest 'DAO method existence checks' => sub {
+    # Methods called by workflow steps that may not exist
+    ok(Registry::DAO::Project->can('find'),   'Project->find exists');
+    ok(Registry::DAO::Location->can('find'),  'Location->find exists');
+
+    # These are called by workflow steps but may not exist on base Object
+    my $has_project_list  = Registry::DAO::Project->can('list');
+    my $has_location_list = Registry::DAO::Location->can('list');
+
+    ok($has_project_list,  'Project->list exists')
+        or diag('MISSING: SelectProgram calls Project->list() but it does not exist');
+    ok($has_location_list, 'Location->list exists')
+        or diag('MISSING: ChooseLocations calls Location->list() but it does not exist');
+
+    # SelectProgram and ChooseLocations call ->new(id => $id)->load($db)
+    # but Object base class has no load() method
+    my $has_project_load  = Registry::DAO::Project->can('load');
+    my $has_location_load = Registry::DAO::Location->can('load');
+
+    ok($has_project_load,  'Project->load exists')
+        or diag('MISSING: SelectProgram calls Project->new(id => $id)->load($db)');
+    ok($has_location_load, 'Location->load exists')
+        or diag('MISSING: ChooseLocations calls Location->new(id => $id)->load($db)');
+
+    # SelectProgram stores $project->description but Project has no description method
+    my $has_project_desc = Registry::DAO::Project->can('description');
+    ok($has_project_desc, 'Project->description exists')
+        or diag('MISSING: SelectProgram stores $project->description but Project has notes, not description');
+
+    # GenerateEvents calls $session->project_id but Session has no project_id accessor
+    my $has_session_project_id = Registry::DAO::Session->can('project_id');
+    ok($has_session_project_id, 'Session->project_id exists')
+        or diag('MISSING: GenerateEvents line 131 calls $session->project_id but Session has no such accessor');
+
+    # PricingPlan needs to be findable by plan_name
+    require Registry::DAO::PricingPlan;
+    ok(Registry::DAO::PricingPlan->can('find'), 'PricingPlan->find exists');
+};
+
+done_testing();

--- a/t/dao/admin-workflow-smoke.t
+++ b/t/dao/admin-workflow-smoke.t
@@ -364,23 +364,31 @@ subtest 'Location Assignment: GenerateEvents step' => sub {
     ok(!$@, 'prepare_data does not crash') or diag("Error: $@");
 
     # Test event generation
+    # Note: events.teacher_id is NOT NULL, so a teacher must be assigned
     my $start_epoch = time() + 86400 * 7; # one week from now
+    my $location_id = $configured->[0]{id};
     my $result = eval {
         $step->process($db, {
-            confirm_generation   => 1,
-            generation_params    => {
+            confirm_generation  => 1,
+            generation_params   => {
                 start_date     => $start_epoch,
                 duration_weeks => 4,
+            },
+            teacher_assignments => {
+                $location_id => $admin->id,
             },
         }, $run);
     };
     ok(!$@, 'process with generation params does not crash') or diag("Error: $@");
 
-    if ($result && $result->{next_step}) {
+    if ($result && $result->{errors}) {
+        fail('GenerateEvents returned errors: ' . join('; ', @{$result->{errors}}));
+    }
+    elsif ($result && $result->{next_step} && $result->{next_step} ne $step->id) {
         is($result->{next_step}, 'complete', 'advances to complete');
     }
-    elsif ($result && $result->{errors}) {
-        diag("Generation errors: @{$result->{errors}}");
+    else {
+        fail('GenerateEvents did not advance');
     }
 };
 
@@ -481,16 +489,6 @@ subtest 'DAO method existence checks' => sub {
         or diag('MISSING: SelectProgram calls Project->list() but it does not exist');
     ok($has_location_list, 'Location->list exists')
         or diag('MISSING: ChooseLocations calls Location->list() but it does not exist');
-
-    # SelectProgram and ChooseLocations call ->new(id => $id)->load($db)
-    # but Object base class has no load() method
-    my $has_project_load  = Registry::DAO::Project->can('load');
-    my $has_location_load = Registry::DAO::Location->can('load');
-
-    ok($has_project_load,  'Project->load exists')
-        or diag('MISSING: SelectProgram calls Project->new(id => $id)->load($db)');
-    ok($has_location_load, 'Location->load exists')
-        or diag('MISSING: ChooseLocations calls Location->new(id => $id)->load($db)');
 
     # SelectProgram stores $project->description but Project has no description method
     my $has_project_desc = Registry::DAO::Project->can('description');


### PR DESCRIPTION
## Summary

- Adds admin program setup spec at \`docs/specs/admin-program-setup.md\`.
- Adds smoke test exercising each admin workflow step's \`process()\` method end-to-end.
- Fixes the program-location-assignment workflow, which was broken with cascading bugs that made it unusable.

## Context

Victoria (SACP program manager) needs to create programs, sessions, locations, and pricing through the admin UI by May 14, 2026 (kindergarten round-up at Dr Phillips). Before writing new features from the spec, we smoke-tested the existing admin workflows. Five of twelve subtests failed. This PR makes them pass.

## Changes

**DAO additions:**
- \`Project->list\`, \`Project->description\` (alias for \`notes\`)
- \`Location->list\`
- \`Session->project_id\`, \`Session->location_id\` accessors reading from metadata

**Workflow step fixes:**
- \`SelectProgram\`, \`ChooseLocations\`: replace broken \`->new(id => \$id)->load(\$db)\` pattern with \`find(\$db, {id => \$id})\` (the old pattern could not work — constructors require \`name\`, and no \`load\` method exists anywhere)
- \`GenerateEvents\`: four-way fix
  - session status \`upcoming\` -> \`draft\` (CHECK constraint rejects \`upcoming\`)
  - session field name \`description\` -> \`notes\` (column doesn't exist)
  - metadata passed as hashref (\`Session->create\` handles JSON encoding internally)
  - event time as ISO-8601 string (events.time column rejects raw epoch integers)

**Schedule fixes:**
- \`get_travel_time_config\` tolerates missing \`tenant_profiles.travel_time_minutes\` column (tracked as #168)
- \`check_conflicts\` SQL rewritten to fix unbound placeholder error

## Follow-up Issues

- #168 Add \`tenant_profiles.travel_time_minutes\` column, remove defensive eval
- #169 Add \`project_id\`/\`location_id\` FK columns to sessions, remove metadata-reading accessors
- #170 Replace remaining \`->new->load\` callers in Schedule/Payment/InstallmentPayment
- #171 Unify DAO \`list\` method signatures

## Test plan

- [x] Smoke test \`t/dao/admin-workflow-smoke.t\` passes (12/12 subtests)
- [x] Full test suite passes (191 files, 1853 tests, zero regressions)
- [x] Smoke test asserts DB side effects, not just that steps don't crash