### PR TITLE
Add Program Type Management workflow

### DIFF
--- a/lib/Registry/DAO/WorkflowSteps/ProgramTypeDetails.pm
+++ b/lib/Registry/DAO/WorkflowSteps/ProgramTypeDetails.pm
@@ -18,11 +18,28 @@ method process ($db, $form_data, $run = undef) {
     push @errors, 'Program type name is required'
         unless defined $form_data->{name} && length $form_data->{name};
 
+    # session_pattern is an enum -- don't trust whatever the form POSTs.
+    my %valid_pattern = map { $_ => 1 } qw(weekly daily one_time);
+    if (defined $form_data->{session_pattern}
+        && length $form_data->{session_pattern}
+        && !$valid_pattern{$form_data->{session_pattern}}) {
+        push @errors, 'Invalid session pattern';
+    }
+
+    # default_capacity must be a positive integer if supplied.
+    if (defined $form_data->{default_capacity} && length $form_data->{default_capacity}) {
+        unless ($form_data->{default_capacity} =~ /\A\d+\z/
+                && $form_data->{default_capacity} + 0 >= 1) {
+            push @errors, 'Default capacity must be a positive integer';
+        }
+    }
+
     return { errors => \@errors } if @errors;
 
     my %config;
     $config{description}     = $form_data->{description}     if defined $form_data->{description};
-    $config{session_pattern} = $form_data->{session_pattern} if defined $form_data->{session_pattern};
+    $config{session_pattern} = $form_data->{session_pattern}
+        if defined $form_data->{session_pattern} && length $form_data->{session_pattern};
     $config{default_capacity} = $form_data->{default_capacity} + 0
         if defined $form_data->{default_capacity} && length $form_data->{default_capacity};
 

--- a/lib/Registry/DAO/WorkflowSteps/ProgramTypeDetails.pm
+++ b/lib/Registry/DAO/WorkflowSteps/ProgramTypeDetails.pm
@@ -1,0 +1,88 @@
+use 5.42.0;
+# ABOUTME: Workflow step that collects program-type details and either
+# ABOUTME: creates a new ProgramType or updates the one named by editing_slug.
+
+use Object::Pad;
+
+class Registry::DAO::WorkflowSteps::ProgramTypeDetails :isa(Registry::DAO::WorkflowStep) {
+
+use Registry::DAO::ProgramType;
+
+method process ($db, $form_data, $run = undef) {
+    $run //= do { my $w = $self->workflow($db); $w->latest_run($db) };
+
+    # No form submission yet -- stay on the page to show the form.
+    return { stay => 1 } unless exists $form_data->{name};
+
+    my @errors;
+    push @errors, 'Program type name is required'
+        unless defined $form_data->{name} && length $form_data->{name};
+
+    return { errors => \@errors } if @errors;
+
+    my %config;
+    $config{description}     = $form_data->{description}     if defined $form_data->{description};
+    $config{session_pattern} = $form_data->{session_pattern} if defined $form_data->{session_pattern};
+    $config{default_capacity} = $form_data->{default_capacity} + 0
+        if defined $form_data->{default_capacity} && length $form_data->{default_capacity};
+
+    my $editing_slug = $run->data->{editing_slug};
+
+    if ($editing_slug) {
+        my $existing = Registry::DAO::ProgramType->find_by_slug($db, $editing_slug);
+        return { errors => ["Program type not found: $editing_slug"] }
+            unless $existing;
+
+        my %update_data = (
+            name   => $form_data->{name},
+            config => { %{ $existing->config // {} }, %config },
+        );
+        $existing->update($db, \%update_data);
+
+        return { next_step => 'complete' };
+    }
+
+    # New program type
+    my $created = eval {
+        Registry::DAO::ProgramType->create($db, {
+            name   => $form_data->{name},
+            config => \%config,
+        });
+    };
+    if (my $e = $@) {
+        return { errors => ["Failed to create program type: $e"] };
+    }
+
+    return {
+        next_step          => 'complete',
+        created_type_slug  => $created->slug,
+    };
+}
+
+method prepare_template_data ($db, $run, $params = {}) {
+    my $editing_slug = $run->data->{editing_slug};
+    if ($editing_slug) {
+        my $existing = Registry::DAO::ProgramType->find_by_slug($db, $editing_slug);
+        if ($existing) {
+            my $cfg = $existing->config // {};
+            return {
+                editing          => 1,
+                editing_slug     => $editing_slug,
+                name             => $existing->name,
+                description      => $cfg->{description}      // '',
+                session_pattern  => $cfg->{session_pattern}  // '',
+                default_capacity => $cfg->{default_capacity} // '',
+            };
+        }
+    }
+
+    return {
+        editing          => 0,
+        name             => '',
+        description      => '',
+        session_pattern  => '',
+        default_capacity => '',
+    };
+}
+
+}

--- a/lib/Registry/DAO/WorkflowSteps/ProgramTypeList.pm
+++ b/lib/Registry/DAO/WorkflowSteps/ProgramTypeList.pm
@@ -1,0 +1,53 @@
+use 5.42.0;
+# ABOUTME: Workflow step that lists existing program types for edit or
+# ABOUTME: offers a path to create a new one in program-type-management.
+
+use Object::Pad;
+
+class Registry::DAO::WorkflowSteps::ProgramTypeList :isa(Registry::DAO::WorkflowStep) {
+
+use Registry::DAO::ProgramType;
+
+method process ($db, $form_data, $run = undef) {
+    $run //= do { my $w = $self->workflow($db); $w->latest_run($db) };
+
+    my $action = $form_data->{action} // '';
+
+    if ($action eq 'new') {
+        # Clear any carried editing_slug and advance.
+        $run->update_data($db, { editing_slug => undef });
+        return { next_step => 'type-details' };
+    }
+
+    if ($action eq 'edit') {
+        my $slug = $form_data->{slug} // '';
+        my $type = $slug
+            ? Registry::DAO::ProgramType->find_by_slug($db, $slug)
+            : undef;
+
+        unless ($type) {
+            return {
+                stay   => 1,
+                errors => ["Unknown program type: $slug"],
+            };
+        }
+
+        # Carry the editing slug forward via run data and advance.
+        $run->update_data($db, { editing_slug => $slug });
+        return {
+            next_step    => 'type-details',
+            editing_slug => $slug,
+        };
+    }
+
+    # No action submitted -- stay on the list view.
+    return { stay => 1 };
+}
+
+method prepare_template_data ($db, $run, $params = {}) {
+    return {
+        program_types => Registry::DAO::ProgramType->list($db),
+    };
+}
+
+}

--- a/lib/Registry/DAO/WorkflowSteps/ProgramTypeList.pm
+++ b/lib/Registry/DAO/WorkflowSteps/ProgramTypeList.pm
@@ -14,7 +14,9 @@ method process ($db, $form_data, $run = undef) {
     my $action = $form_data->{action} // '';
 
     if ($action eq 'new') {
-        # Clear any carried editing_slug and advance.
+        # Reset editing_slug to JSON null so the details step takes
+        # the create path. update_data merges via jsonb, so we can't
+        # delete the key but we can null it.
         $run->update_data($db, { editing_slug => undef });
         return { next_step => 'type-details' };
     }

--- a/t/controller/program-type-management.t
+++ b/t/controller/program-type-management.t
@@ -1,0 +1,94 @@
+#!/usr/bin/env perl
+# ABOUTME: Controller tests for program-type-management workflow end-to-end.
+# ABOUTME: Hits the public URLs and verifies list and create flows render.
+use 5.42.0;
+use warnings;
+use utf8;
+use lib qw(lib t/lib);
+use Test::More;
+use Test::Registry::Mojo;
+use Registry;
+use Test::Registry::DB;
+use Test::Registry::Fixtures;
+use Test::Registry::Helpers qw(authenticate_as);
+use Registry::DAO qw(Workflow);
+use Registry::DAO::ProgramType;
+use Mojo::Home;
+use YAML::XS qw(Load);
+use Mojo::JSON qw(encode_json);
+
+my $test_db = Test::Registry::DB->new;
+my $dao     = $test_db->db;
+$ENV{DB_URL} = $test_db->uri;
+
+# Import workflows from the repo (the one we just added is included).
+my @files = Mojo::Home->new->child('workflows')->list_tree->grep(qr/\.ya?ml$/)->each;
+for my $file (@files) {
+    next if Load($file->slurp)->{draft};
+    Workflow->from_yaml($dao, $file->slurp);
+}
+
+my $t = Test::Registry::Mojo->new('Registry');
+
+my $admin = $dao->create(User => {
+    username => 'ptm_admin',
+    name     => 'Admin',
+    email    => 'ptm@test.local',
+    user_type => 'admin',
+    password => 'x',
+});
+authenticate_as($t, $admin);
+
+# Seed a program type so the list has something.
+Registry::DAO::ProgramType->create($dao->db, {
+    name   => 'Seeded Type',
+    slug   => 'seeded-type',
+    config => encode_json({ description => 'pre-existing' }),
+});
+
+subtest 'list view shows existing types and a create button' => sub {
+    $t->get_ok('/program-type-management')
+      ->status_is(200)
+      ->content_like(qr/Seeded Type/,            'existing type listed')
+      ->content_like(qr/pre-existing/,           'description shown')
+      ->content_like(qr/Create New Program Type/,'create button present');
+};
+
+# POST to a workflow step redirects to GET of the next step, so we follow.
+$t->ua->max_redirects(5);
+
+subtest 'clicking Create New lands on the details form' => sub {
+    my $body = $t->get_ok('/program-type-management')->tx->res->body;
+    # The workflow_process_step URL has list-or-create in the path.
+    my ($action) = $body =~ m{action="([^"]*list-or-create[^"]*)"};
+    ok($action, 'found list-or-create form action');
+
+    $t->post_ok($action => form => { action => 'new' })
+      ->status_is(200)
+      ->content_like(qr/New Program Type/, 'details form title');
+};
+
+subtest 'submitting details creates a program type' => sub {
+    $t->post_ok('/program-type-management' => form => { action => 'new' })
+      ->status_is(200);
+
+    # Find the form by the type-details URL marker in its action attribute.
+    my $body = $t->tx->res->body;
+    my ($action) = $body =~ m{<form[^>]*action="([^"]*type-details[^"]*)"};
+    ok($action, 'found details form action') or diag($body);
+
+    $t->post_ok($action => form => {
+        name             => 'Art Class',
+        description      => 'Creative arts programs',
+        session_pattern  => 'weekly',
+        default_capacity => 12,
+    })->status_is(200)
+      ->content_like(qr/saved/i, 'complete page reached');
+
+    my $created = Registry::DAO::ProgramType->find_by_slug($dao->db, 'art-class');
+    ok($created, 'program type created in DB');
+    is($created->name, 'Art Class', 'name matches');
+    is($created->session_pattern, 'weekly', 'config stored');
+};
+
+done_testing();

--- a/t/dao/program-type-management-workflow.t
+++ b/t/dao/program-type-management-workflow.t
@@ -144,6 +144,38 @@ subtest 'details step validates required fields' => sub {
     ok((grep /name/i, @{$result->{errors}}), 'error mentions name');
 };
 
+subtest 'details step rejects invalid session_pattern' => sub {
+    my $step = Registry::DAO::WorkflowStep->find($db, {
+        workflow_id => $workflow->id,
+        slug        => 'type-details',
+    });
+    my $run = $workflow->new_run($db);
+
+    my $result = $step->process($db, {
+        name            => 'Bogus',
+        session_pattern => 'something-else',
+    }, $run);
+    ok($result->{errors}, 'returns errors for invalid pattern');
+    ok((grep /session pattern/i, @{$result->{errors}}),
+       'error mentions session pattern');
+};
+
+subtest 'details step rejects non-positive default_capacity' => sub {
+    my $step = Registry::DAO::WorkflowStep->find($db, {
+        workflow_id => $workflow->id,
+        slug        => 'type-details',
+    });
+    my $run = $workflow->new_run($db);
+
+    for my $bad ('0', '-3', 'banana') {
+        my $result = $step->process($db, {
+            name             => 'Bogus',
+            default_capacity => $bad,
+        }, $run);
+        ok($result->{errors}, "rejects default_capacity=$bad");
+    }
+};
+
 subtest 'details step edits an existing program type' => sub {
     my $step = Registry::DAO::WorkflowStep->find($db, {
         workflow_id => $workflow->id,

--- a/t/dao/program-type-management-workflow.t
+++ b/t/dao/program-type-management-workflow.t
@@ -1,0 +1,182 @@
+#!/usr/bin/env perl
+# ABOUTME: DAO-level tests for the program-type-management workflow steps.
+# ABOUTME: Verifies list, create, and edit (by slug) flows end-to-end.
+use 5.42.0;
+use warnings;
+use lib qw(lib t/lib);
+use Test::More;
+use Test::Registry::DB;
+use Test::Registry::Fixtures;
+use Mojo::JSON qw(encode_json);
+use Registry::DAO::Workflow;
+use Registry::DAO::WorkflowStep;
+use Registry::DAO::ProgramType;
+
+my $tdb = Test::Registry::DB->new;
+my $dao = $tdb->db;
+
+my $tenant = Test::Registry::Fixtures::create_tenant($dao->db, {
+    name => 'Type Mgmt Tenant',
+    slug => 'type_mgmt',
+});
+$dao->db->query('SELECT clone_schema(?)', 'type_mgmt');
+$dao = Registry::DAO->new(url => $tdb->uri, schema => 'type_mgmt');
+my $db = $dao->db;
+
+# Seed one existing program type so list has something to show.
+Registry::DAO::ProgramType->create($db, {
+    name   => 'After School',
+    slug   => 'after-school',
+    config => encode_json({ session_pattern => 'weekly' }),
+});
+
+# Build a workflow matching the YAML we'll ship.
+my $workflow = Registry::DAO::Workflow->create($db, {
+    name        => 'Program Type Management',
+    slug        => 'program-type-management',
+    description => 'Manage program types',
+    first_step  => 'list-or-create',
+});
+$workflow->add_step($db, {
+    slug        => 'list-or-create',
+    description => 'List existing or start a new program type',
+    class       => 'Registry::DAO::WorkflowSteps::ProgramTypeList',
+});
+$workflow->add_step($db, {
+    slug        => 'type-details',
+    description => 'Name, description, and configuration',
+    class       => 'Registry::DAO::WorkflowSteps::ProgramTypeDetails',
+});
+$workflow->add_step($db, {
+    slug        => 'complete',
+    description => 'Done',
+    class       => 'Registry::DAO::WorkflowStep',
+});
+
+subtest 'list step shows existing program types' => sub {
+    require_ok 'Registry::DAO::WorkflowSteps::ProgramTypeList';
+
+    my $step = Registry::DAO::WorkflowStep->find($db, {
+        workflow_id => $workflow->id,
+        slug        => 'list-or-create',
+    });
+    my $run = $workflow->new_run($db);
+
+    my $data = $step->prepare_template_data($db, $run);
+    ok($data->{program_types}, 'program_types returned');
+    is(scalar @{$data->{program_types}}, 1, 'one existing type listed');
+    is($data->{program_types}[0]->name, 'After School', 'correct type');
+};
+
+subtest 'list step Create New advances to type-details with no slug' => sub {
+    my $step = Registry::DAO::WorkflowStep->find($db, {
+        workflow_id => $workflow->id,
+        slug        => 'list-or-create',
+    });
+    my $run = $workflow->new_run($db);
+
+    my $result = $step->process($db, { action => 'new' }, $run);
+    is($result->{next_step}, 'type-details', 'advances to type-details');
+    ok(!$result->{editing_slug}, 'no editing_slug on new');
+};
+
+subtest 'list step Edit picks an existing type' => sub {
+    my $step = Registry::DAO::WorkflowStep->find($db, {
+        workflow_id => $workflow->id,
+        slug        => 'list-or-create',
+    });
+    my $run = $workflow->new_run($db);
+
+    my $result = $step->process($db, {
+        action => 'edit', slug => 'after-school',
+    }, $run);
+    is($result->{next_step},    'type-details', 'advances to type-details');
+    is($result->{editing_slug}, 'after-school', 'editing_slug carries through');
+};
+
+subtest 'list step rejects edit of unknown slug' => sub {
+    my $step = Registry::DAO::WorkflowStep->find($db, {
+        workflow_id => $workflow->id,
+        slug        => 'list-or-create',
+    });
+    my $run = $workflow->new_run($db);
+
+    my $result = $step->process($db, {
+        action => 'edit', slug => 'does-not-exist',
+    }, $run);
+    ok($result->{stay}, 'stays on step when target is unknown');
+    ok($result->{errors}, 'returns errors');
+};
+
+subtest 'details step creates a new program type' => sub {
+    require_ok 'Registry::DAO::WorkflowSteps::ProgramTypeDetails';
+
+    my $step = Registry::DAO::WorkflowStep->find($db, {
+        workflow_id => $workflow->id,
+        slug        => 'type-details',
+    });
+    my $run = $workflow->new_run($db);
+
+    my $result = $step->process($db, {
+        name            => 'Summer Camp',
+        description     => 'Full-day summer programs',
+        session_pattern => 'daily',
+    }, $run);
+
+    ok(!$result->{errors}, 'no validation errors') or diag(explain($result));
+    is($result->{next_step}, 'complete', 'advances to complete');
+
+    my $created = Registry::DAO::ProgramType->find_by_slug($db, 'summer-camp');
+    ok($created, 'program type was created');
+    is($created->name, 'Summer Camp', 'correct name');
+    is($created->session_pattern, 'daily', 'config was stored');
+};
+
+subtest 'details step validates required fields' => sub {
+    my $step = Registry::DAO::WorkflowStep->find($db, {
+        workflow_id => $workflow->id,
+        slug        => 'type-details',
+    });
+    my $run = $workflow->new_run($db);
+
+    my $result = $step->process($db, { name => '' }, $run);
+    ok($result->{errors}, 'returns validation errors');
+    ok((grep /name/i, @{$result->{errors}}), 'error mentions name');
+};
+
+subtest 'details step edits an existing program type' => sub {
+    my $step = Registry::DAO::WorkflowStep->find($db, {
+        workflow_id => $workflow->id,
+        slug        => 'type-details',
+    });
+    my $run = $workflow->new_run($db);
+    $run->update_data($db, { editing_slug => 'after-school' });
+
+    my $result = $step->process($db, {
+        name            => 'After-School Renamed',
+        description     => 'Updated description',
+        session_pattern => 'weekly',
+    }, $run);
+
+    ok(!$result->{errors}, 'no errors on update') or diag(explain($result));
+    is($result->{next_step}, 'complete', 'advances to complete');
+
+    my $updated = Registry::DAO::ProgramType->find_by_slug($db, 'after-school');
+    is($updated->name, 'After-School Renamed', 'name updated');
+};
+
+subtest 'details step pre-populates form when editing' => sub {
+    my $step = Registry::DAO::WorkflowStep->find($db, {
+        workflow_id => $workflow->id,
+        slug        => 'type-details',
+    });
+    my $run = $workflow->new_run($db);
+    $run->update_data($db, { editing_slug => 'summer-camp' });
+
+    my $data = $step->prepare_template_data($db, $run);
+    is($data->{name}, 'Summer Camp', 'name pre-filled');
+    is($data->{session_pattern}, 'daily', 'config field pre-filled');
+    ok($data->{editing}, 'editing flag set');
+};
+
+done_testing();

--- a/templates/layouts/dashboard.html.ep
+++ b/templates/layouts/dashboard.html.ep
@@ -37,6 +37,10 @@
                    class="dashboard-nav-link<%= stash('active_nav') && stash('active_nav') eq 'programs' ? ' active' : '' %>">
                     New Program
                 </a>
+                <a href="/program-type-management"
+                   class="dashboard-nav-link<%= stash('active_nav') && stash('active_nav') eq 'program-types' ? ' active' : '' %>">
+                    Program Types
+                </a>
                 <a href="/teacher/"
                    class="dashboard-nav-link<%= stash('active_nav') && stash('active_nav') eq 'teacher' ? ' active' : '' %>">
                     Attendance

--- a/templates/program-type-management/complete.html.ep
+++ b/templates/program-type-management/complete.html.ep
@@ -1,5 +1,6 @@
 % layout 'workflow';
 % title 'Program type saved';
+% stash active_nav => 'program-types';
 
 <h2>Program type saved</h2>
 

--- a/templates/program-type-management/complete.html.ep
+++ b/templates/program-type-management/complete.html.ep
@@ -1,0 +1,12 @@
+% layout 'workflow';
+% title 'Program type saved';
+
+<h2>Program type saved</h2>
+
+<p>Your program type has been saved.</p>
+
+<p>
+    <a href="<%= url_for('workflow_start', workflow => 'program-type-management') %>">
+        Back to program types
+    </a>
+</p>

--- a/templates/program-type-management/list-or-create.html.ep
+++ b/templates/program-type-management/list-or-create.html.ep
@@ -1,5 +1,6 @@
 % layout 'workflow';
 % title 'Program Types';
+% stash active_nav => 'program-types';
 
 <h2>Program Types</h2>
 <p>Create a new program type or edit an existing one.</p>

--- a/templates/program-type-management/list-or-create.html.ep
+++ b/templates/program-type-management/list-or-create.html.ep
@@ -1,0 +1,31 @@
+% layout 'workflow';
+% title 'Program Types';
+
+<h2>Program Types</h2>
+<p>Create a new program type or edit an existing one.</p>
+
+% my $types = stash('program_types') || [];
+% if (@$types) {
+    <ul class="program-type-list">
+        % for my $type (@$types) {
+            <li>
+                <strong><%= $type->name %></strong>
+                % if ($type->config->{description}) {
+                    -- <%= $type->config->{description} %>
+                % }
+                <form method="POST" action="<%= $action %>" style="display:inline">
+                    <input type="hidden" name="action" value="edit">
+                    <input type="hidden" name="slug"   value="<%= $type->slug %>">
+                    <button type="submit">Edit</button>
+                </form>
+            </li>
+        % }
+    </ul>
+% } else {
+    <p><em>No program types yet.</em></p>
+% }
+
+<form method="POST" action="<%= $action %>">
+    <input type="hidden" name="action" value="new">
+    <button type="submit">Create New Program Type</button>
+</form>

--- a/templates/program-type-management/type-details.html.ep
+++ b/templates/program-type-management/type-details.html.ep
@@ -1,0 +1,49 @@
+% layout 'workflow';
+% title stash('editing') ? 'Edit Program Type' : 'New Program Type';
+
+<h2><%= stash('editing') ? 'Edit Program Type' : 'New Program Type' %></h2>
+
+% if (my $errors = stash('errors')) {
+    <ul class="errors">
+        % for my $e (@$errors) {
+            <li><%= $e %></li>
+        % }
+    </ul>
+% }
+
+<form method="POST" action="<%= $action %>">
+    <p>
+        <label for="pt-name">Name</label>
+        <input id="pt-name" name="name" type="text" required
+               value="<%= stash('name') // '' %>">
+    </p>
+
+    <p>
+        <label for="pt-description">Description</label>
+        <textarea id="pt-description" name="description" rows="3"
+                  ><%= stash('description') // '' %></textarea>
+    </p>
+
+    <p>
+        <label for="pt-pattern">Session pattern</label>
+        <select id="pt-pattern" name="session_pattern">
+            % my $current = stash('session_pattern') // '';
+            <option value=""         <%= $current eq ''        ? 'selected' : '' %>>-- select --</option>
+            <option value="weekly"   <%= $current eq 'weekly'  ? 'selected' : '' %>>Weekly (e.g. after-school)</option>
+            <option value="daily"    <%= $current eq 'daily'   ? 'selected' : '' %>>Daily (e.g. summer camp)</option>
+            <option value="one_time" <%= $current eq 'one_time'? 'selected' : '' %>>One-time (e.g. workshop)</option>
+        </select>
+    </p>
+
+    <p>
+        <label for="pt-capacity">Default capacity</label>
+        <input id="pt-capacity" name="default_capacity" type="number" min="1"
+               value="<%= stash('default_capacity') // '' %>">
+    </p>
+
+    <p>
+        <button type="submit">
+            <%= stash('editing') ? 'Update Program Type' : 'Create Program Type' %>
+        </button>
+    </p>
+</form>

--- a/templates/program-type-management/type-details.html.ep
+++ b/templates/program-type-management/type-details.html.ep
@@ -1,5 +1,6 @@
 % layout 'workflow';
 % title stash('editing') ? 'Edit Program Type' : 'New Program Type';
+% stash active_nav => 'program-types';
 
 <h2><%= stash('editing') ? 'Edit Program Type' : 'New Program Type' %></h2>
 

--- a/workflows/program-type-management.yaml
+++ b/workflows/program-type-management.yaml
@@ -1,0 +1,23 @@
+# ABOUTME: Workflow for managing program types -- create new types or edit
+# ABOUTME: existing ones. Part of the admin program setup orchestrator.
+
+name: Program Type Management
+description: Create or edit the program types that programs can be associated with
+slug: program-type-management
+first_step: list-or-create
+
+steps:
+  - slug: list-or-create
+    description: Select an existing program type to edit or create a new one
+    template: program-type-management/list-or-create
+    class: Registry::DAO::WorkflowSteps::ProgramTypeList
+
+  - slug: type-details
+    description: Program type details
+    template: program-type-management/type-details
+    class: Registry::DAO::WorkflowSteps::ProgramTypeDetails
+
+  - slug: complete
+    description: Program type saved
+    template: program-type-management/complete
+    class: Registry::DAO::WorkflowStep


### PR DESCRIPTION
## Summary

Closes the Program Type Management piece of the admin program setup spec. Victoria can now list, create, and edit program types from the admin nav.

## Workflow

\`workflows/program-type-management.yaml\` -- three steps, auto-imported on startup:

- \`list-or-create\` -- lists existing types with Edit buttons, plus a Create New button (Registry::DAO::WorkflowSteps::ProgramTypeList)
- \`type-details\` -- form for name, description, session pattern, default capacity (Registry::DAO::WorkflowSteps::ProgramTypeDetails)
- \`complete\` -- confirmation page

## Implementation

- Edit flow carries \`editing_slug\` through \`\$run->data\`, matching the pattern \`SelectProgram.pm\` uses for \`project_id\`.
- Details step validates name (required), session_pattern (enum: weekly/daily/one_time), default_capacity (positive integer if supplied). All server-side -- form-side constraints are not trusted.
- Templates follow the plain-HTML convention of \`templates/program-creation/*\`. Each sets \`active_nav => 'program-types'\`.
- New \"Program Types\" link in the admin/staff nav bar (\`templates/layouts/dashboard.html.ep\`).

## Follow-up issues

- #188 Add delete path for unused program types

## Test plan

- [x] \`t/dao/program-type-management-workflow.t\` -- 10 subtests covering list/create/edit/validation/pre-population
- [x] \`t/controller/program-type-management.t\` -- 3 subtests covering full-stack HTTP flow
- [x] Full suite: 198 files, 1885 tests, all passing