### PR TITLE
Wire session-level publish toggles on admin dashboard

### DIFF
--- a/lib/Registry/Controller/AdminDashboard.pm
+++ b/lib/Registry/Controller/AdminDashboard.pm
@@ -259,6 +259,23 @@ class Registry::Controller::AdminDashboard :isa(Registry::Controller) {
         return $self->render(json => { error => 'not found' }, status => 404)
             unless $session;
 
+        # Publishing a session requires its parent program to be published
+        # first (spec rule: program publishes before any sessions).
+        if ($status eq 'published') {
+            require Registry::DAO::Project;
+            my $project_id = $session->project_id($dao->db);
+            my $program    = $project_id
+                ? Registry::DAO::Project->find($dao->db, { id => $project_id })
+                : undef;
+
+            unless ($program && $program->status eq 'published') {
+                return $self->render(
+                    json   => { error => 'parent program must be published first' },
+                    status => 409,
+                );
+            }
+        }
+
         $session->update($dao->db, { status => $status });
 
         return $self->render(json => {

--- a/lib/Registry/DAO/Project.pm
+++ b/lib/Registry/DAO/Project.pm
@@ -120,6 +120,41 @@ class Registry::DAO::Project :isa(Registry::DAO::Object) {
             }
         }
 
+        # Load sessions per program so the admin dashboard can render
+        # per-session publish toggles.
+        if (@$results) {
+            my @program_ids = map { $_->{program_id} } @$results;
+            my $placeholders = join(',', ('?') x @program_ids);
+            my $session_rows = $db->query(qq{
+                SELECT DISTINCT
+                    s.id, s.name, s.slug, s.status,
+                    s.start_date, s.end_date, s.capacity,
+                    e.project_id
+                FROM sessions s
+                JOIN session_events se ON se.session_id = s.id
+                JOIN events e ON e.id = se.event_id
+                WHERE e.project_id IN ($placeholders)
+                ORDER BY s.start_date, s.name
+            }, @program_ids)->hashes->to_array;
+
+            my %by_program;
+            for my $row (@$session_rows) {
+                push @{$by_program{$row->{project_id}}}, {
+                    id         => $row->{id},
+                    name       => $row->{name},
+                    slug       => $row->{slug},
+                    status     => $row->{status},
+                    start_date => $row->{start_date},
+                    end_date   => $row->{end_date},
+                    capacity   => $row->{capacity},
+                };
+            }
+
+            for my $program (@$results) {
+                $program->{sessions} = $by_program{$program->{program_id}} || [];
+            }
+        }
+
         return $results;
     }
 

--- a/lib/Registry/DAO/Project.pm
+++ b/lib/Registry/DAO/Project.pm
@@ -125,6 +125,8 @@ class Registry::DAO::Project :isa(Registry::DAO::Object) {
         if (@$results) {
             my @program_ids = map { $_->{program_id} } @$results;
             my $placeholders = join(',', ('?') x @program_ids);
+            # DISTINCT because session_events produces multiple rows per
+            # (session, program) when a session has more than one event.
             my $session_rows = $db->query(qq{
                 SELECT DISTINCT
                     s.id, s.name, s.slug, s.status,

--- a/lib/Registry/DAO/Session.pm
+++ b/lib/Registry/DAO/Session.pm
@@ -24,8 +24,34 @@ class Registry::DAO::Session :isa(Registry::DAO::Object) {
 
     # project_id and location_id are stored inside metadata (see create())
     # because the sessions table has no dedicated columns for them.
-    method project_id  { $metadata->{project_id} }
-    method location_id { $metadata->{location_id} }
+    # When metadata is empty (e.g. a Session created directly and linked
+    # to a program via a separate Event row), fall back to the
+    # session_events -> events join.
+    method project_id ($db = undef) {
+        return $metadata->{project_id} if $metadata->{project_id};
+        return undef unless $db && $id;
+        $db = $db->db if $db isa Registry::DAO;
+        my $row = $db->query(
+            q{SELECT e.project_id FROM session_events se
+              JOIN events e ON e.id = se.event_id
+              WHERE se.session_id = ? LIMIT 1},
+            $id,
+        )->hash;
+        return $row ? $row->{project_id} : undef;
+    }
+
+    method location_id ($db = undef) {
+        return $metadata->{location_id} if $metadata->{location_id};
+        return undef unless $db && $id;
+        $db = $db->db if $db isa Registry::DAO;
+        my $row = $db->query(
+            q{SELECT e.location_id FROM session_events se
+              JOIN events e ON e.id = se.event_id
+              WHERE se.session_id = ? LIMIT 1},
+            $id,
+        )->hash;
+        return $row ? $row->{location_id} : undef;
+    }
 
     ADJUST {
         # Decode JSON metadata if it's a string

--- a/t/controller/admin-publish-ui.t
+++ b/t/controller/admin-publish-ui.t
@@ -90,4 +90,61 @@ subtest 'admin dashboard shows unpublish button for published program' => sub {
       ->content_like(qr/>Unpublish</, 'button labelled Unpublish');
 };
 
+subtest 'program card lists sessions with publish toggles' => sub {
+    # Add a draft session to the existing published program.
+    my $draft_session = $dao->create(Session => {
+        name       => 'Draft UI Child Session',
+        start_date => $today,
+        end_date   => $next_year,
+        status     => 'draft',
+        capacity   => 10,
+    });
+
+    # Link it via an event (use a different hour so the unique
+    # (project_id, location_id, time) constraint is satisfied).
+    my $new_event = $dao->create(Event => {
+        session_id  => $draft_session->id,
+        time        => '2099-09-05 16:00:00',
+        duration    => 60,
+        location_id => $location->id,
+        project_id  => $program->id,
+        teacher_id  => $admin->id,
+    });
+    ok($new_event, 'new event created');
+
+    # Confirm session_events link was made -- Event->create writes this
+    # via a separate insert.
+    my $link_count = $dao->db->query(
+        'SELECT COUNT(*) FROM session_events WHERE session_id = ?',
+        $draft_session->id,
+    )->array->[0];
+    is($link_count, 1, 'session_events link created for new session');
+
+    $t->get_ok('/admin/dashboard')
+      ->status_is(200)
+      ->content_like(qr/Draft UI Child Session/,
+                     'session listed on program card')
+      ->content_like(
+            qr/hx-post="\/admin\/sessions\/\Q@{[ $draft_session->id ]}\E\/status"/,
+            'session publish form targets session endpoint')
+      ->content_like(qr{name="status" value="published"},
+                     'draft session offers Publish action');
+
+    # Flip the session to published and re-check.
+    $draft_session->update($dao->db, { status => 'published' });
+
+    # Fetch the dashboard, find the session's form, and verify its
+    # hidden status field targets 'draft' (i.e. the button unpublishes).
+    $t->get_ok('/admin/dashboard')
+      ->status_is(200);
+
+    my $session_id = $draft_session->id;
+    my $body       = $t->tx->res->body;
+    like(
+        $body,
+        qr{hx-post="/admin/sessions/\Q$session_id\E/status"(?:[^<]|<(?!/form))*?<input type="hidden" name="status" value="draft">}s,
+        'published session form posts status=draft (Unpublish)',
+    );
+};
+
 done_testing();

--- a/t/controller/admin-publish.t
+++ b/t/controller/admin-publish.t
@@ -73,9 +73,28 @@ subtest 'non-existent program returns 404' => sub {
 };
 
 subtest 'session publish toggle' => sub {
+    # Session must belong to a published program before it can be
+    # published itself -- create the program, a linking event, then
+    # the session.
+    require Registry::DAO::Location;
+    require Registry::DAO::Event;
+    my $location = Registry::DAO::Location->create($dao->db, {
+        name => 'Session Toggle Location', address_info => {},
+    });
+    my $published_program = Registry::DAO::Project->create($dao->db, {
+        name => 'Parent Program', status => 'published',
+    });
     my $session = Registry::DAO::Session->create($dao->db, {
         name   => 'Draft Session',
         status => 'draft',
+    });
+    Registry::DAO::Event->create($dao->db, {
+        session_id  => $session->id,
+        time        => '2099-07-04 09:00:00',
+        duration    => 60,
+        location_id => $location->id,
+        project_id  => $published_program->id,
+        teacher_id  => $admin->id,
     });
 
     $t->post_ok("/admin/sessions/@{[ $session->id ]}/status" => form => {
@@ -84,6 +103,38 @@ subtest 'session publish toggle' => sub {
 
     my $refreshed = Registry::DAO::Session->find($dao->db, { id => $session->id });
     is( $refreshed->status, 'published', 'session is published' );
+};
+
+subtest 'cannot publish a session under a draft program' => sub {
+    require Registry::DAO::Location;
+    require Registry::DAO::Event;
+    my $location = Registry::DAO::Location->create($dao->db, {
+        name => 'Draft Parent Location', address_info => {},
+    });
+    my $draft_program = Registry::DAO::Project->create($dao->db, {
+        name => 'Not-Yet-Public Program', status => 'draft',
+    });
+    my $session = Registry::DAO::Session->create($dao->db, {
+        name   => 'Orphaned Session',
+        status => 'draft',
+    });
+    Registry::DAO::Event->create($dao->db, {
+        session_id  => $session->id,
+        time        => '2099-08-04 09:00:00',
+        duration    => 60,
+        location_id => $location->id,
+        project_id  => $draft_program->id,
+        teacher_id  => $admin->id,
+    });
+
+    $t->post_ok("/admin/sessions/@{[ $session->id ]}/status" => form => {
+        status => 'published',
+    })->status_is(409, 'returns 409 Conflict')
+      ->content_like(qr/parent program must be published/i,
+                     'error message names the reason');
+
+    my $refreshed = Registry::DAO::Session->find($dao->db, { id => $session->id });
+    is( $refreshed->status, 'draft', 'session remains draft' );
 };
 
 subtest 'unauthenticated users cannot toggle status' => sub {

--- a/t/dao/program-overview-sessions.t
+++ b/t/dao/program-overview-sessions.t
@@ -1,0 +1,97 @@
+#!/usr/bin/env perl
+# ABOUTME: Program overview should return per-program session lists
+# ABOUTME: so the admin dashboard can render session-level publish toggles.
+use 5.42.0;
+use warnings;
+use lib qw(lib t/lib);
+use Test::More;
+use Test::Registry::DB;
+use Test::Registry::Fixtures;
+use Registry::DAO::Project;
+use Registry::DAO::Session;
+use Registry::DAO::Event;
+use Registry::DAO::Location;
+use Registry::DAO::User;
+use DateTime;
+
+my $tdb = Test::Registry::DB->new;
+my $dao = $tdb->db;
+
+my $tenant = Test::Registry::Fixtures::create_tenant($dao->db, {
+    name => 'Session Overview Tenant',
+    slug => 'session_overview',
+});
+$dao->db->query('SELECT clone_schema(?)', 'session_overview');
+$dao = Registry::DAO->new(url => $tdb->uri, schema => 'session_overview');
+my $db = $dao->db;
+
+my $today     = DateTime->now;
+my $tomorrow  = $today->clone->add(days => 1);
+my $next_year = $today->clone->add(years => 1);
+
+my $location = Registry::DAO::Location->create($db, {
+    name => 'Session Test Location', address_info => {},
+});
+my $teacher = Registry::DAO::User->create($db, {
+    name => 'T Teacher', username => 'sovt', email => 't@t.com',
+    user_type => 'staff', password => 'x',
+});
+
+my $program = Registry::DAO::Project->create($db, {
+    name   => 'Multi-Session Program',
+    status => 'published',
+});
+
+# Two sessions that span CURRENT_DATE (so 'current' range includes them).
+my $published_session = Registry::DAO::Session->create($db, {
+    name       => 'Published Session',
+    start_date => $today->ymd,
+    end_date   => $next_year->ymd,
+    status     => 'published',
+    capacity   => 20,
+});
+my $draft_session = Registry::DAO::Session->create($db, {
+    name       => 'Draft Session',
+    start_date => $today->ymd,
+    end_date   => $next_year->ymd,
+    status     => 'draft',
+    capacity   => 15,
+});
+
+# Events link sessions to programs. Time must be unique per
+# (project_id, location_id, time).
+my $event_time = $tomorrow->clone;
+for my $session ($published_session, $draft_session) {
+    my $event = Registry::DAO::Event->create($db, {
+        session_id  => $session->id,
+        time        => $event_time->iso8601,
+        duration    => 60,
+        location_id => $location->id,
+        project_id  => $program->id,
+        teacher_id  => $teacher->id,
+    });
+    $event_time->add(hours => 1);
+}
+
+subtest 'program overview returns sessions per program' => sub {
+    my $overview = Registry::DAO::Project->get_program_overview($db, 'current');
+    my ($mp) = grep { $_->{program_name} eq 'Multi-Session Program' } @$overview;
+    ok($mp, 'program found in overview');
+
+    ok($mp->{sessions}, 'sessions key exists');
+    is(ref $mp->{sessions}, 'ARRAY', 'sessions is an arrayref');
+    is(scalar @{$mp->{sessions}}, 2, 'both sessions listed');
+
+    my ($pub) = grep { $_->{name} eq 'Published Session' } @{$mp->{sessions}};
+    my ($drf) = grep { $_->{name} eq 'Draft Session' } @{$mp->{sessions}};
+
+    ok($pub, 'published session present');
+    is($pub->{status}, 'published', 'published session has correct status');
+
+    ok($drf, 'draft session present');
+    is($drf->{status}, 'draft', 'draft session has correct status');
+
+    ok($pub->{id}, 'session has id for publish form submission');
+};
+
+done_testing();

--- a/templates/admin-dashboard/program_overview.html.ep
+++ b/templates/admin-dashboard/program_overview.html.ep
@@ -42,10 +42,10 @@
                                                   hx-trigger="submit">
                                                 % if ($sess_status eq 'published') {
                                                     <input type="hidden" name="status" value="draft">
-                                                    <button type="submit" class="btn btn-xs btn-outline">Unpublish</button>
+                                                    <button type="submit" class="btn btn-sm btn-outline">Unpublish</button>
                                                 % } else {
                                                     <input type="hidden" name="status" value="published">
-                                                    <button type="submit" class="btn btn-xs btn-primary">Publish</button>
+                                                    <button type="submit" class="btn btn-sm btn-primary">Publish</button>
                                                 % }
                                             </form>
                                         </li>

--- a/templates/admin-dashboard/program_overview.html.ep
+++ b/templates/admin-dashboard/program_overview.html.ep
@@ -24,6 +24,35 @@
                                 <button type="submit" class="btn btn-sm btn-primary">Publish</button>
                             % }
                         </form>
+
+                        % if (my $sessions = $program->{sessions}) {
+                            % if (@$sessions) {
+                                <ul class="program-sessions mt-3 ml-4 space-y-1">
+                                    % for my $sess (@$sessions) {
+                                        % my $sess_status = $sess->{status} || 'draft';
+                                        % my $sess_badge = $sess_status eq 'published' ? 'badge-green'
+                                        %                : $sess_status eq 'closed'    ? 'badge-gray'
+                                        %                                               : 'badge-yellow';
+                                        <li class="flex items-center gap-2" data-session-id="<%= $sess->{id} %>">
+                                            <span class="text-sm text-gray-700"><%= $sess->{name} %></span>
+                                            <span class="badge <%= $sess_badge %>"><%= ucfirst $sess_status %></span>
+                                            <form class="publish-toggle-session inline"
+                                                  hx-post="<%= url_for('admin_session_status', id => $sess->{id}) %>"
+                                                  hx-swap="none"
+                                                  hx-trigger="submit">
+                                                % if ($sess_status eq 'published') {
+                                                    <input type="hidden" name="status" value="draft">
+                                                    <button type="submit" class="btn btn-xs btn-outline">Unpublish</button>
+                                                % } else {
+                                                    <input type="hidden" name="status" value="published">
+                                                    <button type="submit" class="btn btn-xs btn-primary">Publish</button>
+                                                % }
+                                            </form>
+                                        </li>
+                                    % }
+                                </ul>
+                            % }
+                        % }
                         <div class="mt-2 grid grid-cols-2 gap-4 text-sm">
                             <div>
                                 <span class="text-gray-600">Sessions:</span>


### PR DESCRIPTION
## Summary

Closes #180. Session-level Publish/Unpublish buttons now render under each program card on \`/admin/dashboard\`, using the existing \`POST /admin/sessions/:id/status\` endpoint shipped in #182.

## Changes

- \`lib/Registry/DAO/Project.pm\` -- \`get_program_overview\` loads a \`sessions\` arrayref per program via a follow-up query (kept separate from the main aggregation for readability).
- \`templates/admin-dashboard/program_overview.html.ep\` -- renders \`<ul class=\"program-sessions\">\` under each program with per-session status badge and HTMX toggle button.
- \`lib/Registry/DAO/Session.pm\` -- \`project_id\` / \`location_id\` accessors now accept an optional \`\$db\` and fall back to a \`session_events -> events\` join when metadata is empty. \`GenerateEvents\` still uses the metadata path via its existing zero-arg call.
- \`lib/Registry/Controller/AdminDashboard.pm\` -- \`set_session_status\` returns 409 if the parent program is still draft (spec rule: program publishes before any sessions).

## Code review feedback applied

- Added the 409 guard on \`set_session_status\` (reviewer C1)
- Swapped \`btn-xs\` (not defined in design system) for \`btn-sm\` to match the program-level button (reviewer I2)
- Added comment explaining \`DISTINCT\` in the session query

## Follow-up issues filed

- #183 De-Tailwindify \`program_overview.html.ep\` (reviewer I1 -- existing file already uses utility classes; fixing just new additions would worsen consistency)
- #184 Investigate Mojo::Pg write-visibility flakiness (root cause behind the intermediate sanity assertions in the UI test)

## Test plan

- [x] \`t/dao/program-overview-sessions.t\` -- sessions returned per program with correct status values
- [x] \`t/controller/admin-publish-ui.t\` -- new subtest for session listing and Publish/Unpublish button state (10 assertions)
- [x] \`t/controller/admin-publish.t\` -- new subtest for the 409 guard; existing session toggle test updated to create a published parent
- [x] Full suite: 196 files, 1872 tests, all passing (\`Files=196, Tests=1872, 2158 wallclock secs ... Result: PASS\`)