### PR TITLE
Add status to projects and contact_person_id to locations

### DIFF
--- a/lib/Registry/DAO/Location.pm
+++ b/lib/Registry/DAO/Location.pm
@@ -12,6 +12,7 @@ class Registry::DAO::Location :isa(Registry::DAO::Object) {
     field $notes :param :reader = undef;
     field $capacity :param :reader = undef;
     field $contact_info :param :reader = {};
+    field $contact_person_id :param :reader = undef;
     field $facilities :param :reader = {};
     field $latitude :param :reader = undef;
     field $longitude :param :reader = undef;

--- a/lib/Registry/DAO/Project.pm
+++ b/lib/Registry/DAO/Project.pm
@@ -12,6 +12,7 @@ class Registry::DAO::Project :isa(Registry::DAO::Object) {
     field $program_type_slug :param :reader;
     field $metadata :param :reader = {};
     field $notes :param :reader = '';
+    field $status :param :reader = 'draft';
     field $created_at :param :reader;
     field $updated_at :param :reader;
 

--- a/sql/deploy/program-publish-status.sql
+++ b/sql/deploy/program-publish-status.sql
@@ -1,0 +1,61 @@
+-- ABOUTME: Add status enum and contact person FK to support the admin
+-- ABOUTME: program setup workflow. Mirrors sessions.status semantics.
+
+-- Deploy registry:program-publish-status to pg
+-- requires: summer-camp-module
+
+BEGIN;
+
+SET client_min_messages = 'warning';
+SET search_path TO registry, public;
+
+-- Programs (projects) need a status to match sessions. Draft programs
+-- are not visible to parents in the storefront; published programs are;
+-- closed programs are archived.
+ALTER TABLE projects
+    ADD COLUMN IF NOT EXISTS status text DEFAULT 'draft'
+    CHECK (status IN ('draft', 'published', 'closed'));
+
+-- Each location has a responsible contact person, referenced as a user
+-- account rather than denormalized contact fields.
+ALTER TABLE locations
+    ADD COLUMN IF NOT EXISTS contact_person_id uuid REFERENCES users(id);
+
+CREATE INDEX IF NOT EXISTS idx_locations_contact_person
+    ON locations (contact_person_id);
+
+-- Propagate the same columns to every tenant schema that exists.
+-- Some tenants have slugs with hyphens or other characters that
+-- clone_schema() rejects, so their schemas are not created.
+DO
+$$
+DECLARE
+    s name;
+BEGIN
+    FOR s IN SELECT slug FROM registry.tenants LOOP
+        CONTINUE WHEN to_regnamespace(quote_ident(s)) IS NULL;
+
+        EXECUTE format(
+            'ALTER TABLE %I.projects
+                ADD COLUMN IF NOT EXISTS status text DEFAULT ''draft''
+                CHECK (status IN (''draft'', ''published'', ''closed''));',
+            s
+        );
+
+        EXECUTE format(
+            'ALTER TABLE %I.locations
+                ADD COLUMN IF NOT EXISTS contact_person_id uuid
+                REFERENCES %I.users(id);',
+            s, s
+        );
+
+        EXECUTE format(
+            'CREATE INDEX IF NOT EXISTS idx_locations_contact_person
+                ON %I.locations (contact_person_id);',
+            s
+        );
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMIT;

--- a/sql/revert/program-publish-status.sql
+++ b/sql/revert/program-publish-status.sql
@@ -1,0 +1,35 @@
+-- Revert registry:program-publish-status from pg
+
+BEGIN;
+
+SET client_min_messages = 'warning';
+SET search_path TO registry, public;
+
+ALTER TABLE projects DROP COLUMN IF EXISTS status;
+
+DROP INDEX IF EXISTS idx_locations_contact_person;
+ALTER TABLE locations DROP COLUMN IF EXISTS contact_person_id;
+
+DO
+$$
+DECLARE
+    s name;
+BEGIN
+    FOR s IN SELECT slug FROM registry.tenants LOOP
+        CONTINUE WHEN to_regnamespace(quote_ident(s)) IS NULL;
+
+        EXECUTE format(
+            'ALTER TABLE %I.projects DROP COLUMN IF EXISTS status;', s
+        );
+        EXECUTE format(
+            'DROP INDEX IF EXISTS %I.idx_locations_contact_person;', s
+        );
+        EXECUTE format(
+            'ALTER TABLE %I.locations DROP COLUMN IF EXISTS contact_person_id;',
+            s
+        );
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMIT;

--- a/sql/sqitch.plan
+++ b/sql/sqitch.plan
@@ -49,3 +49,4 @@ seed-registry-storefront-v2 [seed-registry-storefront] 2026-04-07T14:44:00Z Chri
 registry-landing-page-template [seed-registry-storefront-v2] 2026-04-11T00:00:00Z Chris Prather <chris.prather@tamarou.com> # Customize registry tenant landing page for Jordan's user journey
 fix-utf8-mojibake [registry-landing-page-template] 2026-04-11T12:00:00Z Chris Prather <chris.prather@tamarou.com> # Delete DB templates with mojibake so app reimports fixed versions
 update-registry-landing-copy [fix-utf8-mojibake] 2026-04-11T14:00:00Z Chris Prather <chris.prather@tamarou.com> # Update registry landing page copy and 3x2 card grid
+program-publish-status [summer-camp-module tenant-domains] 2026-04-19T00:00:00Z Chris Prather <chris.prather@tamarou.com> # Add status to projects and contact_person_id to locations for admin program setup

--- a/sql/test-schema.sql
+++ b/sql/test-schema.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
-\restrict ZVGVcCyd9VgxllQwLGmoBzo1nPvlPCXMTBdh5X7KJbijOar8i9vVUZlRWjvzQ5K
+\restrict nPRE3dRoUoGGkLkeysFaSv2jNX47l8tcgRW4HnzAX7HrFbGwweefAy7QCqNySvO
 
 -- Dumped from database version 18.3 (Ubuntu 18.3-1.pgdg22.04+1)
 -- Dumped by pg_dump version 18.3 (Ubuntu 18.3-1.pgdg22.04+1)
@@ -964,6 +964,7 @@ CREATE TABLE registry.locations (
     facilities jsonb,
     latitude numeric(10,8),
     longitude numeric(11,8),
+    contact_person_id uuid,
     CONSTRAINT valid_address_info CHECK ((jsonb_typeof(address_info) = 'object'::text))
 );
 
@@ -1342,7 +1343,9 @@ CREATE TABLE registry.projects (
     notes text,
     created_at timestamp with time zone DEFAULT now(),
     updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    program_type_slug text
+    program_type_slug text,
+    status text DEFAULT 'draft'::text,
+    CONSTRAINT projects_status_check CHECK ((status = ANY (ARRAY['draft'::text, 'published'::text, 'closed'::text])))
 );
 
 
@@ -2250,7 +2253,7 @@ COPY registry.enrollments (id, session_id, student_id, status, metadata, created
 --
 
 COPY registry.events (id, "time", duration, location_id, project_id, teacher_id, metadata, notes, created_at, updated_at, min_age, max_age, capacity, event_type, status) FROM stdin;
-da3bfe99-fcde-4741-ad98-5b166960a5a0	2026-04-07 22:39:46.028257+00	0	f623b0bf-7911-45b9-a1cf-cd76314243ff	22f3cb4b-7a87-48b6-97f9-c13aec8dde67	85a26e45-bd0f-4eba-b804-cee468109f4d	\N	\N	2026-04-07 22:39:46.028257+00	2026-04-07 22:39:46.028257	\N	\N	999999	registration	published
+bdbf3ca9-c026-48ab-a7b6-47a16ad18c81	2026-04-19 07:12:54.381851+00	0	f1dbf461-86d5-451c-bd8c-c46f48bb2612	cfb3c4f1-1b96-44d5-8820-5b350da7fa63	13cb2d29-f94a-41ab-816d-cb34cb2c04cc	\N	\N	2026-04-19 07:12:54.381851+00	2026-04-19 07:12:54.381851	\N	\N	999999	registration	published
 \.
 
 
@@ -2266,8 +2269,8 @@ COPY registry.family_members (id, family_id, child_name, birth_date, grade, medi
 -- Data for Name: locations; Type: TABLE DATA; Schema: registry; Owner: postgres
 --
 
-COPY registry.locations (id, name, slug, address_info, metadata, notes, created_at, updated_at, address_street, address_city, address_state, address_zip, capacity, contact_info, facilities, latitude, longitude) FROM stdin;
-f623b0bf-7911-45b9-a1cf-cd76314243ff	Online	online	{"type": "virtual"}	\N	\N	2026-04-07 22:39:46.019981+00	2026-04-07 22:39:46.019981	\N	\N	\N	\N	\N	\N	\N	\N	\N
+COPY registry.locations (id, name, slug, address_info, metadata, notes, created_at, updated_at, address_street, address_city, address_state, address_zip, capacity, contact_info, facilities, latitude, longitude, contact_person_id) FROM stdin;
+f1dbf461-86d5-451c-bd8c-c46f48bb2612	Online	online	{"type": "virtual"}	\N	\N	2026-04-19 07:12:54.376002+00	2026-04-19 07:12:54.376002	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N
 \.
 
 
@@ -2292,9 +2295,9 @@ COPY registry.message_recipients (id, message_id, recipient_id, recipient_type, 
 --
 
 COPY registry.message_templates (id, name, subject_template, body_template, message_type, scope, variables, created_by, is_active, created_at, updated_at) FROM stdin;
-140a789d-d8c4-4fc4-8624-38288ced61aa	Program Announcement	Important Update: {{program_name}}	Dear {{parent_name}},\n\nWe have an important announcement regarding {{program_name}}.\n\n{{announcement_details}}\n\nIf you have any questions, please don't hesitate to contact us.\n\nBest regards,\n{{sender_name}}\n{{organization_name}}	announcement	program	{"parent_name": "Parent's name", "sender_name": "Staff member name", "program_name": "Name of the program", "organization_name": "Organization name", "announcement_details": "Details of the announcement"}	00000000-0000-0000-0000-000000000000	t	2026-04-07 22:39:40.386877+00	2026-04-07 22:39:40.386877+00
-c30b893c-33f9-41c8-b47b-f377d195cc72	Session Update	Session Update: {{session_name}}	Dear {{parent_name}},\n\nWe wanted to update you about {{session_name}} for {{child_name}}.\n\n{{update_details}}\n\nThank you for your understanding.\n\nBest regards,\n{{sender_name}}	update	session	{"child_name": "Child's name", "parent_name": "Parent's name", "sender_name": "Staff member name", "session_name": "Name of the session", "update_details": "Details of the update"}	00000000-0000-0000-0000-000000000000	t	2026-04-07 22:39:40.386877+00	2026-04-07 22:39:40.386877+00
-dca25cb8-0fbd-423d-b669-3835651c4621	Emergency Alert	URGENT: {{emergency_title}}	Dear {{parent_name}},\n\nThis is an urgent message regarding {{scope_description}}.\n\n{{emergency_details}}\n\nPlease take immediate action as needed.\n\n{{contact_information}}\n\n{{sender_name}}\n{{organization_name}}	emergency	tenant-wide	{"parent_name": "Parent's name", "sender_name": "Staff member name", "emergency_title": "Title of emergency", "emergency_details": "Emergency details", "organization_name": "Organization name", "scope_description": "What the emergency affects", "contact_information": "Emergency contact info"}	00000000-0000-0000-0000-000000000000	t	2026-04-07 22:39:40.386877+00	2026-04-07 22:39:40.386877+00
+a5c9abe7-25e1-4742-8e6a-0fd4aa1aa0fb	Program Announcement	Important Update: {{program_name}}	Dear {{parent_name}},\n\nWe have an important announcement regarding {{program_name}}.\n\n{{announcement_details}}\n\nIf you have any questions, please don't hesitate to contact us.\n\nBest regards,\n{{sender_name}}\n{{organization_name}}	announcement	program	{"parent_name": "Parent's name", "sender_name": "Staff member name", "program_name": "Name of the program", "organization_name": "Organization name", "announcement_details": "Details of the announcement"}	00000000-0000-0000-0000-000000000000	t	2026-04-19 07:12:50.221977+00	2026-04-19 07:12:50.221977+00
+8aeec595-6f15-4da0-8030-4175930fb1c1	Session Update	Session Update: {{session_name}}	Dear {{parent_name}},\n\nWe wanted to update you about {{session_name}} for {{child_name}}.\n\n{{update_details}}\n\nThank you for your understanding.\n\nBest regards,\n{{sender_name}}	update	session	{"child_name": "Child's name", "parent_name": "Parent's name", "sender_name": "Staff member name", "session_name": "Name of the session", "update_details": "Details of the update"}	00000000-0000-0000-0000-000000000000	t	2026-04-19 07:12:50.221977+00	2026-04-19 07:12:50.221977+00
+72e47eb8-b2b8-4165-b5b2-195d1b44ca5d	Emergency Alert	URGENT: {{emergency_title}}	Dear {{parent_name}},\n\nThis is an urgent message regarding {{scope_description}}.\n\n{{emergency_details}}\n\nPlease take immediate action as needed.\n\n{{contact_information}}\n\n{{sender_name}}\n{{organization_name}}	emergency	tenant-wide	{"parent_name": "Parent's name", "sender_name": "Staff member name", "emergency_title": "Title of emergency", "emergency_details": "Emergency details", "organization_name": "Organization name", "scope_description": "What the emergency affects", "contact_information": "Emergency contact info"}	00000000-0000-0000-0000-000000000000	t	2026-04-19 07:12:50.221977+00	2026-04-19 07:12:50.221977+00
 \.
 
 
@@ -2359,9 +2362,9 @@ COPY registry.payments (id, user_id, amount, currency, status, stripe_payment_in
 --
 
 COPY registry.pricing_plans (id, session_id, plan_scope, plan_name, plan_type, pricing_model_type, amount, currency, installments_allowed, installment_count, requirements, pricing_configuration, metadata, created_at, updated_at) FROM stdin;
-69bd24a1-2888-4e21-9461-3abc4ee4653e	\N	tenant	Registry Revenue Share - 2%	revenue_share	percentage	0.02	USD	f	\N	{}	{"applies_to": "customer_payments", "percentage": 0.02, "minimum_monthly": 0}	{"default": false, "description": "2% of all customer payments, no minimums"}	2026-04-07 22:39:43.747201+00	2026-04-07 22:39:43.747201+00
-3fdb012c-877e-4c7a-bb11-368fd8cd288d	\N	tenant	Registry Standard - $200/month	subscription	fixed	200.00	USD	f	\N	{}	{"includes": ["unlimited_programs", "unlimited_enrollments", "email_support"], "monthly_amount": 200.00}	{"default": true, "description": "Standard monthly subscription"}	2026-04-07 22:39:43.747201+00	2026-04-07 22:39:43.747201+00
-e9493351-2bb1-4a19-a2e9-afc764e29b85	\N	tenant	Registry Plus - $100/month + 1%	hybrid	hybrid	100.00	USD	f	\N	{}	{"applies_to": "customer_payments", "percentage": 0.01, "monthly_base": 100.00}	{"default": false, "description": "Reduced monthly fee with revenue share"}	2026-04-07 22:39:43.747201+00	2026-04-07 22:39:43.747201+00
+b26b599a-0c84-4806-8e02-6383125b82c4	\N	tenant	Registry Revenue Share - 2%	revenue_share	percentage	0.02	USD	f	\N	{}	{"applies_to": "customer_payments", "percentage": 0.02, "minimum_monthly": 0}	{"default": false, "description": "2% of all customer payments, no minimums"}	2026-04-19 07:12:52.678848+00	2026-04-19 07:12:52.678848+00
+9a1fe51c-4292-41c9-9ae0-95a0d3e75126	\N	tenant	Registry Standard - $200/month	subscription	fixed	200.00	USD	f	\N	{}	{"includes": ["unlimited_programs", "unlimited_enrollments", "email_support"], "monthly_amount": 200.00}	{"default": true, "description": "Standard monthly subscription"}	2026-04-19 07:12:52.678848+00	2026-04-19 07:12:52.678848+00
+87487edc-aa9a-4dd3-bc41-bb639bef1ade	\N	tenant	Registry Plus - $100/month + 1%	hybrid	hybrid	100.00	USD	f	\N	{}	{"applies_to": "customer_payments", "percentage": 0.01, "monthly_base": 100.00}	{"default": false, "description": "Reduced monthly fee with revenue share"}	2026-04-19 07:12:52.678848+00	2026-04-19 07:12:52.678848+00
 \.
 
 
@@ -2386,8 +2389,8 @@ COPY registry.pricing_relationships (id, provider_id, consumer_id, pricing_plan_
 --
 
 COPY registry.program_types (id, slug, name, config, created_at, updated_at) FROM stdin;
-72a206cc-fa46-4f4b-9235-a8c878eabf8f	afterschool	After School Program	{"standard_times": {"friday": "15:00", "monday": "15:00", "tuesday": "15:00", "thursday": "15:00", "wednesday": "14:00"}, "session_pattern": "weekly_for_x_weeks", "enrollment_rules": {"same_session_for_siblings": true}}	2026-04-07 22:39:38.065575+00	2026-04-07 22:39:38.065575
-54abf7fa-64e7-4a43-bf4b-14e086850e40	summer-camp	Summer Camp	{"standard_times": {"end": "15:00", "start": "09:00"}, "session_pattern": "daily_for_x_days", "enrollment_rules": {"same_session_for_siblings": false}}	2026-04-07 22:39:38.065575+00	2026-04-07 22:39:38.065575
+1d8e771c-7384-42f9-9f22-8cac65e0032f	afterschool	After School Program	{"standard_times": {"friday": "15:00", "monday": "15:00", "tuesday": "15:00", "thursday": "15:00", "wednesday": "14:00"}, "session_pattern": "weekly_for_x_weeks", "enrollment_rules": {"same_session_for_siblings": true}}	2026-04-19 07:12:48.516102+00	2026-04-19 07:12:48.516102
+fc9197b0-f248-47f9-b773-497d5c774244	summer-camp	Summer Camp	{"standard_times": {"end": "15:00", "start": "09:00"}, "session_pattern": "daily_for_x_days", "enrollment_rules": {"same_session_for_siblings": false}}	2026-04-19 07:12:48.516102+00	2026-04-19 07:12:48.516102
 \.
 
 
@@ -2395,8 +2398,8 @@ COPY registry.program_types (id, slug, name, config, created_at, updated_at) FRO
 -- Data for Name: projects; Type: TABLE DATA; Schema: registry; Owner: postgres
 --
 
-COPY registry.projects (id, name, slug, metadata, notes, created_at, updated_at, program_type_slug) FROM stdin;
-22f3cb4b-7a87-48b6-97f9-c13aec8dde67	Tiny Art Empire	tiny-art-empire	{"registration_workflow": "tenant-signup"}	Start your own art education business. Create programs, manage enrollments, accept payments — all in one platform.	2026-04-07 22:39:46.022232+00	2026-04-07 22:39:46.022232	\N
+COPY registry.projects (id, name, slug, metadata, notes, created_at, updated_at, program_type_slug, status) FROM stdin;
+cfb3c4f1-1b96-44d5-8820-5b350da7fa63	Tiny Art Empire	tiny-art-empire	{"registration_workflow": "tenant-signup"}	Start your own art education business. Create programs, manage enrollments, accept payments — all in one platform.	2026-04-19 07:12:54.377893+00	2026-04-19 07:12:54.377893	\N	draft
 \.
 
 
@@ -2413,7 +2416,7 @@ COPY registry.scheduled_payments (id, payment_schedule_id, payment_id, installme
 --
 
 COPY registry.session_events (id, session_id, event_id, created_at, updated_at) FROM stdin;
-f3bc62bf-6835-4dd7-a3d7-233953138b03	4780c5f4-d016-4022-8aec-3ae41b6cf56e	da3bfe99-fcde-4741-ad98-5b166960a5a0	2026-04-07 22:39:46.033834+00	2026-04-07 22:39:46.033834
+14e293b1-9f00-45cc-8b9f-cda96d66fed4	8adeb44f-428c-4667-ba92-86b86bddcfee	bdbf3ca9-c026-48ab-a7b6-47a16ad18c81	2026-04-19 07:12:54.385704+00	2026-04-19 07:12:54.385704
 \.
 
 
@@ -2430,7 +2433,7 @@ COPY registry.session_teachers (id, session_id, teacher_id, created_at, updated_
 --
 
 COPY registry.sessions (id, name, slug, metadata, notes, created_at, updated_at, session_type, start_date, end_date, status, capacity) FROM stdin;
-4780c5f4-d016-4022-8aec-3ae41b6cf56e	Get Started Today	get-started	\N	\N	2026-04-07 22:39:46.025225+00	2026-04-07 22:39:46.025225	regular	2026-04-07	2036-04-07	published	999999
+8adeb44f-428c-4667-ba92-86b86bddcfee	Get Started Today	get-started	\N	\N	2026-04-19 07:12:54.379799+00	2026-04-19 07:12:54.379799	regular	2026-04-19	2036-04-19	published	999999
 \.
 
 
@@ -2447,6 +2450,7 @@ COPY registry.subscription_events (id, tenant_id, stripe_event_id, event_type, e
 --
 
 COPY registry.templates (id, name, slug, content, metadata, notes, created_at, updated_at) FROM stdin;
+f1516ead-2675-489f-9225-e11a13c46d8d	tenant-storefront/program-listing	tenant-storefront-program-listing	% layout 'default';\n% title 'Tiny Art Empire';\n% stash no_container => 1, enable_background_effects => 1;\n\n% # Extract data for callcc form\n% my $prog = $programs->[0] || {};\n% my $project = $prog->{project};\n% my $sess_info = ($prog->{sessions} || [])->[0] || {};\n% my $session = $sess_info->{session};\n% my $reg_workflow = ($project && $project->metadata || {})->{registration_workflow} || 'tenant-signup';\n\n<div class="landing-page">\n  <nav class="landing-nav">\n    <div class="landing-logo">Tiny Art Empire</div>\n  </nav>\n\n  <!-- Hero: The Why -->\n  <section class="landing-hero">\n    <h1>Your art deserves a real business.</h1>\n    <p class="landing-hero-subtitle">\n      Everything you need to fill classes, get paid, and stay organized\n      -- so you can get back to making art.\n    </p>\n    <div class="landing-cta-container">\n      % if ($project && $session) {\n        <form method="POST"\n              action="/tenant-storefront/<%= $run->id %>/callcc/<%= $reg_workflow %>">\n          <input type="hidden" name="session_id" value="<%= $session->id %>">\n          <input type="hidden" name="program_id" value="<%= $project->id %>">\n          <button type="submit" class="landing-cta-button">Get Started</button>\n        </form>\n      % } else {\n        <a href="<%= url_for('workflow_start', workflow => 'tenant-signup') %>" class="landing-cta-button">\n          Get Started\n        </a>\n      % }\n    </div>\n  </section>\n\n  <!-- Problem Cards: The How -->\n  <section class="landing-features">\n    <div class="landing-features-container">\n      <h2>Less paperwork. More studio time.</h2>\n      <div class="landing-features-grid" style="grid-template-columns: repeat(3, 1fr);">\n        <article class="landing-feature-card">\n          <h3 class="landing-feature-title">Fill your classes without the hustle</h3>\n          <p class="landing-feature-description">\n            Parents find your programs and register online -- no back-and-forth\n            emails or paper forms.\n          </p>\n        </article>\n        <article class="landing-feature-card">\n          <h3 class="landing-feature-title">Get paid before class starts</h3>\n          <p class="landing-feature-description">\n            Online payments at registration. No chasing checks, no awkward reminders.\n          </p>\n        </article>\n        <article class="landing-feature-card">\n          <h3 class="landing-feature-title">One place for all of it</h3>\n          <p class="landing-feature-description">\n            Scheduling, attendance, waitlists, and families with three kids -- handled.\n          </p>\n        </article>\n        <article class="landing-feature-card">\n          <h3 class="landing-feature-title">Keep parents in the loop</h3>\n          <p class="landing-feature-description">\n            Automatic updates and notifications so you're not writing the same\n            email twelve times.\n          </p>\n        </article>\n        <article class="landing-feature-card">\n          <h3 class="landing-feature-title">See how your business is doing</h3>\n          <p class="landing-feature-description">\n            Plain-English reports on revenue, enrollment, and trends.\n            No spreadsheet required.\n          </p>\n        </article>\n        <article class="landing-feature-card">\n          <h3 class="landing-feature-title">Grow when you're ready</h3>\n          <p class="landing-feature-description">\n            Add instructors, locations, and programs without adding chaos.\n          </p>\n        </article>\n      </div>\n    </div>\n  </section>\n\n  <!-- Alignment: The Trust -->\n  <section class="landing-features">\n    <div class="landing-features-container" style="text-align: center;">\n      <h2>Free to Start</h2>\n      <p class="landing-hero-subtitle">\n        There are no monthly fees, no set up fees. We have a 2.5% revenue\n        share, so we only make money when you do. Our entire job is to help\n        you succeed!\n      </p>\n      <div class="landing-cta-container">\n        % if ($project && $session) {\n          <form method="POST"\n                action="/tenant-storefront/<%= $run->id %>/callcc/<%= $reg_workflow %>">\n            <input type="hidden" name="session_id" value="<%= $session->id %>">\n            <input type="hidden" name="program_id" value="<%= $project->id %>">\n            <button type="submit" class="landing-cta-button">Get Started</button>\n          </form>\n        % } else {\n          <a href="<%= url_for('workflow_start', workflow => 'tenant-signup') %>" class="landing-cta-button">\n            Get Started\n          </a>\n        % }\n      </div>\n    </div>\n  </section>\n\n  <footer style="text-align: center; padding: var(--space-8); color: var(--landing-text-secondary); font-size: var(--font-size-sm);">\n    <p>A <strong>Tamarou</strong> &amp; <strong>Super Awesome Cool Pottery</strong> project</p>\n  </footer>\n</div>	{}	Registry tenant landing page for Jordan (art teacher) user journey	2026-04-19 07:12:54.559785+00	2026-04-19 07:12:54.930361+00
 \.
 
 
@@ -2479,8 +2483,8 @@ COPY registry.tenant_users (tenant_id, user_id, is_primary, created_at) FROM std
 --
 
 COPY registry.tenants (id, name, slug, created_at, stripe_customer_id, stripe_subscription_id, billing_status, trial_ends_at, subscription_started_at, canonical_domain, magic_link_expiry_hours) FROM stdin;
-e234b0e9-039b-41fb-b159-3257689c2dfa	Registry System	registry	2026-04-07 22:39:36.490106+00	\N	\N	trial	\N	\N	\N	24
-00000000-0000-0000-0000-000000000000	Registry Platform	registry-platform	2026-04-07 22:39:43.747201+00	\N	\N	active	\N	\N	\N	24
+f7a3a4fc-e0f6-4f88-9089-d7eaf365ca4f	Registry System	registry	2026-04-19 07:12:47.353466+00	\N	\N	trial	\N	\N	\N	24
+00000000-0000-0000-0000-000000000000	Registry Platform	registry-platform	2026-04-19 07:12:52.678848+00	\N	\N	active	\N	\N	\N	24
 \.
 
 
@@ -2505,7 +2509,7 @@ COPY registry.user_preferences (id, user_id, preference_key, preference_value, c
 --
 
 COPY registry.user_profiles (user_id, email, name, phone, data, created_at) FROM stdin;
-85a26e45-bd0f-4eba-b804-cee468109f4d	system@tinyartempire.com	System	\N	\N	2026-04-07 22:39:46.016229+00
+13cb2d29-f94a-41ab-816d-cb34cb2c04cc	system@tinyartempire.com	System	\N	\N	2026-04-19 07:12:54.373556+00
 \.
 
 
@@ -2514,7 +2518,7 @@ COPY registry.user_profiles (user_id, email, name, phone, data, created_at) FROM
 --
 
 COPY registry.users (id, username, passhash, created_at, birth_date, user_type, grade, email_verified_at, invite_pending) FROM stdin;
-85a26e45-bd0f-4eba-b804-cee468109f4d	system	nologin	2026-04-07 22:39:46.013466+00	\N	parent	\N	\N	f
+13cb2d29-f94a-41ab-816d-cb34cb2c04cc	system	nologin	2026-04-19 07:12:54.371252+00	\N	parent	\N	\N	f
 \.
 
 
@@ -2555,50 +2559,54 @@ COPY registry.workflows (id, slug, name, description, first_step, created_at, up
 --
 
 COPY sqitch.changes (change_id, script_hash, change, project, note, committed_at, committer_name, committer_email, planned_at, planner_name, planner_email) FROM stdin;
-c9235c00bc368836d5323cd4b98cadfa673aa00e	a363697ff7f1f2ad0642dfc426f003e430fbb342	users	registry	initial creation of users table and basic schema etc	2026-04-07 22:39:36.122128+00	Chris Prather	chris.prather@tamarou.com	2024-05-13 17:21:58+00	Chris Prather	chris@prather.org
-2960f6c6a1df94ef7f1c75a036db14aefe121bc5	978d2b0afaad7749217fc4bf998d858c91cb9e93	workflows	registry	add workflows\n\nWorkflows define a sequence of steps to be executed. We process each step and record the outcome in a workflow run.	2026-04-07 22:39:36.380707+00	Chris Prather	chris.prather@tamarou.com	2024-05-13 17:30:35+00	Chris Prather	chris@prather.org
-2abd1a15dc06e9db731062527f8541e8c79ffb6f	24d73f7d6572fe110f256ca48b0a2a48dfafa96b	tenant-on-boarding	registry	create an onboarding workflow for tenants	2026-04-07 22:39:36.626331+00	Chris Prather	chris.prather@tamarou.com	2024-05-20 21:00:32+00	Chris Prather	chris@prather.org
-2f7ae3c1f6f41d31425a9ba8fa21f2e73560115c	707b1c42fa45736727df395e145cbf439387c241	schema-based-multitennancy	registry	add the tools to do the schema-based multi-tenancy	2026-04-07 22:39:36.853989+00	Chris Prather	chris.prather@tamarou.com	2024-05-21 01:43:52+00	Chris Prather	chris@prather.org
-5920ebcdc5fd6c9478af9fb1e435aedd26b5b5ce	841ff17f8bd522a515385b293e9914d111f0fd19	events-and-sessions	registry	Add events and sessions to the system	2026-04-07 22:39:37.120114+00	Chris Prather	chris.prather@tamarou.com	2024-05-31 03:36:11+00	Chris Prather	chris.prather@tamarou.com
-72bea40753b0250624322f67c9a64fe479f02df7	67a0442cd1589b353394cbd451cca098bb8e8634	edit-template-workflow	registry	default workflow for editing templates	2026-04-07 22:39:37.331225+00	Chris Prather	chris.prather@tamarou.com	2025-02-11 23:59:19+00	Chris Prather	chris.prather@tamarou.com
-daf665c0e9b4b1255a0cf09bb88e322f6609b59f	db62b982c609c21307787f014f58577662cca0cd	outcomes	registry	add outcome definitions	2026-04-07 22:39:37.577326+00	Chris Prather	chris.prather@tamarou.com	2025-02-21 06:45:47+00	Chris Prather	chris.prather@tamarou.com
-c0bb268a4a0c27a97351166c95d50a5f6d73d0ae	7d3e7133c01ac03e83020ba1578259ec444584cd	summer-camp-module	registry	add summer-camp-module	2026-04-07 22:39:37.795757+00	Chris Prather	chris.prather@tamarou.com	2025-02-22 04:38:37+00	Chris Prather	chris.prather@tamarou.com
-6d1c676dccf7787d99a54edd3ec556193ff0562d	464a90d2ef6e7939e38fa2717439f3796e2f6936	fix-tenant-workflows	registry	Fix tenant workflows to include first_step	2026-04-07 22:39:37.979218+00	Chris Prather	chris.prather@tamarou.com	2025-03-22 18:57:13+00	Chris Prather	chris.prather@tamarou.com
-4d1cce9dd15eadfe664b1a909c36f1afd6d943f2	7851550d6b87474630cd02469c9772024987ce32	program-types	registry	Add program types configuration system	2026-04-07 22:39:38.170611+00	Chris Prather	chris.prather@tamarou.com	2025-01-27 12:00:00+00	Claude	noreply@anthropic.com
-ac009951a991475b6b82050987874c5e1562b227	e79fc2deea1f57838d388bd3effc672f3d9de20b	enhanced-pricing-model	registry	Transform pricing to flexible pricing_plans with multiple tiers per session	2026-04-07 22:39:38.37236+00	Chris Prather	chris.prather@tamarou.com	2025-01-27 12:30:00+00	Claude	noreply@anthropic.com
-ca85da23e2f52eb6ef3b500530d301617d8d64d3	6e636122ad2b14731a616bee3fb8d06083559358	attendance-tracking	registry	Add attendance tracking infrastructure	2026-04-07 22:39:38.575105+00	Chris Prather	chris.prather@tamarou.com	2025-01-27 13:00:00+00	Claude	noreply@anthropic.com
-9478a08db15d08f6fae783493e14eb2348a478a4	1b0a9ae93451b1aad3fcad727c30430146b39669	waitlist-management	registry	Add waitlist functionality to enrollment system	2026-04-07 22:39:38.825516+00	Chris Prather	chris.prather@tamarou.com	2025-01-27 13:30:00+00	Claude	noreply@anthropic.com
-125881c219bfb9b9053e66b6b5fb5fdb720a1ee3	fa279aaea8c8f5c6fc0fc942ac69274ced15c1d4	add-program-type-to-projects	registry	Add program type reference to projects	2026-04-07 22:39:39.053374+00	Chris Prather	chris.prather@tamarou.com	2025-01-27 14:00:00+00	Claude	noreply@anthropic.com
-b935f44f3eace95edc2fa318ed7de32c27e8ac1a	b93b975d490c4384a02a3f8a66a48d99fd35a84b	add-user-fields-for-family	registry	Add birth_date, user_type, grade fields to users	2026-04-07 22:39:39.278844+00	Chris Prather	chris.prather@tamarou.com	2025-01-27 14:25:00+00	Claude	noreply@anthropic.com
-7deaa9fb9f8f3d0309d635af087792c28525f78e	189953a84a37895f33e367d8eb0fe3b647a2bfdf	multi-child-data-model	registry	Add family_members table for multi-child support	2026-04-07 22:39:39.548068+00	Chris Prather	chris.prather@tamarou.com	2025-01-27 14:30:00+00	Claude	noreply@anthropic.com
-815c14422aeab29c0c21415ea7e8927785a1c910	36fd27b0aff2c634ec86eb7662a0ecbc11d188e6	payments	registry	Add payments infrastructure for Stripe integration	2026-04-07 22:39:39.786223+00	Chris Prather	chris.prather@tamarou.com	2025-01-27 19:00:00+00	Claude	noreply@anthropic.com
-eee70c0e408183c5d818fa1a6ce7e3b34d3b7cf6	344a280c4b37d460e57e312c538aa0507dae53e1	add-payment-to-enrollments	registry	Add payment_id reference to enrollments table	2026-04-07 22:39:40.006523+00	Chris Prather	chris.prather@tamarou.com	2025-01-27 19:15:00+00	Claude	noreply@anthropic.com
-acd808bf85b5a9d8971f598186ced619196ffd0e	8cdbcbf5f5d6b5933c1027b75293e23c21f82f45	notifications-and-preferences	registry	Add notifications and user preferences for attendance tracking	2026-04-07 22:39:40.274501+00	Chris Prather	chris.prather@tamarou.com	2025-01-28 10:00:00+00	Claude	noreply@anthropic.com
-5ce709b8eff5b3b920e7a675d78bee9dabd98367	9f6bfbd59ca138c524285ed7d9f0b7895354f801	parent-communication-system	registry	Add parent communication system with messages, recipients, and templates	2026-04-07 22:39:40.556574+00	Chris Prather	chris.prather@tamarou.com	2025-01-28 11:00:00+00	Claude	noreply@anthropic.com
-fbe73787977942423bb4d7ba5dd152c0c1551e38	fea7e5a85e605358de32808abb27b09f7dd78e83	performance-optimization	registry	Add database indexes and performance optimizations for production readiness	2026-04-07 22:39:40.802275+00	Chris Prather	chris.prather@tamarou.com	2025-01-28 15:00:00+00	Claude	noreply@anthropic.com
-d7d8aaecb2610865fd3801bb68ef57e474b29181	4a0067318476e1aa7150a0f54458884434cf9bfb	stripe-subscription-integration	registry	Add Stripe subscription integration for tenant billing	2026-04-07 22:39:41.000734+00	Chris Prather	chris.prather@tamarou.com	2025-01-28 16:00:00+00	Claude	noreply@anthropic.com
-8eb88eeec3cb411430882061df8d5563af64ba1c	3fa34c99f03fa41b55239b2a0c7f393ba3d49bbf	fix-multi-child-enrollments	registry	Fix multi-child enrollment constraints for cleaner architecture	2026-04-07 22:39:41.228963+00	Chris Prather	chris.prather@tamarou.com	2025-07-15 00:34:24+00	Chris Prather	chris.prather@tamarou.com
-4883848eccc158220c9e751882d20ae963d71f52	c4e3ea6ffbffc982060b0d165f60f0ff17bf78e7	flexible-enrollment-architecture	registry	Create flexible enrollment architecture supporting family, individual, group, and corporate students	2026-04-07 22:39:41.436001+00	Chris Prather	chris.prather@tamarou.com	2025-07-15 01:09:59+00	Chris Prather	chris.prather@tamarou.com
-f6dbddd094284b0b7296c6e8258922882ae24b5d	b5baa9d2cf71178ed6fd3382231eb69d0b310cfd	remove-student-id-foreign-key	registry	Remove student_id foreign key constraint to support polymorphic student references	2026-04-07 22:39:41.625022+00	Chris Prather	chris.prather@tamarou.com	2025-07-15 01:28:59+00	Chris Prather	chris.prather@tamarou.com
-ffe9a13ee38d1ffa2c706750718b34126adfe6e1	d2feca17971e5f93417b098a4295ff70ead570ee	fix-waitlist-family-member-refs	registry	Fix waitlist student_id to reference family_members instead of users	2026-04-07 22:39:41.860158+00	Chris Prather	chris.prather@tamarou.com	2025-07-16 14:30:00+00	Claude	noreply@anthropic.com
-3c3d83d65febc9de2fbce70f02fa01b5483736e8	49be975f75b20172863921261abf3906bc100990	fix-waitlist-reorder	registry	Fix waitlist position reordering to avoid unique constraint violations	2026-04-07 22:39:42.098573+00	Chris Prather	chris.prather@tamarou.com	2025-07-16 12:30:00+00	Claude	noreply@anthropic.com
-300e4d9f1d6bafe1b45f937ea482260f3313760d	b2b54846389dbdf3e2cf7ecbb15ae53fb4175d82	fix-waitlist-reorder-v2	registry	Improved waitlist position reordering to fully avoid constraint violations	2026-04-07 22:39:42.355588+00	Chris Prather	chris.prather@tamarou.com	2025-07-16 22:50:00+00	Claude	noreply@anthropic.com
-0903ffab54af2242711b1cb470a44753acf6c9d7	695f0a352ff02e4b5f84381856fe538ac1badbb7	fix-waitlist-reorder-v3	registry	Remove problematic database trigger and handle position reordering in application code	2026-04-07 22:39:42.603323+00	Chris Prather	chris.prather@tamarou.com	2025-07-17 00:00:00+00	Claude	noreply@anthropic.com
-acbd53f8d5ddfc205c3c1ca518ed92170803e32c	7b6df5319ffd75e81b5f3f06e95102a1df7f2e92	drop-transfer-business-rules	registry	Add drop and transfer business rules with admin approval workflow	2026-04-07 22:39:42.878908+00	Chris Prather	chris.prather@tamarou.com	2025-09-18 00:00:00+00	Claude	noreply@anthropic.com
-41ae5ed8ebd0150b8a8c2987bdbfd98967252b18	4ca09b1d82b01de2a829979849fa4a7f4c3120d4	remove-waitlist-position-constraint	registry	Remove unique constraint on waitlist position to allow status-based visibility	2026-04-07 22:39:43.121784+00	Chris Prather	chris.prather@tamarou.com	2025-09-21 00:00:00+00	Claude	noreply@anthropic.com
-788f8edbabafb05aef3b90f4b634beb1aaab7b8b	7dda1d870afb87ee03300b43bacf070e53c5c5ba	installment-payment-schedules	registry	Add payment schedules and scheduled payments for installment processing	2026-04-07 22:39:43.40088+00	Chris Prather	chris.prather@tamarou.com	2025-09-23 03:35:05+00	Chris Prather	chris.prather@tamarou.com
-2fc34cc17316d64ee48ef1c04e4d9c5e096b29ba	e7ea8e7d72a0222c7493190abb060dd0767adb28	simplify-installment-schema-for-stripe	registry	Simplify database schema to use Stripe native scheduling and retry features	2026-04-07 22:39:43.660116+00	Chris Prather	chris.prather@tamarou.com	2025-09-24 18:00:00+00	Claude	noreply@anthropic.com
-f61a99336db06d9d07bd30abcf6e18e98d7609ac	0f1e40107de5540b06f5181f72d75c6741728143	unified-pricing-infrastructure	registry	Add unified tenant-to-tenant pricing infrastructure	2026-04-07 22:39:43.887242+00	Chris Prather	chris.prather@tamarou.com	2025-09-29 00:44:03+00	Chris Prather	chris.prather@tamarou.com
-eb5973974d4f4c06b6e5a93c84b5a66bfcd8f342	031717d9b7ea0651ef6b5f67942c8c978f502dbe	consolidate-pricing-relationships	registry	Consolidate pricing relationships into unified model	2026-04-07 22:39:44.126333+00	Chris Prather	chris.prather@tamarou.com	2025-09-29 16:07:15+00	Chris Prather	chris.prather@tamarou.com
-20f187ed4e2e4c35404fcb5f7d48df933cebfcd5	6017815b229c39d2e9f7af54f1a963e3257a5bf2	pricing-relationship-events	registry	Add event sourcing for pricing relationship audit trail	2026-04-07 22:39:44.333464+00	Chris Prather	chris.prather@tamarou.com	2025-09-29 19:55:59+00	Chris Prather	chris.prather@tamarou.com
-5f3d84a4d2158ce0ffcfeabc5772970faca7c3d3	f41063facc70f0ff67e7cc54de594af5b99d358b	remove-pricing-plan-relationship-fields	registry	Remove obsolete target_tenant_id and offering_tenant_id from pricing_plans	2026-04-07 22:39:44.526477+00	Chris Prather	chris.prather@tamarou.com	2025-09-29 22:27:51+00	Chris Prather	chris.prather@tamarou.com
-a2248de7c1f81778ea19e6f9bc5c94e806e21268	5c6daf2fa1ab2205c6f0f0a0b153947e9304f3bd	passwordless-auth	registry	Passwordless auth: passkeys, magic links, API keys	2026-04-07 22:39:44.773252+00	Chris Prather	chris.prather@tamarou.com	2026-03-25 00:00:00+00	Chris Prather	chris.prather@tamarou.com
-afdf73989587e92e423e0b5f643361890a90a860	bdd207b58bea14042c69ffad9efcc71e3cbfbcd7	auth-notification-types	registry	Add auth notification types to notification_type enum	2026-04-07 22:39:45.00424+00	Chris Prather	chris.prather@tamarou.com	2026-03-30 06:56:54+00	Chris Prather	chris.prather@tamarou.com
-c0834addb5a970c41dc185be91f226cba562e013	314f27eca2ee77ce95e888776a12618b7d1bb0fc	tenant-domains	registry	Custom domain management for tenants	2026-04-07 22:39:45.240943+00	Chris Prather	chris.prather@tamarou.com	2026-03-30 19:04:42+00	Chris Prather	chris.prather@tamarou.com
-5656344b5447eb9e8d5b274f18d9fbfffa20f8d4	aeab9e685093de23275127520d1387c90bff2e78	magic-link-verification	registry	Add verified_at column for two-step magic link flow	2026-04-07 22:39:45.481087+00	Chris Prather	chris.prather@tamarou.com	2026-03-31 12:11:05+00	Chris Prather	chris.prather@tamarou.com
-c3c7ae6599f4db30315a79d7021519f29dafa31d	ca3c13270b018c747b12a06b702742a416a46a0e	waitlist-accepted-status	registry	Add accepted status to waitlist check constraint	2026-04-07 22:39:45.698362+00	Chris Prather	chris.prather@tamarou.com	2026-04-05 01:37:21+00	Chris Prather	chris.prather@tamarou.com
-b1024a8fd0df88c3fd8a543fb5a09512b3fa1cfb	a54ac0d95185ebb088b7bc391c48cb9cfbfb792e	seed-registry-storefront	registry	Seed registry tenant storefront (empty stub, deployed to production)	2026-04-07 22:39:45.909709+00	Chris Prather	chris.prather@tamarou.com	2026-04-07 13:42:30+00	Chris Prather	chris.prather@tamarou.com
-0d0c296e547099f9f75884c8283a0077920abc8c	70ca373942437f7f4629b935d4f21ac4b07c0c2e	seed-registry-storefront-v2	registry	Seed registry tenant storefront with actual data	2026-04-07 22:39:46.146653+00	Chris Prather	chris.prather@tamarou.com	2026-04-07 14:44:00+00	Chris Prather	chris.prather@tamarou.com
+c9235c00bc368836d5323cd4b98cadfa673aa00e	a363697ff7f1f2ad0642dfc426f003e430fbb342	users	registry	initial creation of users table and basic schema etc	2026-04-19 07:12:47.099246+00	Chris Prather	chris.prather@tamarou.com	2024-05-13 17:21:58+00	Chris Prather	chris@prather.org
+2960f6c6a1df94ef7f1c75a036db14aefe121bc5	978d2b0afaad7749217fc4bf998d858c91cb9e93	workflows	registry	add workflows\n\nWorkflows define a sequence of steps to be executed. We process each step and record the outcome in a workflow run.	2026-04-19 07:12:47.283201+00	Chris Prather	chris.prather@tamarou.com	2024-05-13 17:30:35+00	Chris Prather	chris@prather.org
+2abd1a15dc06e9db731062527f8541e8c79ffb6f	24d73f7d6572fe110f256ca48b0a2a48dfafa96b	tenant-on-boarding	registry	create an onboarding workflow for tenants	2026-04-19 07:12:47.450177+00	Chris Prather	chris.prather@tamarou.com	2024-05-20 21:00:32+00	Chris Prather	chris@prather.org
+2f7ae3c1f6f41d31425a9ba8fa21f2e73560115c	707b1c42fa45736727df395e145cbf439387c241	schema-based-multitennancy	registry	add the tools to do the schema-based multi-tenancy	2026-04-19 07:12:47.601939+00	Chris Prather	chris.prather@tamarou.com	2024-05-21 01:43:52+00	Chris Prather	chris@prather.org
+5920ebcdc5fd6c9478af9fb1e435aedd26b5b5ce	841ff17f8bd522a515385b293e9914d111f0fd19	events-and-sessions	registry	Add events and sessions to the system	2026-04-19 07:12:47.782162+00	Chris Prather	chris.prather@tamarou.com	2024-05-31 03:36:11+00	Chris Prather	chris.prather@tamarou.com
+72bea40753b0250624322f67c9a64fe479f02df7	67a0442cd1589b353394cbd451cca098bb8e8634	edit-template-workflow	registry	default workflow for editing templates	2026-04-19 07:12:47.926846+00	Chris Prather	chris.prather@tamarou.com	2025-02-11 23:59:19+00	Chris Prather	chris.prather@tamarou.com
+daf665c0e9b4b1255a0cf09bb88e322f6609b59f	db62b982c609c21307787f014f58577662cca0cd	outcomes	registry	add outcome definitions	2026-04-19 07:12:48.084848+00	Chris Prather	chris.prather@tamarou.com	2025-02-21 06:45:47+00	Chris Prather	chris.prather@tamarou.com
+c0bb268a4a0c27a97351166c95d50a5f6d73d0ae	7d3e7133c01ac03e83020ba1578259ec444584cd	summer-camp-module	registry	add summer-camp-module	2026-04-19 07:12:48.288135+00	Chris Prather	chris.prather@tamarou.com	2025-02-22 04:38:37+00	Chris Prather	chris.prather@tamarou.com
+6d1c676dccf7787d99a54edd3ec556193ff0562d	464a90d2ef6e7939e38fa2717439f3796e2f6936	fix-tenant-workflows	registry	Fix tenant workflows to include first_step	2026-04-19 07:12:48.445817+00	Chris Prather	chris.prather@tamarou.com	2025-03-22 18:57:13+00	Chris Prather	chris.prather@tamarou.com
+4d1cce9dd15eadfe664b1a909c36f1afd6d943f2	7851550d6b87474630cd02469c9772024987ce32	program-types	registry	Add program types configuration system	2026-04-19 07:12:48.60945+00	Chris Prather	chris.prather@tamarou.com	2025-01-27 12:00:00+00	Claude	noreply@anthropic.com
+ac009951a991475b6b82050987874c5e1562b227	e79fc2deea1f57838d388bd3effc672f3d9de20b	enhanced-pricing-model	registry	Transform pricing to flexible pricing_plans with multiple tiers per session	2026-04-19 07:12:48.781279+00	Chris Prather	chris.prather@tamarou.com	2025-01-27 12:30:00+00	Claude	noreply@anthropic.com
+ca85da23e2f52eb6ef3b500530d301617d8d64d3	6e636122ad2b14731a616bee3fb8d06083559358	attendance-tracking	registry	Add attendance tracking infrastructure	2026-04-19 07:12:48.947878+00	Chris Prather	chris.prather@tamarou.com	2025-01-27 13:00:00+00	Claude	noreply@anthropic.com
+9478a08db15d08f6fae783493e14eb2348a478a4	1b0a9ae93451b1aad3fcad727c30430146b39669	waitlist-management	registry	Add waitlist functionality to enrollment system	2026-04-19 07:12:49.115545+00	Chris Prather	chris.prather@tamarou.com	2025-01-27 13:30:00+00	Claude	noreply@anthropic.com
+125881c219bfb9b9053e66b6b5fb5fdb720a1ee3	fa279aaea8c8f5c6fc0fc942ac69274ced15c1d4	add-program-type-to-projects	registry	Add program type reference to projects	2026-04-19 07:12:49.267058+00	Chris Prather	chris.prather@tamarou.com	2025-01-27 14:00:00+00	Claude	noreply@anthropic.com
+b935f44f3eace95edc2fa318ed7de32c27e8ac1a	b93b975d490c4384a02a3f8a66a48d99fd35a84b	add-user-fields-for-family	registry	Add birth_date, user_type, grade fields to users	2026-04-19 07:12:49.419334+00	Chris Prather	chris.prather@tamarou.com	2025-01-27 14:25:00+00	Claude	noreply@anthropic.com
+7deaa9fb9f8f3d0309d635af087792c28525f78e	189953a84a37895f33e367d8eb0fe3b647a2bfdf	multi-child-data-model	registry	Add family_members table for multi-child support	2026-04-19 07:12:49.60782+00	Chris Prather	chris.prather@tamarou.com	2025-01-27 14:30:00+00	Claude	noreply@anthropic.com
+815c14422aeab29c0c21415ea7e8927785a1c910	36fd27b0aff2c634ec86eb7662a0ecbc11d188e6	payments	registry	Add payments infrastructure for Stripe integration	2026-04-19 07:12:49.800515+00	Chris Prather	chris.prather@tamarou.com	2025-01-27 19:00:00+00	Claude	noreply@anthropic.com
+eee70c0e408183c5d818fa1a6ce7e3b34d3b7cf6	344a280c4b37d460e57e312c538aa0507dae53e1	add-payment-to-enrollments	registry	Add payment_id reference to enrollments table	2026-04-19 07:12:49.967666+00	Chris Prather	chris.prather@tamarou.com	2025-01-27 19:15:00+00	Claude	noreply@anthropic.com
+acd808bf85b5a9d8971f598186ced619196ffd0e	8cdbcbf5f5d6b5933c1027b75293e23c21f82f45	notifications-and-preferences	registry	Add notifications and user preferences for attendance tracking	2026-04-19 07:12:50.151576+00	Chris Prather	chris.prather@tamarou.com	2025-01-28 10:00:00+00	Claude	noreply@anthropic.com
+5ce709b8eff5b3b920e7a675d78bee9dabd98367	9f6bfbd59ca138c524285ed7d9f0b7895354f801	parent-communication-system	registry	Add parent communication system with messages, recipients, and templates	2026-04-19 07:12:50.332917+00	Chris Prather	chris.prather@tamarou.com	2025-01-28 11:00:00+00	Claude	noreply@anthropic.com
+fbe73787977942423bb4d7ba5dd152c0c1551e38	fea7e5a85e605358de32808abb27b09f7dd78e83	performance-optimization	registry	Add database indexes and performance optimizations for production readiness	2026-04-19 07:12:50.558213+00	Chris Prather	chris.prather@tamarou.com	2025-01-28 15:00:00+00	Claude	noreply@anthropic.com
+d7d8aaecb2610865fd3801bb68ef57e474b29181	4a0067318476e1aa7150a0f54458884434cf9bfb	stripe-subscription-integration	registry	Add Stripe subscription integration for tenant billing	2026-04-19 07:12:50.727405+00	Chris Prather	chris.prather@tamarou.com	2025-01-28 16:00:00+00	Claude	noreply@anthropic.com
+8eb88eeec3cb411430882061df8d5563af64ba1c	3fa34c99f03fa41b55239b2a0c7f393ba3d49bbf	fix-multi-child-enrollments	registry	Fix multi-child enrollment constraints for cleaner architecture	2026-04-19 07:12:50.889174+00	Chris Prather	chris.prather@tamarou.com	2025-07-15 00:34:24+00	Chris Prather	chris.prather@tamarou.com
+4883848eccc158220c9e751882d20ae963d71f52	c4e3ea6ffbffc982060b0d165f60f0ff17bf78e7	flexible-enrollment-architecture	registry	Create flexible enrollment architecture supporting family, individual, group, and corporate students	2026-04-19 07:12:51.06056+00	Chris Prather	chris.prather@tamarou.com	2025-07-15 01:09:59+00	Chris Prather	chris.prather@tamarou.com
+f6dbddd094284b0b7296c6e8258922882ae24b5d	b5baa9d2cf71178ed6fd3382231eb69d0b310cfd	remove-student-id-foreign-key	registry	Remove student_id foreign key constraint to support polymorphic student references	2026-04-19 07:12:51.214261+00	Chris Prather	chris.prather@tamarou.com	2025-07-15 01:28:59+00	Chris Prather	chris.prather@tamarou.com
+ffe9a13ee38d1ffa2c706750718b34126adfe6e1	d2feca17971e5f93417b098a4295ff70ead570ee	fix-waitlist-family-member-refs	registry	Fix waitlist student_id to reference family_members instead of users	2026-04-19 07:12:51.36747+00	Chris Prather	chris.prather@tamarou.com	2025-07-16 14:30:00+00	Claude	noreply@anthropic.com
+3c3d83d65febc9de2fbce70f02fa01b5483736e8	49be975f75b20172863921261abf3906bc100990	fix-waitlist-reorder	registry	Fix waitlist position reordering to avoid unique constraint violations	2026-04-19 07:12:51.54984+00	Chris Prather	chris.prather@tamarou.com	2025-07-16 12:30:00+00	Claude	noreply@anthropic.com
+300e4d9f1d6bafe1b45f937ea482260f3313760d	b2b54846389dbdf3e2cf7ecbb15ae53fb4175d82	fix-waitlist-reorder-v2	registry	Improved waitlist position reordering to fully avoid constraint violations	2026-04-19 07:12:51.732568+00	Chris Prather	chris.prather@tamarou.com	2025-07-16 22:50:00+00	Claude	noreply@anthropic.com
+0903ffab54af2242711b1cb470a44753acf6c9d7	695f0a352ff02e4b5f84381856fe538ac1badbb7	fix-waitlist-reorder-v3	registry	Remove problematic database trigger and handle position reordering in application code	2026-04-19 07:12:51.907768+00	Chris Prather	chris.prather@tamarou.com	2025-07-17 00:00:00+00	Claude	noreply@anthropic.com
+acbd53f8d5ddfc205c3c1ca518ed92170803e32c	7b6df5319ffd75e81b5f3f06e95102a1df7f2e92	drop-transfer-business-rules	registry	Add drop and transfer business rules with admin approval workflow	2026-04-19 07:12:52.090384+00	Chris Prather	chris.prather@tamarou.com	2025-09-18 00:00:00+00	Claude	noreply@anthropic.com
+41ae5ed8ebd0150b8a8c2987bdbfd98967252b18	4ca09b1d82b01de2a829979849fa4a7f4c3120d4	remove-waitlist-position-constraint	registry	Remove unique constraint on waitlist position to allow status-based visibility	2026-04-19 07:12:52.251346+00	Chris Prather	chris.prather@tamarou.com	2025-09-21 00:00:00+00	Claude	noreply@anthropic.com
+788f8edbabafb05aef3b90f4b634beb1aaab7b8b	7dda1d870afb87ee03300b43bacf070e53c5c5ba	installment-payment-schedules	registry	Add payment schedules and scheduled payments for installment processing	2026-04-19 07:12:52.430253+00	Chris Prather	chris.prather@tamarou.com	2025-09-23 03:35:05+00	Chris Prather	chris.prather@tamarou.com
+2fc34cc17316d64ee48ef1c04e4d9c5e096b29ba	e7ea8e7d72a0222c7493190abb060dd0767adb28	simplify-installment-schema-for-stripe	registry	Simplify database schema to use Stripe native scheduling and retry features	2026-04-19 07:12:52.60779+00	Chris Prather	chris.prather@tamarou.com	2025-09-24 18:00:00+00	Claude	noreply@anthropic.com
+f61a99336db06d9d07bd30abcf6e18e98d7609ac	0f1e40107de5540b06f5181f72d75c6741728143	unified-pricing-infrastructure	registry	Add unified tenant-to-tenant pricing infrastructure	2026-04-19 07:12:52.796425+00	Chris Prather	chris.prather@tamarou.com	2025-09-29 00:44:03+00	Chris Prather	chris.prather@tamarou.com
+eb5973974d4f4c06b6e5a93c84b5a66bfcd8f342	031717d9b7ea0651ef6b5f67942c8c978f502dbe	consolidate-pricing-relationships	registry	Consolidate pricing relationships into unified model	2026-04-19 07:12:52.995413+00	Chris Prather	chris.prather@tamarou.com	2025-09-29 16:07:15+00	Chris Prather	chris.prather@tamarou.com
+20f187ed4e2e4c35404fcb5f7d48df933cebfcd5	6017815b229c39d2e9f7af54f1a963e3257a5bf2	pricing-relationship-events	registry	Add event sourcing for pricing relationship audit trail	2026-04-19 07:12:53.184111+00	Chris Prather	chris.prather@tamarou.com	2025-09-29 19:55:59+00	Chris Prather	chris.prather@tamarou.com
+5f3d84a4d2158ce0ffcfeabc5772970faca7c3d3	f41063facc70f0ff67e7cc54de594af5b99d358b	remove-pricing-plan-relationship-fields	registry	Remove obsolete target_tenant_id and offering_tenant_id from pricing_plans	2026-04-19 07:12:53.343115+00	Chris Prather	chris.prather@tamarou.com	2025-09-29 22:27:51+00	Chris Prather	chris.prather@tamarou.com
+a2248de7c1f81778ea19e6f9bc5c94e806e21268	5c6daf2fa1ab2205c6f0f0a0b153947e9304f3bd	passwordless-auth	registry	Passwordless auth: passkeys, magic links, API keys	2026-04-19 07:12:53.533962+00	Chris Prather	chris.prather@tamarou.com	2026-03-25 00:00:00+00	Chris Prather	chris.prather@tamarou.com
+afdf73989587e92e423e0b5f643361890a90a860	bdd207b58bea14042c69ffad9efcc71e3cbfbcd7	auth-notification-types	registry	Add auth notification types to notification_type enum	2026-04-19 07:12:53.686683+00	Chris Prather	chris.prather@tamarou.com	2026-03-30 06:56:54+00	Chris Prather	chris.prather@tamarou.com
+c0834addb5a970c41dc185be91f226cba562e013	314f27eca2ee77ce95e888776a12618b7d1bb0fc	tenant-domains	registry	Custom domain management for tenants	2026-04-19 07:12:53.855279+00	Chris Prather	chris.prather@tamarou.com	2026-03-30 19:04:42+00	Chris Prather	chris.prather@tamarou.com
+5656344b5447eb9e8d5b274f18d9fbfffa20f8d4	aeab9e685093de23275127520d1387c90bff2e78	magic-link-verification	registry	Add verified_at column for two-step magic link flow	2026-04-19 07:12:54.006652+00	Chris Prather	chris.prather@tamarou.com	2026-03-31 12:11:05+00	Chris Prather	chris.prather@tamarou.com
+c3c7ae6599f4db30315a79d7021519f29dafa31d	ca3c13270b018c747b12a06b702742a416a46a0e	waitlist-accepted-status	registry	Add accepted status to waitlist check constraint	2026-04-19 07:12:54.156343+00	Chris Prather	chris.prather@tamarou.com	2026-04-05 01:37:21+00	Chris Prather	chris.prather@tamarou.com
+b1024a8fd0df88c3fd8a543fb5a09512b3fa1cfb	a54ac0d95185ebb088b7bc391c48cb9cfbfb792e	seed-registry-storefront	registry	Seed registry tenant storefront (empty stub, deployed to production)	2026-04-19 07:12:54.300142+00	Chris Prather	chris.prather@tamarou.com	2026-04-07 13:42:30+00	Chris Prather	chris.prather@tamarou.com
+0d0c296e547099f9f75884c8283a0077920abc8c	70ca373942437f7f4629b935d4f21ac4b07c0c2e	seed-registry-storefront-v2	registry	Seed registry tenant storefront with actual data	2026-04-19 07:12:54.482728+00	Chris Prather	chris.prather@tamarou.com	2026-04-07 14:44:00+00	Chris Prather	chris.prather@tamarou.com
+3c41efd35c15d993a9e2b9e7621c7f14de92649e	c4df39ebada0ae78be2778a281fde400b3609664	registry-landing-page-template	registry	Customize registry tenant landing page for Jordan's user journey	2026-04-19 07:12:54.687396+00	Chris Prather	chris.prather@tamarou.com	2026-04-11 00:00:00+00	Chris Prather	chris.prather@tamarou.com
+730dfd28d76922a358dc3e5eaeb144725df7111e	ba7d12df044fc32538275c58bb83341eb096217d	fix-utf8-mojibake	registry	Delete DB templates with mojibake so app reimports fixed versions	2026-04-19 07:12:54.854226+00	Chris Prather	chris.prather@tamarou.com	2026-04-11 12:00:00+00	Chris Prather	chris.prather@tamarou.com
+4a34ed08664b5ae39f7caacd4f663285efb88267	0c6e696b7529c06d71365a38e32403b54bb173fc	update-registry-landing-copy	registry	Update registry landing page copy and 3x2 card grid	2026-04-19 07:12:55.01828+00	Chris Prather	chris.prather@tamarou.com	2026-04-11 14:00:00+00	Chris Prather	chris.prather@tamarou.com
+44c65bead55e0a35c5372aa2410a7fe5b3bf0e6b	83f48bc9c421c0e1cf1f0825a2e6a9498ca63e0d	program-publish-status	registry	Add status to projects and contact_person_id to locations for admin program setup	2026-04-19 07:12:55.207943+00	Chris Prather	chris.prather@tamarou.com	2026-04-19 00:00:00+00	Chris Prather	chris.prather@tamarou.com
 \.
 
 
@@ -2653,6 +2661,11 @@ c0834addb5a970c41dc185be91f226cba562e013	require	notifications-and-preferences	a
 c3c7ae6599f4db30315a79d7021519f29dafa31d	require	waitlist-management	9478a08db15d08f6fae783493e14eb2348a478a4
 b1024a8fd0df88c3fd8a543fb5a09512b3fa1cfb	require	events-and-sessions	5920ebcdc5fd6c9478af9fb1e435aedd26b5b5ce
 0d0c296e547099f9f75884c8283a0077920abc8c	require	seed-registry-storefront	b1024a8fd0df88c3fd8a543fb5a09512b3fa1cfb
+3c41efd35c15d993a9e2b9e7621c7f14de92649e	require	seed-registry-storefront-v2	0d0c296e547099f9f75884c8283a0077920abc8c
+730dfd28d76922a358dc3e5eaeb144725df7111e	require	registry-landing-page-template	3c41efd35c15d993a9e2b9e7621c7f14de92649e
+4a34ed08664b5ae39f7caacd4f663285efb88267	require	fix-utf8-mojibake	730dfd28d76922a358dc3e5eaeb144725df7111e
+44c65bead55e0a35c5372aa2410a7fe5b3bf0e6b	require	summer-camp-module	c0bb268a4a0c27a97351166c95d50a5f6d73d0ae
+44c65bead55e0a35c5372aa2410a7fe5b3bf0e6b	require	tenant-domains	c0834addb5a970c41dc185be91f226cba562e013
 \.
 
 
@@ -2661,50 +2674,54 @@ b1024a8fd0df88c3fd8a543fb5a09512b3fa1cfb	require	events-and-sessions	5920ebcdc5f
 --
 
 COPY sqitch.events (event, change_id, change, project, note, requires, conflicts, tags, committed_at, committer_name, committer_email, planned_at, planner_name, planner_email) FROM stdin;
-deploy	c9235c00bc368836d5323cd4b98cadfa673aa00e	users	registry	initial creation of users table and basic schema etc	{}	{}	{}	2026-04-07 22:39:36.126041+00	Chris Prather	chris.prather@tamarou.com	2024-05-13 17:21:58+00	Chris Prather	chris@prather.org
-deploy	2960f6c6a1df94ef7f1c75a036db14aefe121bc5	workflows	registry	add workflows\n\nWorkflows define a sequence of steps to be executed. We process each step and record the outcome in a workflow run.	{users}	{}	{}	2026-04-07 22:39:36.38589+00	Chris Prather	chris.prather@tamarou.com	2024-05-13 17:30:35+00	Chris Prather	chris@prather.org
-deploy	2abd1a15dc06e9db731062527f8541e8c79ffb6f	tenant-on-boarding	registry	create an onboarding workflow for tenants	{workflows,users}	{}	{}	2026-04-07 22:39:36.630534+00	Chris Prather	chris.prather@tamarou.com	2024-05-20 21:00:32+00	Chris Prather	chris@prather.org
-deploy	2f7ae3c1f6f41d31425a9ba8fa21f2e73560115c	schema-based-multitennancy	registry	add the tools to do the schema-based multi-tenancy	{tenant-on-boarding}	{}	{}	2026-04-07 22:39:36.857788+00	Chris Prather	chris.prather@tamarou.com	2024-05-21 01:43:52+00	Chris Prather	chris@prather.org
-deploy	5920ebcdc5fd6c9478af9fb1e435aedd26b5b5ce	events-and-sessions	registry	Add events and sessions to the system	{schema-based-multitennancy}	{}	{}	2026-04-07 22:39:37.123507+00	Chris Prather	chris.prather@tamarou.com	2024-05-31 03:36:11+00	Chris Prather	chris.prather@tamarou.com
-deploy	72bea40753b0250624322f67c9a64fe479f02df7	edit-template-workflow	registry	default workflow for editing templates	{}	{}	{}	2026-04-07 22:39:37.333469+00	Chris Prather	chris.prather@tamarou.com	2025-02-11 23:59:19+00	Chris Prather	chris.prather@tamarou.com
-deploy	daf665c0e9b4b1255a0cf09bb88e322f6609b59f	outcomes	registry	add outcome definitions	{}	{}	{}	2026-04-07 22:39:37.579323+00	Chris Prather	chris.prather@tamarou.com	2025-02-21 06:45:47+00	Chris Prather	chris.prather@tamarou.com
-deploy	c0bb268a4a0c27a97351166c95d50a5f6d73d0ae	summer-camp-module	registry	add summer-camp-module	{}	{}	{}	2026-04-07 22:39:37.797105+00	Chris Prather	chris.prather@tamarou.com	2025-02-22 04:38:37+00	Chris Prather	chris.prather@tamarou.com
-deploy	6d1c676dccf7787d99a54edd3ec556193ff0562d	fix-tenant-workflows	registry	Fix tenant workflows to include first_step	{schema-based-multitennancy}	{}	{}	2026-04-07 22:39:37.98148+00	Chris Prather	chris.prather@tamarou.com	2025-03-22 18:57:13+00	Chris Prather	chris.prather@tamarou.com
-deploy	4d1cce9dd15eadfe664b1a909c36f1afd6d943f2	program-types	registry	Add program types configuration system	{schema-based-multitennancy}	{}	{}	2026-04-07 22:39:38.172688+00	Chris Prather	chris.prather@tamarou.com	2025-01-27 12:00:00+00	Claude	noreply@anthropic.com
-deploy	ac009951a991475b6b82050987874c5e1562b227	enhanced-pricing-model	registry	Transform pricing to flexible pricing_plans with multiple tiers per session	{summer-camp-module}	{}	{}	2026-04-07 22:39:38.374408+00	Chris Prather	chris.prather@tamarou.com	2025-01-27 12:30:00+00	Claude	noreply@anthropic.com
-deploy	ca85da23e2f52eb6ef3b500530d301617d8d64d3	attendance-tracking	registry	Add attendance tracking infrastructure	{summer-camp-module,program-types}	{}	{}	2026-04-07 22:39:38.578309+00	Chris Prather	chris.prather@tamarou.com	2025-01-27 13:00:00+00	Claude	noreply@anthropic.com
-deploy	9478a08db15d08f6fae783493e14eb2348a478a4	waitlist-management	registry	Add waitlist functionality to enrollment system	{summer-camp-module,program-types}	{}	{}	2026-04-07 22:39:38.829302+00	Chris Prather	chris.prather@tamarou.com	2025-01-27 13:30:00+00	Claude	noreply@anthropic.com
-deploy	125881c219bfb9b9053e66b6b5fb5fdb720a1ee3	add-program-type-to-projects	registry	Add program type reference to projects	{program-types}	{}	{}	2026-04-07 22:39:39.056744+00	Chris Prather	chris.prather@tamarou.com	2025-01-27 14:00:00+00	Claude	noreply@anthropic.com
-deploy	b935f44f3eace95edc2fa318ed7de32c27e8ac1a	add-user-fields-for-family	registry	Add birth_date, user_type, grade fields to users	{users}	{}	{}	2026-04-07 22:39:39.28237+00	Chris Prather	chris.prather@tamarou.com	2025-01-27 14:25:00+00	Claude	noreply@anthropic.com
-deploy	7deaa9fb9f8f3d0309d635af087792c28525f78e	multi-child-data-model	registry	Add family_members table for multi-child support	{summer-camp-module,add-user-fields-for-family,program-types}	{}	{}	2026-04-07 22:39:39.552084+00	Chris Prather	chris.prather@tamarou.com	2025-01-27 14:30:00+00	Claude	noreply@anthropic.com
-deploy	815c14422aeab29c0c21415ea7e8927785a1c910	payments	registry	Add payments infrastructure for Stripe integration	{schema-based-multitennancy}	{}	{}	2026-04-07 22:39:39.789747+00	Chris Prather	chris.prather@tamarou.com	2025-01-27 19:00:00+00	Claude	noreply@anthropic.com
-deploy	eee70c0e408183c5d818fa1a6ce7e3b34d3b7cf6	add-payment-to-enrollments	registry	Add payment_id reference to enrollments table	{payments,summer-camp-module}	{}	{}	2026-04-07 22:39:40.01031+00	Chris Prather	chris.prather@tamarou.com	2025-01-27 19:15:00+00	Claude	noreply@anthropic.com
-deploy	acd808bf85b5a9d8971f598186ced619196ffd0e	notifications-and-preferences	registry	Add notifications and user preferences for attendance tracking	{attendance-tracking}	{}	{}	2026-04-07 22:39:40.278092+00	Chris Prather	chris.prather@tamarou.com	2025-01-28 10:00:00+00	Claude	noreply@anthropic.com
-deploy	5ce709b8eff5b3b920e7a675d78bee9dabd98367	parent-communication-system	registry	Add parent communication system with messages, recipients, and templates	{notifications-and-preferences}	{}	{}	2026-04-07 22:39:40.559649+00	Chris Prather	chris.prather@tamarou.com	2025-01-28 11:00:00+00	Claude	noreply@anthropic.com
-deploy	fbe73787977942423bb4d7ba5dd152c0c1551e38	performance-optimization	registry	Add database indexes and performance optimizations for production readiness	{parent-communication-system}	{}	{}	2026-04-07 22:39:40.804234+00	Chris Prather	chris.prather@tamarou.com	2025-01-28 15:00:00+00	Claude	noreply@anthropic.com
-deploy	d7d8aaecb2610865fd3801bb68ef57e474b29181	stripe-subscription-integration	registry	Add Stripe subscription integration for tenant billing	{enhanced-pricing-model}	{}	{}	2026-04-07 22:39:41.002693+00	Chris Prather	chris.prather@tamarou.com	2025-01-28 16:00:00+00	Claude	noreply@anthropic.com
-deploy	8eb88eeec3cb411430882061df8d5563af64ba1c	fix-multi-child-enrollments	registry	Fix multi-child enrollment constraints for cleaner architecture	{multi-child-data-model}	{}	{}	2026-04-07 22:39:41.230714+00	Chris Prather	chris.prather@tamarou.com	2025-07-15 00:34:24+00	Chris Prather	chris.prather@tamarou.com
-deploy	4883848eccc158220c9e751882d20ae963d71f52	flexible-enrollment-architecture	registry	Create flexible enrollment architecture supporting family, individual, group, and corporate students	{fix-multi-child-enrollments}	{}	{}	2026-04-07 22:39:41.438001+00	Chris Prather	chris.prather@tamarou.com	2025-07-15 01:09:59+00	Chris Prather	chris.prather@tamarou.com
-deploy	f6dbddd094284b0b7296c6e8258922882ae24b5d	remove-student-id-foreign-key	registry	Remove student_id foreign key constraint to support polymorphic student references	{flexible-enrollment-architecture}	{}	{}	2026-04-07 22:39:41.627138+00	Chris Prather	chris.prather@tamarou.com	2025-07-15 01:28:59+00	Chris Prather	chris.prather@tamarou.com
-deploy	ffe9a13ee38d1ffa2c706750718b34126adfe6e1	fix-waitlist-family-member-refs	registry	Fix waitlist student_id to reference family_members instead of users	{remove-student-id-foreign-key}	{}	{}	2026-04-07 22:39:41.863635+00	Chris Prather	chris.prather@tamarou.com	2025-07-16 14:30:00+00	Claude	noreply@anthropic.com
-deploy	3c3d83d65febc9de2fbce70f02fa01b5483736e8	fix-waitlist-reorder	registry	Fix waitlist position reordering to avoid unique constraint violations	{waitlist-management}	{}	{}	2026-04-07 22:39:42.102032+00	Chris Prather	chris.prather@tamarou.com	2025-07-16 12:30:00+00	Claude	noreply@anthropic.com
-deploy	300e4d9f1d6bafe1b45f937ea482260f3313760d	fix-waitlist-reorder-v2	registry	Improved waitlist position reordering to fully avoid constraint violations	{fix-waitlist-reorder}	{}	{}	2026-04-07 22:39:42.36012+00	Chris Prather	chris.prather@tamarou.com	2025-07-16 22:50:00+00	Claude	noreply@anthropic.com
-deploy	0903ffab54af2242711b1cb470a44753acf6c9d7	fix-waitlist-reorder-v3	registry	Remove problematic database trigger and handle position reordering in application code	{fix-waitlist-reorder-v2}	{}	{}	2026-04-07 22:39:42.60786+00	Chris Prather	chris.prather@tamarou.com	2025-07-17 00:00:00+00	Claude	noreply@anthropic.com
-deploy	acbd53f8d5ddfc205c3c1ca518ed92170803e32c	drop-transfer-business-rules	registry	Add drop and transfer business rules with admin approval workflow	{fix-multi-child-enrollments}	{}	{}	2026-04-07 22:39:42.8818+00	Chris Prather	chris.prather@tamarou.com	2025-09-18 00:00:00+00	Claude	noreply@anthropic.com
-deploy	41ae5ed8ebd0150b8a8c2987bdbfd98967252b18	remove-waitlist-position-constraint	registry	Remove unique constraint on waitlist position to allow status-based visibility	{fix-waitlist-reorder-v3}	{}	{}	2026-04-07 22:39:43.125309+00	Chris Prather	chris.prather@tamarou.com	2025-09-21 00:00:00+00	Claude	noreply@anthropic.com
-deploy	788f8edbabafb05aef3b90f4b634beb1aaab7b8b	installment-payment-schedules	registry	Add payment schedules and scheduled payments for installment processing	{payments}	{}	{}	2026-04-07 22:39:43.404463+00	Chris Prather	chris.prather@tamarou.com	2025-09-23 03:35:05+00	Chris Prather	chris.prather@tamarou.com
-deploy	2fc34cc17316d64ee48ef1c04e4d9c5e096b29ba	simplify-installment-schema-for-stripe	registry	Simplify database schema to use Stripe native scheduling and retry features	{installment-payment-schedules}	{}	{}	2026-04-07 22:39:43.662946+00	Chris Prather	chris.prather@tamarou.com	2025-09-24 18:00:00+00	Claude	noreply@anthropic.com
-deploy	f61a99336db06d9d07bd30abcf6e18e98d7609ac	unified-pricing-infrastructure	registry	Add unified tenant-to-tenant pricing infrastructure	{}	{}	{}	2026-04-07 22:39:43.888329+00	Chris Prather	chris.prather@tamarou.com	2025-09-29 00:44:03+00	Chris Prather	chris.prather@tamarou.com
-deploy	eb5973974d4f4c06b6e5a93c84b5a66bfcd8f342	consolidate-pricing-relationships	registry	Consolidate pricing relationships into unified model	{unified-pricing-infrastructure}	{}	{}	2026-04-07 22:39:44.128483+00	Chris Prather	chris.prather@tamarou.com	2025-09-29 16:07:15+00	Chris Prather	chris.prather@tamarou.com
-deploy	20f187ed4e2e4c35404fcb5f7d48df933cebfcd5	pricing-relationship-events	registry	Add event sourcing for pricing relationship audit trail	{consolidate-pricing-relationships}	{}	{}	2026-04-07 22:39:44.335398+00	Chris Prather	chris.prather@tamarou.com	2025-09-29 19:55:59+00	Chris Prather	chris.prather@tamarou.com
-deploy	5f3d84a4d2158ce0ffcfeabc5772970faca7c3d3	remove-pricing-plan-relationship-fields	registry	Remove obsolete target_tenant_id and offering_tenant_id from pricing_plans	{}	{}	{}	2026-04-07 22:39:44.527768+00	Chris Prather	chris.prather@tamarou.com	2025-09-29 22:27:51+00	Chris Prather	chris.prather@tamarou.com
-deploy	a2248de7c1f81778ea19e6f9bc5c94e806e21268	passwordless-auth	registry	Passwordless auth: passkeys, magic links, API keys	{users,schema-based-multitennancy}	{}	{}	2026-04-07 22:39:44.777794+00	Chris Prather	chris.prather@tamarou.com	2026-03-25 00:00:00+00	Chris Prather	chris.prather@tamarou.com
-deploy	afdf73989587e92e423e0b5f643361890a90a860	auth-notification-types	registry	Add auth notification types to notification_type enum	{notifications-and-preferences,passwordless-auth}	{}	{}	2026-04-07 22:39:45.007364+00	Chris Prather	chris.prather@tamarou.com	2026-03-30 06:56:54+00	Chris Prather	chris.prather@tamarou.com
-deploy	c0834addb5a970c41dc185be91f226cba562e013	tenant-domains	registry	Custom domain management for tenants	{notifications-and-preferences}	{}	{}	2026-04-07 22:39:45.244114+00	Chris Prather	chris.prather@tamarou.com	2026-03-30 19:04:42+00	Chris Prather	chris.prather@tamarou.com
-deploy	5656344b5447eb9e8d5b274f18d9fbfffa20f8d4	magic-link-verification	registry	Add verified_at column for two-step magic link flow	{passwordless-auth}	{}	{}	2026-04-07 22:39:45.484106+00	Chris Prather	chris.prather@tamarou.com	2026-03-31 12:11:05+00	Chris Prather	chris.prather@tamarou.com
-deploy	c3c7ae6599f4db30315a79d7021519f29dafa31d	waitlist-accepted-status	registry	Add accepted status to waitlist check constraint	{waitlist-management}	{}	{}	2026-04-07 22:39:45.70116+00	Chris Prather	chris.prather@tamarou.com	2026-04-05 01:37:21+00	Chris Prather	chris.prather@tamarou.com
-deploy	b1024a8fd0df88c3fd8a543fb5a09512b3fa1cfb	seed-registry-storefront	registry	Seed registry tenant storefront (empty stub, deployed to production)	{events-and-sessions}	{}	{}	2026-04-07 22:39:45.912744+00	Chris Prather	chris.prather@tamarou.com	2026-04-07 13:42:30+00	Chris Prather	chris.prather@tamarou.com
-deploy	0d0c296e547099f9f75884c8283a0077920abc8c	seed-registry-storefront-v2	registry	Seed registry tenant storefront with actual data	{seed-registry-storefront}	{}	{}	2026-04-07 22:39:46.149784+00	Chris Prather	chris.prather@tamarou.com	2026-04-07 14:44:00+00	Chris Prather	chris.prather@tamarou.com
+deploy	c9235c00bc368836d5323cd4b98cadfa673aa00e	users	registry	initial creation of users table and basic schema etc	{}	{}	{}	2026-04-19 07:12:47.101076+00	Chris Prather	chris.prather@tamarou.com	2024-05-13 17:21:58+00	Chris Prather	chris@prather.org
+deploy	2960f6c6a1df94ef7f1c75a036db14aefe121bc5	workflows	registry	add workflows\n\nWorkflows define a sequence of steps to be executed. We process each step and record the outcome in a workflow run.	{users}	{}	{}	2026-04-19 07:12:47.285406+00	Chris Prather	chris.prather@tamarou.com	2024-05-13 17:30:35+00	Chris Prather	chris@prather.org
+deploy	2abd1a15dc06e9db731062527f8541e8c79ffb6f	tenant-on-boarding	registry	create an onboarding workflow for tenants	{workflows,users}	{}	{}	2026-04-19 07:12:47.452301+00	Chris Prather	chris.prather@tamarou.com	2024-05-20 21:00:32+00	Chris Prather	chris@prather.org
+deploy	2f7ae3c1f6f41d31425a9ba8fa21f2e73560115c	schema-based-multitennancy	registry	add the tools to do the schema-based multi-tenancy	{tenant-on-boarding}	{}	{}	2026-04-19 07:12:47.603819+00	Chris Prather	chris.prather@tamarou.com	2024-05-21 01:43:52+00	Chris Prather	chris@prather.org
+deploy	5920ebcdc5fd6c9478af9fb1e435aedd26b5b5ce	events-and-sessions	registry	Add events and sessions to the system	{schema-based-multitennancy}	{}	{}	2026-04-19 07:12:47.783934+00	Chris Prather	chris.prather@tamarou.com	2024-05-31 03:36:11+00	Chris Prather	chris.prather@tamarou.com
+deploy	72bea40753b0250624322f67c9a64fe479f02df7	edit-template-workflow	registry	default workflow for editing templates	{}	{}	{}	2026-04-19 07:12:47.928039+00	Chris Prather	chris.prather@tamarou.com	2025-02-11 23:59:19+00	Chris Prather	chris.prather@tamarou.com
+deploy	daf665c0e9b4b1255a0cf09bb88e322f6609b59f	outcomes	registry	add outcome definitions	{}	{}	{}	2026-04-19 07:12:48.085919+00	Chris Prather	chris.prather@tamarou.com	2025-02-21 06:45:47+00	Chris Prather	chris.prather@tamarou.com
+deploy	c0bb268a4a0c27a97351166c95d50a5f6d73d0ae	summer-camp-module	registry	add summer-camp-module	{}	{}	{}	2026-04-19 07:12:48.289278+00	Chris Prather	chris.prather@tamarou.com	2025-02-22 04:38:37+00	Chris Prather	chris.prather@tamarou.com
+deploy	6d1c676dccf7787d99a54edd3ec556193ff0562d	fix-tenant-workflows	registry	Fix tenant workflows to include first_step	{schema-based-multitennancy}	{}	{}	2026-04-19 07:12:48.447558+00	Chris Prather	chris.prather@tamarou.com	2025-03-22 18:57:13+00	Chris Prather	chris.prather@tamarou.com
+deploy	4d1cce9dd15eadfe664b1a909c36f1afd6d943f2	program-types	registry	Add program types configuration system	{schema-based-multitennancy}	{}	{}	2026-04-19 07:12:48.610898+00	Chris Prather	chris.prather@tamarou.com	2025-01-27 12:00:00+00	Claude	noreply@anthropic.com
+deploy	ac009951a991475b6b82050987874c5e1562b227	enhanced-pricing-model	registry	Transform pricing to flexible pricing_plans with multiple tiers per session	{summer-camp-module}	{}	{}	2026-04-19 07:12:48.78278+00	Chris Prather	chris.prather@tamarou.com	2025-01-27 12:30:00+00	Claude	noreply@anthropic.com
+deploy	ca85da23e2f52eb6ef3b500530d301617d8d64d3	attendance-tracking	registry	Add attendance tracking infrastructure	{summer-camp-module,program-types}	{}	{}	2026-04-19 07:12:48.949461+00	Chris Prather	chris.prather@tamarou.com	2025-01-27 13:00:00+00	Claude	noreply@anthropic.com
+deploy	9478a08db15d08f6fae783493e14eb2348a478a4	waitlist-management	registry	Add waitlist functionality to enrollment system	{summer-camp-module,program-types}	{}	{}	2026-04-19 07:12:49.117101+00	Chris Prather	chris.prather@tamarou.com	2025-01-27 13:30:00+00	Claude	noreply@anthropic.com
+deploy	125881c219bfb9b9053e66b6b5fb5fdb720a1ee3	add-program-type-to-projects	registry	Add program type reference to projects	{program-types}	{}	{}	2026-04-19 07:12:49.268546+00	Chris Prather	chris.prather@tamarou.com	2025-01-27 14:00:00+00	Claude	noreply@anthropic.com
+deploy	b935f44f3eace95edc2fa318ed7de32c27e8ac1a	add-user-fields-for-family	registry	Add birth_date, user_type, grade fields to users	{users}	{}	{}	2026-04-19 07:12:49.420984+00	Chris Prather	chris.prather@tamarou.com	2025-01-27 14:25:00+00	Claude	noreply@anthropic.com
+deploy	7deaa9fb9f8f3d0309d635af087792c28525f78e	multi-child-data-model	registry	Add family_members table for multi-child support	{summer-camp-module,add-user-fields-for-family,program-types}	{}	{}	2026-04-19 07:12:49.610154+00	Chris Prather	chris.prather@tamarou.com	2025-01-27 14:30:00+00	Claude	noreply@anthropic.com
+deploy	815c14422aeab29c0c21415ea7e8927785a1c910	payments	registry	Add payments infrastructure for Stripe integration	{schema-based-multitennancy}	{}	{}	2026-04-19 07:12:49.802177+00	Chris Prather	chris.prather@tamarou.com	2025-01-27 19:00:00+00	Claude	noreply@anthropic.com
+deploy	eee70c0e408183c5d818fa1a6ce7e3b34d3b7cf6	add-payment-to-enrollments	registry	Add payment_id reference to enrollments table	{payments,summer-camp-module}	{}	{}	2026-04-19 07:12:49.96953+00	Chris Prather	chris.prather@tamarou.com	2025-01-27 19:15:00+00	Claude	noreply@anthropic.com
+deploy	acd808bf85b5a9d8971f598186ced619196ffd0e	notifications-and-preferences	registry	Add notifications and user preferences for attendance tracking	{attendance-tracking}	{}	{}	2026-04-19 07:12:50.15323+00	Chris Prather	chris.prather@tamarou.com	2025-01-28 10:00:00+00	Claude	noreply@anthropic.com
+deploy	5ce709b8eff5b3b920e7a675d78bee9dabd98367	parent-communication-system	registry	Add parent communication system with messages, recipients, and templates	{notifications-and-preferences}	{}	{}	2026-04-19 07:12:50.334565+00	Chris Prather	chris.prather@tamarou.com	2025-01-28 11:00:00+00	Claude	noreply@anthropic.com
+deploy	fbe73787977942423bb4d7ba5dd152c0c1551e38	performance-optimization	registry	Add database indexes and performance optimizations for production readiness	{parent-communication-system}	{}	{}	2026-04-19 07:12:50.559833+00	Chris Prather	chris.prather@tamarou.com	2025-01-28 15:00:00+00	Claude	noreply@anthropic.com
+deploy	d7d8aaecb2610865fd3801bb68ef57e474b29181	stripe-subscription-integration	registry	Add Stripe subscription integration for tenant billing	{enhanced-pricing-model}	{}	{}	2026-04-19 07:12:50.72906+00	Chris Prather	chris.prather@tamarou.com	2025-01-28 16:00:00+00	Claude	noreply@anthropic.com
+deploy	8eb88eeec3cb411430882061df8d5563af64ba1c	fix-multi-child-enrollments	registry	Fix multi-child enrollment constraints for cleaner architecture	{multi-child-data-model}	{}	{}	2026-04-19 07:12:50.890783+00	Chris Prather	chris.prather@tamarou.com	2025-07-15 00:34:24+00	Chris Prather	chris.prather@tamarou.com
+deploy	4883848eccc158220c9e751882d20ae963d71f52	flexible-enrollment-architecture	registry	Create flexible enrollment architecture supporting family, individual, group, and corporate students	{fix-multi-child-enrollments}	{}	{}	2026-04-19 07:12:51.062254+00	Chris Prather	chris.prather@tamarou.com	2025-07-15 01:09:59+00	Chris Prather	chris.prather@tamarou.com
+deploy	f6dbddd094284b0b7296c6e8258922882ae24b5d	remove-student-id-foreign-key	registry	Remove student_id foreign key constraint to support polymorphic student references	{flexible-enrollment-architecture}	{}	{}	2026-04-19 07:12:51.215884+00	Chris Prather	chris.prather@tamarou.com	2025-07-15 01:28:59+00	Chris Prather	chris.prather@tamarou.com
+deploy	ffe9a13ee38d1ffa2c706750718b34126adfe6e1	fix-waitlist-family-member-refs	registry	Fix waitlist student_id to reference family_members instead of users	{remove-student-id-foreign-key}	{}	{}	2026-04-19 07:12:51.369086+00	Chris Prather	chris.prather@tamarou.com	2025-07-16 14:30:00+00	Claude	noreply@anthropic.com
+deploy	3c3d83d65febc9de2fbce70f02fa01b5483736e8	fix-waitlist-reorder	registry	Fix waitlist position reordering to avoid unique constraint violations	{waitlist-management}	{}	{}	2026-04-19 07:12:51.551587+00	Chris Prather	chris.prather@tamarou.com	2025-07-16 12:30:00+00	Claude	noreply@anthropic.com
+deploy	300e4d9f1d6bafe1b45f937ea482260f3313760d	fix-waitlist-reorder-v2	registry	Improved waitlist position reordering to fully avoid constraint violations	{fix-waitlist-reorder}	{}	{}	2026-04-19 07:12:51.734851+00	Chris Prather	chris.prather@tamarou.com	2025-07-16 22:50:00+00	Claude	noreply@anthropic.com
+deploy	0903ffab54af2242711b1cb470a44753acf6c9d7	fix-waitlist-reorder-v3	registry	Remove problematic database trigger and handle position reordering in application code	{fix-waitlist-reorder-v2}	{}	{}	2026-04-19 07:12:51.909555+00	Chris Prather	chris.prather@tamarou.com	2025-07-17 00:00:00+00	Claude	noreply@anthropic.com
+deploy	acbd53f8d5ddfc205c3c1ca518ed92170803e32c	drop-transfer-business-rules	registry	Add drop and transfer business rules with admin approval workflow	{fix-multi-child-enrollments}	{}	{}	2026-04-19 07:12:52.092124+00	Chris Prather	chris.prather@tamarou.com	2025-09-18 00:00:00+00	Claude	noreply@anthropic.com
+deploy	41ae5ed8ebd0150b8a8c2987bdbfd98967252b18	remove-waitlist-position-constraint	registry	Remove unique constraint on waitlist position to allow status-based visibility	{fix-waitlist-reorder-v3}	{}	{}	2026-04-19 07:12:52.253135+00	Chris Prather	chris.prather@tamarou.com	2025-09-21 00:00:00+00	Claude	noreply@anthropic.com
+deploy	788f8edbabafb05aef3b90f4b634beb1aaab7b8b	installment-payment-schedules	registry	Add payment schedules and scheduled payments for installment processing	{payments}	{}	{}	2026-04-19 07:12:52.432142+00	Chris Prather	chris.prather@tamarou.com	2025-09-23 03:35:05+00	Chris Prather	chris.prather@tamarou.com
+deploy	2fc34cc17316d64ee48ef1c04e4d9c5e096b29ba	simplify-installment-schema-for-stripe	registry	Simplify database schema to use Stripe native scheduling and retry features	{installment-payment-schedules}	{}	{}	2026-04-19 07:12:52.609361+00	Chris Prather	chris.prather@tamarou.com	2025-09-24 18:00:00+00	Claude	noreply@anthropic.com
+deploy	f61a99336db06d9d07bd30abcf6e18e98d7609ac	unified-pricing-infrastructure	registry	Add unified tenant-to-tenant pricing infrastructure	{}	{}	{}	2026-04-19 07:12:52.797625+00	Chris Prather	chris.prather@tamarou.com	2025-09-29 00:44:03+00	Chris Prather	chris.prather@tamarou.com
+deploy	eb5973974d4f4c06b6e5a93c84b5a66bfcd8f342	consolidate-pricing-relationships	registry	Consolidate pricing relationships into unified model	{unified-pricing-infrastructure}	{}	{}	2026-04-19 07:12:52.997035+00	Chris Prather	chris.prather@tamarou.com	2025-09-29 16:07:15+00	Chris Prather	chris.prather@tamarou.com
+deploy	20f187ed4e2e4c35404fcb5f7d48df933cebfcd5	pricing-relationship-events	registry	Add event sourcing for pricing relationship audit trail	{consolidate-pricing-relationships}	{}	{}	2026-04-19 07:12:53.185887+00	Chris Prather	chris.prather@tamarou.com	2025-09-29 19:55:59+00	Chris Prather	chris.prather@tamarou.com
+deploy	5f3d84a4d2158ce0ffcfeabc5772970faca7c3d3	remove-pricing-plan-relationship-fields	registry	Remove obsolete target_tenant_id and offering_tenant_id from pricing_plans	{}	{}	{}	2026-04-19 07:12:53.344225+00	Chris Prather	chris.prather@tamarou.com	2025-09-29 22:27:51+00	Chris Prather	chris.prather@tamarou.com
+deploy	a2248de7c1f81778ea19e6f9bc5c94e806e21268	passwordless-auth	registry	Passwordless auth: passkeys, magic links, API keys	{users,schema-based-multitennancy}	{}	{}	2026-04-19 07:12:53.535766+00	Chris Prather	chris.prather@tamarou.com	2026-03-25 00:00:00+00	Chris Prather	chris.prather@tamarou.com
+deploy	afdf73989587e92e423e0b5f643361890a90a860	auth-notification-types	registry	Add auth notification types to notification_type enum	{notifications-and-preferences,passwordless-auth}	{}	{}	2026-04-19 07:12:53.688421+00	Chris Prather	chris.prather@tamarou.com	2026-03-30 06:56:54+00	Chris Prather	chris.prather@tamarou.com
+deploy	c0834addb5a970c41dc185be91f226cba562e013	tenant-domains	registry	Custom domain management for tenants	{notifications-and-preferences}	{}	{}	2026-04-19 07:12:53.856955+00	Chris Prather	chris.prather@tamarou.com	2026-03-30 19:04:42+00	Chris Prather	chris.prather@tamarou.com
+deploy	5656344b5447eb9e8d5b274f18d9fbfffa20f8d4	magic-link-verification	registry	Add verified_at column for two-step magic link flow	{passwordless-auth}	{}	{}	2026-04-19 07:12:54.008226+00	Chris Prather	chris.prather@tamarou.com	2026-03-31 12:11:05+00	Chris Prather	chris.prather@tamarou.com
+deploy	c3c7ae6599f4db30315a79d7021519f29dafa31d	waitlist-accepted-status	registry	Add accepted status to waitlist check constraint	{waitlist-management}	{}	{}	2026-04-19 07:12:54.158031+00	Chris Prather	chris.prather@tamarou.com	2026-04-05 01:37:21+00	Chris Prather	chris.prather@tamarou.com
+deploy	b1024a8fd0df88c3fd8a543fb5a09512b3fa1cfb	seed-registry-storefront	registry	Seed registry tenant storefront (empty stub, deployed to production)	{events-and-sessions}	{}	{}	2026-04-19 07:12:54.301851+00	Chris Prather	chris.prather@tamarou.com	2026-04-07 13:42:30+00	Chris Prather	chris.prather@tamarou.com
+deploy	0d0c296e547099f9f75884c8283a0077920abc8c	seed-registry-storefront-v2	registry	Seed registry tenant storefront with actual data	{seed-registry-storefront}	{}	{}	2026-04-19 07:12:54.484447+00	Chris Prather	chris.prather@tamarou.com	2026-04-07 14:44:00+00	Chris Prather	chris.prather@tamarou.com
+deploy	3c41efd35c15d993a9e2b9e7621c7f14de92649e	registry-landing-page-template	registry	Customize registry tenant landing page for Jordan's user journey	{seed-registry-storefront-v2}	{}	{}	2026-04-19 07:12:54.689016+00	Chris Prather	chris.prather@tamarou.com	2026-04-11 00:00:00+00	Chris Prather	chris.prather@tamarou.com
+deploy	730dfd28d76922a358dc3e5eaeb144725df7111e	fix-utf8-mojibake	registry	Delete DB templates with mojibake so app reimports fixed versions	{registry-landing-page-template}	{}	{}	2026-04-19 07:12:54.855918+00	Chris Prather	chris.prather@tamarou.com	2026-04-11 12:00:00+00	Chris Prather	chris.prather@tamarou.com
+deploy	4a34ed08664b5ae39f7caacd4f663285efb88267	update-registry-landing-copy	registry	Update registry landing page copy and 3x2 card grid	{fix-utf8-mojibake}	{}	{}	2026-04-19 07:12:55.019845+00	Chris Prather	chris.prather@tamarou.com	2026-04-11 14:00:00+00	Chris Prather	chris.prather@tamarou.com
+deploy	44c65bead55e0a35c5372aa2410a7fe5b3bf0e6b	program-publish-status	registry	Add status to projects and contact_person_id to locations for admin program setup	{summer-camp-module,tenant-domains}	{}	{}	2026-04-19 07:12:55.209589+00	Chris Prather	chris.prather@tamarou.com	2026-04-19 00:00:00+00	Chris Prather	chris.prather@tamarou.com
 \.
 
 
@@ -2713,7 +2730,7 @@ deploy	0d0c296e547099f9f75884c8283a0077920abc8c	seed-registry-storefront-v2	regi
 --
 
 COPY sqitch.projects (project, uri, created_at, creator_name, creator_email) FROM stdin;
-registry	\N	2026-04-07 22:39:35.861541+00	Chris Prather	chris.prather@tamarou.com
+registry	\N	2026-04-19 07:12:46.925312+00	Chris Prather	chris.prather@tamarou.com
 \.
 
 
@@ -2722,7 +2739,7 @@ registry	\N	2026-04-07 22:39:35.861541+00	Chris Prather	chris.prather@tamarou.co
 --
 
 COPY sqitch.releases (version, installed_at, installer_name, installer_email) FROM stdin;
-1.1	2026-04-07 22:39:35.85761+00	Chris Prather	chris.prather@tamarou.com
+1.1	2026-04-19 07:12:46.923474+00	Chris Prather	chris.prather@tamarou.com
 \.
 
 
@@ -3558,6 +3575,13 @@ CREATE INDEX idx_family_members_family_id ON registry.family_members USING btree
 --
 
 CREATE INDEX idx_family_members_name ON registry.family_members USING btree (child_name);
+
+
+--
+-- Name: idx_locations_contact_person; Type: INDEX; Schema: registry; Owner: postgres
+--
+
+CREATE INDEX idx_locations_contact_person ON registry.locations USING btree (contact_person_id);
 
 
 --
@@ -4421,6 +4445,14 @@ ALTER TABLE ONLY registry.projects
 
 
 --
+-- Name: locations locations_contact_person_id_fkey; Type: FK CONSTRAINT; Schema: registry; Owner: postgres
+--
+
+ALTER TABLE ONLY registry.locations
+    ADD CONSTRAINT locations_contact_person_id_fkey FOREIGN KEY (contact_person_id) REFERENCES registry.users(id);
+
+
+--
 -- Name: magic_link_tokens magic_link_tokens_user_id_fkey; Type: FK CONSTRAINT; Schema: registry; Owner: postgres
 --
 
@@ -4792,5 +4824,5 @@ ALTER TABLE ONLY sqitch.tags
 -- PostgreSQL database dump complete
 --
 
-\unrestrict ZVGVcCyd9VgxllQwLGmoBzo1nPvlPCXMTBdh5X7KJbijOar8i9vVUZlRWjvzQ5K
+\unrestrict nPRE3dRoUoGGkLkeysFaSv2jNX47l8tcgRW4HnzAX7HrFbGwweefAy7QCqNySvO
 

--- a/sql/verify/program-publish-status.sql
+++ b/sql/verify/program-publish-status.sql
@@ -1,0 +1,20 @@
+-- Verify registry:program-publish-status on pg
+
+BEGIN;
+
+SET search_path TO registry, public;
+
+-- projects.status column exists with expected check constraint
+SELECT 1/count(*) FROM information_schema.columns
+WHERE table_schema = 'registry'
+  AND table_name = 'projects'
+  AND column_name = 'status';
+
+-- locations.contact_person_id column exists as a uuid
+SELECT 1/count(*) FROM information_schema.columns
+WHERE table_schema = 'registry'
+  AND table_name = 'locations'
+  AND column_name = 'contact_person_id'
+  AND data_type = 'uuid';
+
+ROLLBACK;

--- a/t/controller/landing-page-cta.t
+++ b/t/controller/landing-page-cta.t
@@ -22,6 +22,14 @@ use YAML::XS qw(Load);
 my $t_db = Test::Registry::DB->new;
 my $db = $t_db->db;
 
+# The seeded DB template for tenant-storefront/program-listing is a
+# marketing landing page that doesn't render program names in the body.
+# This test asserts program names appear, so fall back to the default
+# filesystem template.
+$db->db->query(
+    q{DELETE FROM templates WHERE name = 'tenant-storefront/program-listing'}
+);
+
 # Import workflows
 my @files = Mojo::Home->new->child('workflows')->list_tree->grep(qr/\.ya?ml$/)->each;
 for my $file (@files) {

--- a/t/controller/tenant-storefront.t
+++ b/t/controller/tenant-storefront.t
@@ -28,6 +28,14 @@ my $test_db = Test::Registry::DB->new;
 my $dao     = $test_db->db;
 $ENV{DB_URL} = $test_db->uri;
 
+# The seeded DB template for tenant-storefront/program-listing renders a
+# marketing landing page that doesn't list programs. This controller test
+# asserts on the default filesystem template's program listing view, so
+# drop the DB override here.
+$dao->db->query(
+    q{DELETE FROM templates WHERE name = 'tenant-storefront/program-listing'}
+);
+
 # Import all workflows from YAML
 my @files = Mojo::Home->new->child('workflows')->list_tree->grep(qr/\.ya?ml$/)->each;
 for my $file (@files) {

--- a/t/dao/program-publish-status-schema.t
+++ b/t/dao/program-publish-status-schema.t
@@ -1,0 +1,120 @@
+#!/usr/bin/env perl
+# ABOUTME: Schema test for the program-publish-status migration.
+# ABOUTME: Verifies projects.status and locations.contact_person_id columns.
+use 5.42.0;
+use warnings;
+use lib qw(lib t/lib);
+use Test::More;
+use Test::Registry::DB;
+use Test::Registry::Fixtures;
+
+my $test_db = Test::Registry::DB->new;
+my $dao     = $test_db->db;
+my $db      = $dao->db;
+
+subtest 'registry.projects has status column with check constraint' => sub {
+    my $column = $db->query(
+        q{SELECT column_name, data_type, column_default
+          FROM information_schema.columns
+          WHERE table_schema = 'registry'
+            AND table_name = 'projects'
+            AND column_name = 'status'}
+    )->hash;
+
+    ok($column, 'status column exists on registry.projects');
+    is($column->{data_type}, 'text', 'status is text');
+    like($column->{column_default} // '', qr/draft/, 'default is draft');
+
+    # Check constraint allows exactly draft/published/closed.
+    my $constraint = $db->query(
+        q{SELECT pg_get_constraintdef(c.oid) AS def
+          FROM pg_constraint c
+          JOIN pg_class t ON t.oid = c.conrelid
+          JOIN pg_namespace n ON n.oid = t.relnamespace
+          WHERE n.nspname = 'registry'
+            AND t.relname = 'projects'
+            AND c.conname = 'projects_status_check'}
+    )->hash;
+
+    ok($constraint, 'projects_status_check exists');
+    like($constraint->{def}, qr/draft/,     'draft allowed');
+    like($constraint->{def}, qr/published/, 'published allowed');
+    like($constraint->{def}, qr/closed/,    'closed allowed');
+};
+
+subtest 'registry.locations has contact_person_id FK to users' => sub {
+    my $column = $db->query(
+        q{SELECT column_name, data_type
+          FROM information_schema.columns
+          WHERE table_schema = 'registry'
+            AND table_name = 'locations'
+            AND column_name = 'contact_person_id'}
+    )->hash;
+
+    ok($column, 'contact_person_id column exists');
+    is($column->{data_type}, 'uuid', 'contact_person_id is uuid');
+
+    # FK constraint exists and points at users.
+    my $fk = $db->query(
+        q{SELECT pg_get_constraintdef(c.oid) AS def
+          FROM pg_constraint c
+          JOIN pg_class t ON t.oid = c.conrelid
+          JOIN pg_namespace n ON n.oid = t.relnamespace
+          WHERE n.nspname = 'registry'
+            AND t.relname = 'locations'
+            AND c.contype = 'f'
+            AND pg_get_constraintdef(c.oid) LIKE '%contact_person_id%'}
+    )->hash;
+
+    ok($fk, 'foreign key on contact_person_id exists');
+    like($fk->{def}, qr/REFERENCES .*users/i, 'references users table');
+
+    # Supporting index for lookups by contact person.
+    my $index = $db->query(
+        q{SELECT indexname FROM pg_indexes
+          WHERE schemaname = 'registry'
+            AND tablename = 'locations'
+            AND indexname = 'idx_locations_contact_person'}
+    )->hash;
+    ok($index, 'supporting index exists');
+};
+
+subtest 'tenant schemas get the same columns' => sub {
+    my $tenant = Test::Registry::Fixtures::create_tenant($db, {
+        name => 'Smoke Migration Tenant',
+        slug => 'smoke_migration',
+    });
+    $db->query('SELECT clone_schema(?)', 'smoke_migration');
+
+    # Re-run only the tenant-propagation portion of the migration by
+    # invoking the relevant ALTER TABLEs in the tenant schema. This
+    # mirrors what the migration's DO block does.
+    $db->query(
+        q{ALTER TABLE smoke_migration.projects
+            ADD COLUMN IF NOT EXISTS status text DEFAULT 'draft'
+            CHECK (status IN ('draft', 'published', 'closed'))}
+    );
+    $db->query(
+        q{ALTER TABLE smoke_migration.locations
+            ADD COLUMN IF NOT EXISTS contact_person_id uuid
+            REFERENCES smoke_migration.users(id)}
+    );
+
+    my $status = $db->query(
+        q{SELECT 1 FROM information_schema.columns
+          WHERE table_schema = 'smoke_migration'
+            AND table_name = 'projects'
+            AND column_name = 'status'}
+    )->hash;
+    ok($status, 'tenant.projects has status column');
+
+    my $contact = $db->query(
+        q{SELECT 1 FROM information_schema.columns
+          WHERE table_schema = 'smoke_migration'
+            AND table_name = 'locations'
+            AND column_name = 'contact_person_id'}
+    )->hash;
+    ok($contact, 'tenant.locations has contact_person_id column');
+};
+
+done_testing();

--- a/t/e2e/tenant-onboarding.t
+++ b/t/e2e/tenant-onboarding.t
@@ -33,6 +33,14 @@ my $test_db = Test::Registry::DB->new;
 my $dao     = $test_db->db;
 $ENV{DB_URL} = $test_db->uri;
 
+# Seeded DB templates (from registry-landing-page-template) override the
+# default filesystem storefront with a marketing landing page that doesn't
+# list programs. This test checks the program-listing view, so remove the
+# override and let the default template render the created fixtures.
+$dao->db->query(
+    q{DELETE FROM templates WHERE name = 'tenant-storefront/program-listing'}
+);
+
 # Import all workflows
 my @files = Mojo::Home->new->child('workflows')->list_tree->grep(qr/\.ya?ml$/)->each;
 for my $file (@files) {

--- a/t/user-journeys/nancy/01-program-discovery.t
+++ b/t/user-journeys/nancy/01-program-discovery.t
@@ -25,6 +25,14 @@ my $tdb = Test::Registry::DB->new;
 my $db  = $tdb->db;
 $ENV{DB_URL} = $tdb->uri;
 
+# Seeded DB templates (from registry-landing-page-template) override the
+# default filesystem storefront with a marketing landing page that doesn't
+# list programs. Nancy is testing the program listing view, so remove the
+# override here and let the default template render the seeded fixtures.
+$db->db->query(
+    q{DELETE FROM templates WHERE name = 'tenant-storefront/program-listing'}
+);
+
 # Import workflows
 my @files = Mojo::Home->new->child('workflows')->list_tree->grep(qr/\.ya?ml$/)->each;
 for my $file (@files) {

--- a/templates/admin-dashboard/program_overview.html.ep
+++ b/templates/admin-dashboard/program_overview.html.ep
@@ -25,9 +25,14 @@
                         </div>
                         
                         % if ($program->{earliest_start} && $program->{latest_end}) {
+                            % # earliest_start/latest_end come from s.start_date / s.end_date (date strings)
+                            % use DateTime::Format::Strptime;
+                            % my $parser = DateTime::Format::Strptime->new(pattern => '%Y-%m-%d');
+                            % my $start = $parser->parse_datetime($program->{earliest_start});
+                            % my $end   = $parser->parse_datetime($program->{latest_end});
                             <div class="mt-2 text-xs text-gray-500">
-                                <%= DateTime->from_epoch(epoch => $program->{earliest_start})->strftime('%b %d') %> - 
-                                <%= DateTime->from_epoch(epoch => $program->{latest_end})->strftime('%b %d, %Y') %>
+                                <%= $start ? $start->strftime('%b %d') : $program->{earliest_start} %> -
+                                <%= $end   ? $end->strftime('%b %d, %Y') : $program->{latest_end} %>
                             </div>
                         % }
                     </div>


### PR DESCRIPTION
## Summary

Foundational migrations for the admin program setup workflow. Adds \`projects.status\` (matching \`sessions.status\` enum shape) and \`locations.contact_person_id\` FK to users. Foundation for #178 (publish workflow) and #179 (Location Management workflow). Spec at \`docs/specs/admin-program-setup.md\`.

## Migration

\`sql/deploy/program-publish-status.sql\`:

- \`projects.status text DEFAULT 'draft' CHECK (status IN ('draft','published','closed'))\` -- same shape as the existing \`sessions.status\` column. Deviates from the spec's original \`published boolean\` in favor of matching sessions semantics and giving us a terminal \`closed\` state for archiving.
- \`locations.contact_person_id uuid REFERENCES users(id)\` with supporting index.
- Propagation to every tenant schema that can be quoted (tenants with hyphenated slugs like the seed \`registry-platform\` are skipped since their schemas never materialise).
- Paired revert and verify scripts.

DAO changes are minimal: new \`:param :reader\` fields on Project and Location matching the new columns.

## Collateral fixes

Regenerating \`sql/test-schema.sql\` (required to include the new columns) revealed that the committed dump was stale and predated the \`registry-landing-page-template\` migration that installs a marketing-style DB-stored landing template. Four tests had been passing against the default filesystem template but would actually hit the DB override in production. They now explicitly drop the DB template in their setup:

- \`t/user-journeys/nancy/01-program-discovery.t\`
- \`t/e2e/tenant-onboarding.t\`
- \`t/controller/tenant-storefront.t\`
- \`t/controller/landing-page-cta.t\`

Separately, \`templates/admin-dashboard/program_overview.html.ep\` was calling \`DateTime->from_epoch(epoch => \$date_string)\` on \`s.start_date\`/\`s.end_date\`. That only worked before because \`Project::get_program_overview\` was silently failing on the missing \`p.status\` column. With \`projects.status\` present the query succeeds and the latent template bug surfaces. Fixed to parse the date with \`DateTime::Format::Strptime\`.

New test \`t/dao/program-publish-status-schema.t\` verifies the schema changes (columns, check constraint, FK, index) on both the registry schema and a freshly cloned tenant schema.

## Follow-up issues

- #173 DB templates should be scoped per-tenant (the root cause of the test collateral)
- #174 Move date parsing out of program_overview template into DAO
- #175 Location->save() doesn't include all fields (will bite the Location Management workflow)
- #176 Standardize tenant-schema-exists check across sqitch migrations

## Test plan

- [x] Fresh sqitch deploy succeeds from empty DB through \`program-publish-status\`
- [x] \`sqitch verify\` passes for the new change
- [x] \`sqitch revert --to update-registry-landing-copy\` cleanly removes the columns, followed by \`sqitch deploy\` to re-add them
- [x] New schema test \`t/dao/program-publish-status-schema.t\` passes (3 subtests)
- [x] Full test suite: 192 files, 1856 tests, all passing