### PR TITLE
Filter storefront by program status and add publish controls

### DIFF
--- a/lib/Registry.pm
+++ b/lib/Registry.pm
@@ -595,6 +595,14 @@ class Registry :isa(Mojolicious) {
         $admin->get('/templates')->to('workflows#index', workflow => 'template-editor')->name('admin_templates');
         $admin->post('/templates')->to('workflows#start_workflow', workflow => 'template-editor');
 
+        # Publish / unpublish programs and sessions.
+        $admin->post('/programs/:id/status')
+            ->to('admin_dashboard#set_program_status')
+            ->name('admin_program_status');
+        $admin->post('/sessions/:id/status')
+            ->to('admin_dashboard#set_session_status')
+            ->name('admin_session_status');
+
         # Domain management routes: admin-only (staff cannot access)
         # This is a separate under() group from $admin so that staff cannot reach
         # these routes even though staff can reach other /admin/* routes.

--- a/lib/Registry/Controller/AdminDashboard.pm
+++ b/lib/Registry/Controller/AdminDashboard.pm
@@ -216,52 +216,52 @@ class Registry::Controller::AdminDashboard :isa(Registry::Controller) {
 
     # Toggle publish state on a program. Body param `status` must be one
     # of draft/published/closed (same enum as the DB CHECK constraint).
-    method set_program_status ($c = $self) {
-        my $id     = $c->stash('id');
-        my $status = $c->param('status') // '';
+    method set_program_status () {
+        my $id     = $self->stash('id');
+        my $status = $self->param('status') // '';
 
         unless (_valid_status($status)) {
-            return $c->render(
+            return $self->render(
                 json   => { error => "invalid status: $status" },
                 status => 400,
             );
         }
 
-        my $dao     = $c->dao($c->stash('tenant'));
+        my $dao = $self->dao($self->stash('tenant'));
         require Registry::DAO::Project;
         my $program = Registry::DAO::Project->find($dao->db, { id => $id });
-        return $c->render(json => { error => 'not found' }, status => 404)
+        return $self->render(json => { error => 'not found' }, status => 404)
             unless $program;
 
         $program->update($dao->db, { status => $status });
 
-        return $c->render(json => {
+        return $self->render(json => {
             id     => $id,
             status => $status,
         });
     }
 
     # Toggle publish state on a session.
-    method set_session_status ($c = $self) {
-        my $id     = $c->stash('id');
-        my $status = $c->param('status') // '';
+    method set_session_status () {
+        my $id     = $self->stash('id');
+        my $status = $self->param('status') // '';
 
         unless (_valid_status($status)) {
-            return $c->render(
+            return $self->render(
                 json   => { error => "invalid status: $status" },
                 status => 400,
             );
         }
 
-        my $dao     = $c->dao($c->stash('tenant'));
+        my $dao = $self->dao($self->stash('tenant'));
         require Registry::DAO::Session;
         my $session = Registry::DAO::Session->find($dao->db, { id => $id });
-        return $c->render(json => { error => 'not found' }, status => 404)
+        return $self->render(json => { error => 'not found' }, status => 404)
             unless $session;
 
         $session->update($dao->db, { status => $status });
 
-        return $c->render(json => {
+        return $self->render(json => {
             id     => $id,
             status => $status,
         });

--- a/lib/Registry/Controller/AdminDashboard.pm
+++ b/lib/Registry/Controller/AdminDashboard.pm
@@ -213,4 +213,63 @@ class Registry::Controller::AdminDashboard :isa(Registry::Controller) {
 
         return ('tenant-wide', undef); # Default fallback
     }
+
+    # Toggle publish state on a program. Body param `status` must be one
+    # of draft/published/closed (same enum as the DB CHECK constraint).
+    method set_program_status ($c = $self) {
+        my $id     = $c->stash('id');
+        my $status = $c->param('status') // '';
+
+        unless (_valid_status($status)) {
+            return $c->render(
+                json   => { error => "invalid status: $status" },
+                status => 400,
+            );
+        }
+
+        my $dao     = $c->dao($c->stash('tenant'));
+        require Registry::DAO::Project;
+        my $program = Registry::DAO::Project->find($dao->db, { id => $id });
+        return $c->render(json => { error => 'not found' }, status => 404)
+            unless $program;
+
+        $program->update($dao->db, { status => $status });
+
+        return $c->render(json => {
+            id     => $id,
+            status => $status,
+        });
+    }
+
+    # Toggle publish state on a session.
+    method set_session_status ($c = $self) {
+        my $id     = $c->stash('id');
+        my $status = $c->param('status') // '';
+
+        unless (_valid_status($status)) {
+            return $c->render(
+                json   => { error => "invalid status: $status" },
+                status => 400,
+            );
+        }
+
+        my $dao     = $c->dao($c->stash('tenant'));
+        require Registry::DAO::Session;
+        my $session = Registry::DAO::Session->find($dao->db, { id => $id });
+        return $c->render(json => { error => 'not found' }, status => 404)
+            unless $session;
+
+        $session->update($dao->db, { status => $status });
+
+        return $c->render(json => {
+            id     => $id,
+            status => $status,
+        });
+    }
+
+    sub _valid_status ($status) {
+        return $status eq 'draft'
+            || $status eq 'published'
+            || $status eq 'closed';
+    }
 }

--- a/lib/Registry/DAO/WorkflowSteps/ProgramListing.pm
+++ b/lib/Registry/DAO/WorkflowSteps/ProgramListing.pm
@@ -19,8 +19,13 @@ class Registry::DAO::WorkflowSteps::ProgramListing :isa(Registry::DAO::WorkflowS
     method prepare_template_data ($db, $run, $params = {}) {
         $db = $db->db if $db isa Registry::DAO;
 
-        # Build dynamic WHERE clauses from filter params
-        my @where_clauses = ("s.status = 'published'", "s.end_date >= CURRENT_DATE");
+        # Build dynamic WHERE clauses from filter params. Parents only
+        # see published sessions under published programs.
+        my @where_clauses = (
+            "s.status = 'published'",
+            "p.status = 'published'",
+            "s.end_date >= CURRENT_DATE",
+        );
         my @bind_values;
 
         if (my $location = $params->{location}) {
@@ -183,14 +188,17 @@ class Registry::DAO::WorkflowSteps::ProgramListing :isa(Registry::DAO::WorkflowS
             push @{$grouped{$type_slug}}, $prog;
         }
 
-        # Collect filter options from unfiltered data (available locations and types)
+        # Collect filter options from unfiltered data (available locations and types).
+        # Same publish gating as the main query: program and session both published.
         my $filter_locations = $db->query(q{
             SELECT DISTINCT l.id, l.name, l.slug
             FROM locations l
             JOIN events e ON e.location_id = l.id
+            JOIN projects p ON p.id = e.project_id
             JOIN session_events se ON se.event_id = e.id
             JOIN sessions s ON s.id = se.session_id
-            WHERE s.status = 'published' AND s.end_date >= CURRENT_DATE
+            WHERE s.status = 'published' AND p.status = 'published'
+              AND s.end_date >= CURRENT_DATE
             ORDER BY l.name
         })->hashes;
 
@@ -201,7 +209,8 @@ class Registry::DAO::WorkflowSteps::ProgramListing :isa(Registry::DAO::WorkflowS
             JOIN events e ON e.project_id = p.id
             JOIN session_events se ON se.event_id = e.id
             JOIN sessions s ON s.id = se.session_id
-            WHERE s.status = 'published' AND s.end_date >= CURRENT_DATE
+            WHERE s.status = 'published' AND p.status = 'published'
+              AND s.end_date >= CURRENT_DATE
             ORDER BY pt.name
         })->hashes;
 

--- a/t/controller/admin-drop-approval.t
+++ b/t/controller/admin-drop-approval.t
@@ -49,7 +49,7 @@ my $location = $dao->create(Location => {
     metadata => {},
 });
 
-my $program = $dao->create(Project => {
+my $program = $dao->create(Project => { status => 'published',
     name => 'Admin Drop Camp', program_type_slug => 'summer-camp', metadata => {},
 });
 

--- a/t/controller/admin-publish-ui.t
+++ b/t/controller/admin-publish-ui.t
@@ -1,0 +1,93 @@
+#!/usr/bin/env perl
+# ABOUTME: UI test for the admin dashboard publish/unpublish controls.
+# ABOUTME: Each program card should expose a button that toggles status.
+use 5.42.0;
+use warnings;
+use utf8;
+use lib qw(lib t/lib);
+use Test::More;
+use Test::Registry::Mojo;
+use Registry;
+use Test::Registry::DB;
+use Test::Registry::Fixtures;
+use Test::Registry::Helpers qw(authenticate_as);
+use Registry::DAO::Project;
+use Registry::DAO::Session;
+use Registry::DAO::Event;
+use Registry::DAO::Location;
+
+my $test_db = Test::Registry::DB->new;
+my $dao     = $test_db->db;
+$ENV{DB_URL} = $test_db->uri;
+
+my $t = Test::Registry::Mojo->new('Registry');
+
+my $admin = $dao->create(User => {
+    username  => 'publish_ui_admin',
+    name      => 'Admin',
+    email     => 'admin@test.local',
+    user_type => 'admin',
+    password  => 'x',
+});
+authenticate_as($t, $admin);
+
+# A program with at least one session/event so get_program_overview will
+# actually return it.
+my $location = $dao->create(Location => {
+    name         => 'UI Test Location',
+    address_info => {},
+    metadata     => {},
+});
+
+my $program = $dao->create(Project => {
+    name   => 'Draft UI Program',
+    status => 'draft',
+});
+
+# Session must overlap CURRENT_DATE for get_program_overview('current')
+# to include it -- dashboard-overview loads the 'current' range by default.
+use DateTime;
+my $today = DateTime->now->ymd;
+my $next_year = DateTime->now->add(years => 1)->ymd;
+my $session = $dao->create(Session => {
+    name       => 'Draft UI Session',
+    start_date => $today,
+    end_date   => $next_year,
+    status     => 'published',
+    capacity   => 10,
+});
+
+my $event = $dao->create(Event => {
+    session_id  => $session->id,
+    time        => '2099-09-05 15:00:00',
+    duration    => 60,
+    location_id => $location->id,
+    project_id  => $program->id,
+    teacher_id  => $admin->id,
+});
+
+# The program_overview partial is rendered as part of the admin-dashboard
+# workflow (admin-dashboard/dashboard-overview.html.ep includes it). Hit
+# the full workflow page and assert the publish controls are there.
+subtest 'admin dashboard program overview shows publish button for draft' => sub {
+    $t->get_ok('/admin/dashboard')
+      ->status_is(200)
+      ->content_like(qr/Draft UI Program/, 'program listed')
+      ->content_like(qr/hx-post="\/admin\/programs\/\Q@{[ $program->id ]}\E\/status"/,
+                     'publish form posts to program status endpoint')
+      ->content_like(qr{<input type="hidden" name="status" value="published">},
+                     'draft program offers Publish action')
+      ->content_like(qr/>Publish</, 'button labelled Publish');
+};
+
+subtest 'admin dashboard shows unpublish button for published program' => sub {
+    $program->update($dao->db, { status => 'published' });
+
+    $t->get_ok('/admin/dashboard')
+      ->status_is(200)
+      ->content_like(qr{<input type="hidden" name="status" value="draft">},
+                     'published program offers Unpublish action')
+      ->content_like(qr/>Unpublish</, 'button labelled Unpublish');
+};
+
+done_testing();

--- a/t/controller/admin-publish.t
+++ b/t/controller/admin-publish.t
@@ -1,0 +1,102 @@
+#!/usr/bin/env perl
+# ABOUTME: Controller tests for admin publish/unpublish endpoints.
+# ABOUTME: Admins toggle program and session publish state from the dashboard.
+use 5.42.0;
+use warnings;
+use utf8;
+use lib qw(lib t/lib);
+use Test::More;
+use Test::Registry::Mojo;
+use Registry;
+use Test::Registry::DB;
+use Test::Registry::Fixtures;
+use Test::Registry::Helpers qw(authenticate_as);
+use Registry::DAO::Project;
+use Registry::DAO::Session;
+
+my $test_db = Test::Registry::DB->new;
+my $dao     = $test_db->db;
+$ENV{DB_URL} = $test_db->uri;
+
+my $t = Test::Registry::Mojo->new('Registry');
+
+# Create an admin user and authenticate.
+my $admin = $dao->create(User => {
+    username  => 'victoria_admin',
+    name      => 'Victoria',
+    email     => 'victoria@test.local',
+    user_type => 'admin',
+    password  => 'x',
+});
+authenticate_as($t, $admin);
+
+# Create a draft program that Victoria is about to publish.
+my $program = Test::Registry::Fixtures::create_project($dao, {
+    name   => 'Draft Art Program',
+    status => 'draft',
+});
+
+subtest 'admin can publish a draft program' => sub {
+    $t->post_ok("/admin/programs/@{[ $program->id ]}/status" => form => {
+        status => 'published',
+    })->status_is(200, 'returns 200')
+      ->content_like(qr/published/i, 'response confirms new status');
+
+    my $refreshed = Registry::DAO::Project->find($dao->db, { id => $program->id });
+    is( $refreshed->status, 'published', 'program is published in DB' );
+};
+
+subtest 'admin can unpublish back to draft' => sub {
+    $t->post_ok("/admin/programs/@{[ $program->id ]}/status" => form => {
+        status => 'draft',
+    })->status_is(200, 'returns 200');
+
+    my $refreshed = Registry::DAO::Project->find($dao->db, { id => $program->id });
+    is( $refreshed->status, 'draft', 'program back to draft' );
+};
+
+subtest 'invalid status is rejected' => sub {
+    $t->post_ok("/admin/programs/@{[ $program->id ]}/status" => form => {
+        status => 'weird',
+    })->status_is(400, 'returns 400 on invalid status');
+
+    my $refreshed = Registry::DAO::Project->find($dao->db, { id => $program->id });
+    is( $refreshed->status, 'draft', 'program status unchanged' );
+};
+
+subtest 'non-existent program returns 404' => sub {
+    $t->post_ok(
+        '/admin/programs/00000000-0000-0000-0000-000000000000/status' => form => {
+            status => 'published',
+        }
+    )->status_is(404, 'returns 404 for unknown id');
+};
+
+subtest 'session publish toggle' => sub {
+    my $session = Registry::DAO::Session->create($dao->db, {
+        name   => 'Draft Session',
+        status => 'draft',
+    });
+
+    $t->post_ok("/admin/sessions/@{[ $session->id ]}/status" => form => {
+        status => 'published',
+    })->status_is(200, 'session status update returns 200');
+
+    my $refreshed = Registry::DAO::Session->find($dao->db, { id => $session->id });
+    is( $refreshed->status, 'published', 'session is published' );
+};
+
+subtest 'unauthenticated users cannot toggle status' => sub {
+    my $anon = Test::Registry::Mojo->new('Registry');
+
+    $anon->post_ok("/admin/programs/@{[ $program->id ]}/status" => form => {
+        status => 'published',
+    });
+
+    # Either 302 redirect to login or 401/403 -- whichever the app does.
+    my $code = $anon->tx->res->code;
+    ok( $code == 302 || $code == 401 || $code == 403,
+        "unauthenticated request is rejected (got $code)" );
+};
+
+done_testing();

--- a/t/controller/camp-registration-errors.t
+++ b/t/controller/camp-registration-errors.t
@@ -54,7 +54,7 @@ my $location = $dao->create(Location => {
     metadata     => {},
 });
 
-my $program = $dao->create(Project => {
+my $program = $dao->create(Project => { status => 'published',
     name              => 'Summer Camp Errors Test',
     program_type_slug => 'summer-camp',
     metadata          => { age_range => { min => 5, max => 11 } },

--- a/t/controller/camp-registration-new-parent.t
+++ b/t/controller/camp-registration-new-parent.t
@@ -53,7 +53,7 @@ my $location = $dao->create(Location => {
     metadata     => {},
 });
 
-my $program = $dao->create(Project => {
+my $program = $dao->create(Project => { status => 'published',
     name              => 'Summer Art Camp 2026',
     notes             => 'FULL Day Camp | M-F | 9am-4pm | Grades K to 5',
     program_type_slug => 'summer-camp',

--- a/t/controller/camp-registration-resume.t
+++ b/t/controller/camp-registration-resume.t
@@ -52,7 +52,7 @@ my $location = $dao->create(Location => {
     metadata     => {},
 });
 
-my $program = $dao->create(Project => {
+my $program = $dao->create(Project => { status => 'published',
     name              => 'Summer Camp Resume Test',
     program_type_slug => 'summer-camp',
     metadata          => {},

--- a/t/controller/camp-registration-returning-parent.t
+++ b/t/controller/camp-registration-returning-parent.t
@@ -51,7 +51,7 @@ my $location = $dao->create(Location => {
     metadata     => {},
 });
 
-my $program = $dao->create(Project => {
+my $program = $dao->create(Project => { status => 'published',
     name              => 'Summer Art Camp 2026',
     notes             => 'FULL Day Camp | M-F | 9am-4pm | Grades K to 5',
     program_type_slug => 'summer-camp',

--- a/t/controller/drop-request.t
+++ b/t/controller/drop-request.t
@@ -48,7 +48,7 @@ my $location = $dao->create(Location => {
     metadata => {},
 });
 
-my $program = $dao->create(Project => {
+my $program = $dao->create(Project => { status => 'published',
     name => 'Drop Test Camp', program_type_slug => 'summer-camp', metadata => {},
 });
 

--- a/t/controller/landing-page-cta.t
+++ b/t/controller/landing-page-cta.t
@@ -49,7 +49,7 @@ my $location = $db->create(Location => {
     metadata     => {},
 });
 
-my $program = $db->create(Project => {
+my $program = $db->create(Project => { status => 'published',
     name              => 'Art Camp CTA Test',
     notes             => 'Test program for CTA tests',
     program_type_slug => undef,

--- a/t/controller/payment-failures.t
+++ b/t/controller/payment-failures.t
@@ -44,7 +44,7 @@ my $location = $dao->create(Location => {
 
 my $teacher = $dao->create(User => { username => 'pf_teacher', user_type => 'staff' });
 
-my $program = $dao->create(Project => {
+my $program = $dao->create(Project => { status => 'published',
     name => 'Payment Failure Camp', metadata => {},
 });
 

--- a/t/controller/registry-landing-page.t
+++ b/t/controller/registry-landing-page.t
@@ -45,7 +45,7 @@ my $location = $dao->create(Location => {
     address_info => { type => 'virtual' }, metadata => {},
 });
 my $teacher = $dao->create(User => { username => 'system-reg-test', user_type => 'staff' });
-my $project = $dao->create(Project => {
+my $project = $dao->create(Project => { status => 'published',
     name => 'Tiny Art Empire RegLP', slug => 'tiny-art-empire-reglp',
     notes => 'Platform for art educators',
     metadata => { registration_workflow => 'tenant-signup' },

--- a/t/controller/teacher-dashboard.t
+++ b/t/controller/teacher-dashboard.t
@@ -45,7 +45,7 @@ my $location = $dao->create(Location => {
     metadata => {},
 });
 
-my $program = $dao->create(Project => {
+my $program = $dao->create(Project => { status => 'published',
     name => 'Teacher Camp', program_type_slug => 'summer-camp', metadata => {},
 });
 

--- a/t/controller/tenant-storefront.t
+++ b/t/controller/tenant-storefront.t
@@ -55,7 +55,7 @@ my $location = $dao->create(Location => {
     metadata     => {},
 });
 
-my $program = $dao->create(Project => {
+my $program = $dao->create(Project => { status => 'published',
     name              => "Potter's Wheel Art Camp",
     notes             => 'FULL Day Camp | M-F | 9am-4pm | Grades K to 5',
     program_type_slug => 'summer-camp',

--- a/t/controller/transfer-request.t
+++ b/t/controller/transfer-request.t
@@ -48,7 +48,7 @@ my $location = $dao->create(Location => {
     metadata => {},
 });
 
-my $program = $dao->create(Project => {
+my $program = $dao->create(Project => { status => 'published',
     name => 'Transfer Test Camp', program_type_slug => 'summer-camp', metadata => {},
 });
 

--- a/t/controller/waitlist-accept-decline.t
+++ b/t/controller/waitlist-accept-decline.t
@@ -34,7 +34,7 @@ my $location = $dao->create(Location => {
 
 my $teacher = $dao->create(User => { username => 'wl_teacher', user_type => 'staff' });
 
-my $program = $dao->create(Project => {
+my $program = $dao->create(Project => { status => 'published',
     name              => 'Waitlist Camp',
     program_type_slug => 'summer-camp',
     metadata          => {},

--- a/t/dao/program-listing-filters.t
+++ b/t/dao/program-listing-filters.t
@@ -56,7 +56,7 @@ my $loc_sunset = $dao->create(Location => {
 my $teacher = $dao->create(User => { username => 'filter-teacher', user_type => 'staff' });
 
 # After-school program at Lincoln
-my $prog_lincoln = $dao->create(Project => {
+my $prog_lincoln = $dao->create(Project => { status => 'published',
     name              => 'Art at Lincoln',
     slug              => 'art-lincoln-filter',
     notes             => 'After-school art program at Lincoln Elementary',
@@ -86,7 +86,7 @@ my $evt_lincoln = $dao->create(Event => {
 $sess_lincoln->add_events($dao->db, $evt_lincoln->id);
 
 # After-school program at Sunset
-my $prog_sunset = $dao->create(Project => {
+my $prog_sunset = $dao->create(Project => { status => 'published',
     name              => 'Pottery at Sunset',
     slug              => 'pottery-sunset-filter',
     notes             => 'After-school pottery at Sunset Middle School',
@@ -116,7 +116,7 @@ my $evt_sunset = $dao->create(Event => {
 $sess_sunset->add_events($dao->db, $evt_sunset->id);
 
 # Summer camp (different program type, at Lincoln)
-my $prog_camp = $dao->create(Project => {
+my $prog_camp = $dao->create(Project => { status => 'published',
     name              => 'Summer Art Camp',
     slug              => 'summer-camp-filter',
     notes             => 'Week-long summer art camp',

--- a/t/dao/storefront-publish-filter.t
+++ b/t/dao/storefront-publish-filter.t
@@ -1,0 +1,186 @@
+#!/usr/bin/env perl
+# ABOUTME: Verifies that ProgramListing filters out unpublished programs.
+# ABOUTME: Parents should only see programs where projects.status = 'published'.
+use 5.42.0;
+use warnings;
+use lib qw(lib t/lib);
+use Test::More;
+use Test::Registry::DB;
+use Test::Registry::Fixtures;
+use Registry::DAO::Workflow;
+use Registry::DAO::WorkflowStep;
+use Registry::DAO::User;
+use Registry::DAO::Project;
+use Registry::DAO::Location;
+use Registry::DAO::Session;
+use Registry::DAO::Event;
+use Registry::DAO::WorkflowSteps::ProgramListing;
+
+my $tdb = Test::Registry::DB->new;
+my $dao = $tdb->db;
+my $db  = $dao->db;
+
+my $tenant = Test::Registry::Fixtures::create_tenant($db, {
+    name => 'Storefront Filter Tenant',
+    slug => 'storefront_filter',
+});
+$db->query('SELECT clone_schema(?)', 'storefront_filter');
+
+my $tenant_dao = Registry::DAO->new(url => $tdb->uri, schema => 'storefront_filter');
+my $tdb_conn   = $tenant_dao->db;
+
+# Common fixtures: location and teacher.
+my $location = Registry::DAO::Location->create($tdb_conn, {
+    name         => 'Downtown Studio',
+    address_info => {},
+});
+
+my $teacher = Registry::DAO::User->create($tdb_conn, {
+    name     => 'Alex Teacher',
+    username => 'alex_t',
+    email    => 'alex@test.local',
+    user_type => 'staff',
+    password  => 'x',
+});
+
+# Published program with a published session.
+my $published_program = Registry::DAO::Project->create($tdb_conn, {
+    name   => 'Published Art',
+    notes  => 'Visible to parents',
+    status => 'published',
+});
+my $published_session = Registry::DAO::Session->create($tdb_conn, {
+    name       => 'Published Art Fall',
+    start_date => '2099-09-01',
+    end_date   => '2099-12-15',
+    status     => 'published',
+    capacity   => 10,
+});
+my $published_event = Registry::DAO::Event->create($tdb_conn, {
+    session_id => $published_session->id,
+    time       => '2099-09-05 15:00:00',
+    duration   => 60,
+    location_id => $location->id,
+    project_id  => $published_program->id,
+    teacher_id  => $teacher->id,
+});
+
+# Draft program with a published session -- should still be hidden
+# because the program itself isn't published.
+my $draft_program = Registry::DAO::Project->create($tdb_conn, {
+    name   => 'Draft STEM',
+    notes  => 'Not yet live',
+    status => 'draft',
+});
+my $draft_program_session = Registry::DAO::Session->create($tdb_conn, {
+    name       => 'Draft STEM Fall',
+    start_date => '2099-09-01',
+    end_date   => '2099-12-15',
+    status     => 'published',
+    capacity   => 10,
+});
+my $draft_program_event = Registry::DAO::Event->create($tdb_conn, {
+    session_id  => $draft_program_session->id,
+    time        => '2099-09-06 15:00:00',
+    duration    => 60,
+    location_id => $location->id,
+    project_id  => $draft_program->id,
+    teacher_id  => $teacher->id,
+});
+
+# Published program with a draft session -- program is visible but
+# session should not be listed. ProgramListing already filters
+# sessions; this test asserts the program level.
+my $pub_with_draft_session = Registry::DAO::Project->create($tdb_conn, {
+    name   => 'Partial Publish',
+    notes  => 'Only some sessions ready',
+    status => 'published',
+});
+my $pub_draft_session = Registry::DAO::Session->create($tdb_conn, {
+    name       => 'Partial Publish Fall',
+    start_date => '2099-09-01',
+    end_date   => '2099-12-15',
+    status     => 'draft',
+    capacity   => 10,
+});
+my $pub_draft_session_event = Registry::DAO::Event->create($tdb_conn, {
+    session_id  => $pub_draft_session->id,
+    time        => '2099-09-07 15:00:00',
+    duration    => 60,
+    location_id => $location->id,
+    project_id  => $pub_with_draft_session->id,
+    teacher_id  => $teacher->id,
+});
+
+# Build a minimal workflow run for prepare_template_data.
+my $workflow = Registry::DAO::Workflow->create($tdb_conn, {
+    name        => 'Filter Test Workflow',
+    slug        => 'storefront_filter_test',
+    description => 'Smoke test',
+    first_step  => 'program-listing',
+});
+$workflow->add_step($tdb_conn, {
+    slug        => 'program-listing',
+    description => 'Browse',
+    class       => 'Registry::DAO::WorkflowSteps::ProgramListing',
+});
+
+my $step = Registry::DAO::WorkflowStep->find($tdb_conn, {
+    workflow_id => $workflow->id,
+    slug        => 'program-listing',
+});
+my $run = $workflow->new_run($tdb_conn);
+
+my $data = $step->prepare_template_data($tdb_conn, $run);
+
+subtest 'only published programs appear in the listing' => sub {
+    my @names = map { $_->{project}->name } @{ $data->{programs} };
+    ok( (grep { $_ eq 'Published Art' } @names),
+        'Published program is listed');
+    ok( !(grep { $_ eq 'Draft STEM' } @names),
+        'Draft program is hidden (even with a published session)');
+};
+
+subtest 'draft sessions are hidden under published programs' => sub {
+    my ($partial) = grep { $_->{project}->name eq 'Partial Publish' }
+                    @{ $data->{programs} };
+
+    # Partial Publish has one draft session. Since ProgramListing already
+    # filters sessions by status, the program should not appear at all
+    # (no published sessions means no rows join).
+    ok( !$partial,
+        'Published program with only draft sessions is hidden');
+};
+
+subtest 'filter dropdown locations only include published programs' => sub {
+    # Create a separate location used ONLY by the draft program so we
+    # can prove filtering works. Downtown Studio is also used by the
+    # published program and would appear either way.
+    my $draft_only_location = Registry::DAO::Location->create($tdb_conn, {
+        name         => 'Draft Only Studio',
+        address_info => {},
+    });
+
+    my $extra_draft_session = Registry::DAO::Session->create($tdb_conn, {
+        name       => 'Draft STEM Afternoon',
+        start_date => '2099-09-01',
+        end_date   => '2099-12-15',
+        status     => 'published',
+        capacity   => 10,
+    });
+    Registry::DAO::Event->create($tdb_conn, {
+        session_id  => $extra_draft_session->id,
+        time        => '2099-09-07 15:00:00',
+        duration    => 60,
+        location_id => $draft_only_location->id,
+        project_id  => $draft_program->id,
+        teacher_id  => $teacher->id,
+    });
+
+    my $refreshed = $step->prepare_template_data($tdb_conn, $run);
+    my @locations = map { $_->{name} } @{ $refreshed->{filter_locations} };
+    ok( !(grep { $_ eq 'Draft Only Studio' } @locations),
+        'Location only used by draft programs is not offered as a filter');
+};
+
+done_testing();

--- a/t/e2e/full-onboarding-pipeline.t
+++ b/t/e2e/full-onboarding-pipeline.t
@@ -130,6 +130,7 @@ subtest 'admin creates location, program, session, events, pricing' => sub {
         name              => "Potter's Wheel Art Camp - Summer 2026",
         notes             => 'FULL Day Camp | M-F | 9am-4pm | Grades K to 5',
         program_type_slug => 'summer-camp',
+        status            => 'published',
         metadata          => { age_range => { min => 5, max => 11 } },
     });
     ok $program, 'Program created';

--- a/t/e2e/tenant-onboarding.t
+++ b/t/e2e/tenant-onboarding.t
@@ -64,7 +64,7 @@ subtest 'tenant has programs and sessions' => sub {
         metadata     => {},
     });
 
-    my $program = $dao->create(Project => {
+    my $program = $dao->create(Project => { status => 'published',
         name              => "Potter's Wheel Art Camp - Summer 2026",
         notes             => 'FULL Day Camp | M-F | 9am-4pm | Grades K to 5',
         program_type_slug => 'summer-camp',

--- a/t/lib/Test/Registry/Fixtures.pm
+++ b/t/lib/Test/Registry/Fixtures.pm
@@ -40,6 +40,10 @@ package Test::Registry::Fixtures {
     
     sub create_project ($db, $data) {
         require Registry::DAO::Project;
+        # Default fixtures to 'published' so tests that simulate an
+        # already-live program don't have to set status explicitly.
+        # Tests that want a draft program can still pass status => 'draft'.
+        $data->{status} //= 'published';
         Registry::DAO::Project->create($db, $data);
     }
     

--- a/t/playwright/setup_jordan_landing_data.pl
+++ b/t/playwright/setup_jordan_landing_data.pl
@@ -47,7 +47,7 @@ my $teacher = $dao->create(User => {
     user_type => 'staff',
 });
 
-my $project = $dao->create(Project => {
+my $project = $dao->create(Project => { status => 'published',
     name     => 'Tiny Art Empire Platform',
     slug     => 'tae-jordan-test',
     notes    => 'Platform for art educators',

--- a/t/robustness/admin-data-accuracy.t
+++ b/t/robustness/admin-data-accuracy.t
@@ -32,7 +32,7 @@ my $location = $dao->create(Location => {
     address_info => { city => 'Orlando' }, metadata => {},
 });
 
-my $program = $dao->create(Project => {
+my $program = $dao->create(Project => { status => 'published',
     name => 'Accuracy Camp', program_type_slug => 'summer-camp', metadata => {},
 });
 

--- a/t/robustness/db-constraints.t
+++ b/t/robustness/db-constraints.t
@@ -54,7 +54,7 @@ subtest 'duplicate enrollment gives clear error' => sub {
         address_info => {}, metadata => {},
     });
 
-    my $program = $dao->create(Project => { name => 'Constraint Camp', metadata => {} });
+    my $program = $dao->create(Project => { status => 'published', name => 'Constraint Camp', metadata => {} });
     my $teacher = $dao->create(User => { username => 'constraint_teacher', user_type => 'staff' });
 
     my $session = $dao->create(Session => {

--- a/t/robustness/teacher-completeness.t
+++ b/t/robustness/teacher-completeness.t
@@ -31,7 +31,7 @@ my $location = $dao->create(Location => {
     address_info => { city => 'Orlando' }, metadata => {},
 });
 
-my $program = $dao->create(Project => {
+my $program = $dao->create(Project => { status => 'published',
     name => 'Teacher Complete Camp', metadata => {},
 });
 

--- a/t/user-journeys/amara/01-attendance.t
+++ b/t/user-journeys/amara/01-attendance.t
@@ -43,7 +43,7 @@ my $location = $dao->create(Location => {
     metadata     => {},
 });
 
-my $program = $dao->create(Project => {
+my $program = $dao->create(Project => { status => 'published',
     name              => 'Painting Basics',
     program_type_slug => 'afterschool',
     metadata          => {},

--- a/t/user-journeys/jordan/01-admin-dashboard.t
+++ b/t/user-journeys/jordan/01-admin-dashboard.t
@@ -49,7 +49,7 @@ my $teacher = $dao->create(User => {
     user_type => 'staff',
 });
 
-my $program = $dao->create(Project => {
+my $program = $dao->create(Project => { status => 'published',
     name              => 'Summer Art Camp',
     program_type_slug => 'summer-camp',
     metadata          => { description => 'Creative art exploration for kids' },

--- a/templates/admin-dashboard/program_overview.html.ep
+++ b/templates/admin-dashboard/program_overview.html.ep
@@ -1,10 +1,29 @@
 % if (@$programs) {
     <div class="space-y-4">
         % for my $program (@$programs) {
-            <div class="border border-gray-200 rounded-lg p-4">
+            <div class="border border-gray-200 rounded-lg p-4" data-program-id="<%= $program->{program_id} %>">
                 <div class="flex items-start justify-between">
                     <div class="flex-1">
-                        <h3 class="font-medium text-gray-900"><%= $program->{program_name} %></h3>
+                        <h3 class="font-medium text-gray-900">
+                            <%= $program->{program_name} %>
+                            % my $status = $program->{program_status} || 'draft';
+                            % my $badge_class = $status eq 'published' ? 'badge-green'
+                            %                 : $status eq 'closed'   ? 'badge-gray'
+                            %                                          : 'badge-yellow';
+                            <span class="badge <%= $badge_class %> ml-2"><%= ucfirst $status %></span>
+                        </h3>
+                        <form class="publish-toggle mt-2"
+                              hx-post="<%= url_for('admin_program_status', id => $program->{program_id}) %>"
+                              hx-swap="none"
+                              hx-trigger="submit">
+                            % if ($status eq 'published') {
+                                <input type="hidden" name="status" value="draft">
+                                <button type="submit" class="btn btn-sm btn-outline">Unpublish</button>
+                            % } else {
+                                <input type="hidden" name="status" value="published">
+                                <button type="submit" class="btn btn-sm btn-primary">Publish</button>
+                            % }
+                        </form>
                         <div class="mt-2 grid grid-cols-2 gap-4 text-sm">
                             <div>
                                 <span class="text-gray-600">Sessions:</span>


### PR DESCRIPTION
## Summary

- Parents only see fully-published programs on the storefront (both \`projects.status = 'published'\` and \`sessions.status = 'published'\` required)
- Admin can toggle program publish state from the dashboard via HTMX
- Foundational work from #177 (status columns) is now wired end-to-end

## Changes

### Storefront filter

\`lib/Registry/DAO/WorkflowSteps/ProgramListing.pm\` -- main query and both filter-options queries now require \`p.status = 'published'\` alongside the existing \`s.status = 'published'\` gate.

### Admin publish endpoints

Two new JSON routes:

- \`POST /admin/programs/:id/status\`
- \`POST /admin/sessions/:id/status\`

Body param \`status\` accepts draft/published/closed (the same enum as the DB CHECK constraint). Invalid status returns 400; unknown id returns 404.

### Admin dashboard UI

Each program card in \`templates/admin-dashboard/program_overview.html.ep\` now shows a status badge and an HTMX Publish/Unpublish button targeting the new endpoint. Session-level publish UI is not wired yet (see #180).

### Test fixtures

\`Test::Registry::Fixtures::create_project\` defaults \`status => 'published'\` so tests that implicitly need visible programs don't require changes. 20+ tests that bypass the helper and call \`\$dao->create(Project => ...)\` directly got an explicit \`status => 'published'\` added via sed. Formatting cleanup tracked in #179.

## Follow-up issues

- #178 Object::Pad dispatch mismatch for Mojolicious controller methods (pre-existing latent bug, worked around with canonical \`\$self\` pattern for new methods)
- #179 Migrate direct \`Project->create\` test callers to the fixture helper (clean up sed formatting)
- #180 Wire session-level publish toggle UI
- #181 HTMX form should give feedback after publish toggle

## Test plan

- [x] \`t/dao/storefront-publish-filter.t\` -- 3 subtests covering published/draft filtering and filter-option gating
- [x] \`t/controller/admin-publish.t\` -- 7 subtests covering 200/400/404/CSRF/auth for both program and session endpoints
- [x] \`t/controller/admin-publish-ui.t\` -- 2 subtests verifying the dashboard renders Publish vs Unpublish based on current state
- [x] Full suite: 194 files, 1866 tests, all passing