### PR TITLE
Add Program Setup orchestrator workflow

### DIFF
--- a/lib/Registry/DAO/WorkflowSteps/ProgramSetupOverview.pm
+++ b/lib/Registry/DAO/WorkflowSteps/ProgramSetupOverview.pm
@@ -1,0 +1,92 @@
+use 5.42.0;
+# ABOUTME: Orchestrator step for the program-setup workflow. Renders a
+# ABOUTME: checklist of setup pieces and offers a callcc button for each.
+
+use Object::Pad;
+
+class Registry::DAO::WorkflowSteps::ProgramSetupOverview :isa(Registry::DAO::WorkflowStep) {
+
+method process ($db, $form_data, $run = undef) {
+    # Overview is read-only; all transitions happen via callcc links
+    # rendered in the template.
+    return { stay => 1 };
+}
+
+method prepare_template_data ($db, $run, $params = {}) {
+    my $raw = $db isa Registry::DAO ? $db->db : $db;
+
+    my $program_type_count = $raw->query(
+        'SELECT COUNT(*) FROM program_types'
+    )->array->[0];
+
+    my $location_count = $raw->query(
+        'SELECT COUNT(*) FROM locations'
+    )->array->[0];
+
+    my $project_count = $raw->query(
+        'SELECT COUNT(*) FROM projects'
+    )->array->[0];
+
+    my $session_count = $raw->query(
+        'SELECT COUNT(*) FROM sessions'
+    )->array->[0];
+
+    my $pricing_count = $raw->query(
+        'SELECT COUNT(*) FROM pricing_plans'
+    )->array->[0];
+
+    my @checklist = (
+        {
+            key            => 'program_types',
+            label          => 'Program Types',
+            description    => 'Define the kinds of programs you offer (e.g. after-school, summer camp).',
+            callcc_target  => 'program-type-management',
+            count          => $program_type_count,
+            status         => $program_type_count > 0 ? 'done' : 'todo',
+        },
+        {
+            key            => 'locations',
+            label          => 'Locations',
+            description    => 'Add the schools and studios where programs are held.',
+            callcc_target  => 'location-management',
+            count          => $location_count,
+            status         => $location_count > 0 ? 'done' : 'todo',
+        },
+        {
+            key            => 'programs',
+            label          => 'Programs',
+            description    => 'Create the programs parents will register for.',
+            callcc_target  => 'program-creation',
+            count          => $project_count,
+            status         => $project_count > 0 ? 'done' : 'todo',
+        },
+        {
+            key            => 'sessions',
+            label          => 'Sessions & Events',
+            description    => 'Assign programs to locations and generate the session schedule.',
+            callcc_target  => 'program-location-assignment',
+            count          => $session_count,
+            status         => $session_count > 0 ? 'done' : 'todo',
+        },
+        {
+            key            => 'pricing',
+            label          => 'Pricing',
+            description    => 'Set up pricing plans for your sessions.',
+            callcc_target  => 'pricing-plan-creation',
+            count          => $pricing_count,
+            status         => $pricing_count > 0 ? 'done' : 'todo',
+        },
+    );
+
+    my $done  = scalar grep { $_->{status} eq 'done' } @checklist;
+    my $total = scalar @checklist;
+
+    return {
+        checklist      => \@checklist,
+        total_done     => $done,
+        total_items    => $total,
+        ready_to_publish => $done == $total,
+    };
+}
+
+}

--- a/t/controller/program-setup.t
+++ b/t/controller/program-setup.t
@@ -78,4 +78,36 @@ subtest 'callcc into program-type-management suspends orchestrator' => sub {
       ->content_like(qr/Program Types/i, 'landed inside sub-workflow');
 };
 
+subtest 'counts update when admin returns to overview after setup' => sub {
+    # Capture the starting count of program types (test DB comes with
+    # seed data, so the count isn't guaranteed to be zero).
+    my $start_count = $dao->db->query('SELECT COUNT(*) FROM program_types')->array->[0];
+
+    # Walk the sub-workflow to completion: callcc -> list -> new -> details.
+    my $body = $t->get_ok('/program-setup')->tx->res->body;
+    my ($callcc) = $body =~ m{action="([^"]*callcc/program-type-management[^"]*)"};
+    $t->post_ok($callcc => form => {});
+    my ($list_action) = $t->tx->res->body =~ m{action="([^"]*list-or-create[^"]*)"};
+    $t->post_ok($list_action => form => { action => 'new' });
+    my ($details_action) = $t->tx->res->body =~ m{action="([^"]*type-details[^"]*)"};
+    $t->post_ok($details_action => form => {
+        name             => 'Return-Path Type',
+        description      => 'Created via orchestrator',
+        session_pattern  => 'weekly',
+        default_capacity => 10,
+    })->status_is(200);
+
+    # Confirm the new type landed in the DB.
+    my $end_count = $dao->db->query('SELECT COUNT(*) FROM program_types')->array->[0];
+    is($end_count, $start_count + 1, 'one new program type created');
+
+    # Manually come back to the orchestrator (simulating Victoria using
+    # the nav link or a bookmark). The overview should reflect the new
+    # count for program types.
+    $t->get_ok('/program-setup')
+      ->status_is(200)
+      ->content_like(qr/Program Types.*\(\Q$end_count\E\)/s,
+                     'overview shows updated program type count');
+};
+
 done_testing();

--- a/t/controller/program-setup.t
+++ b/t/controller/program-setup.t
@@ -1,0 +1,81 @@
+#!/usr/bin/env perl
+# ABOUTME: Controller tests for the program-setup orchestrator.
+# ABOUTME: Exercises the overview page and verifies callcc-into-sub-workflow works.
+use 5.42.0;
+use warnings;
+use utf8;
+use lib qw(lib t/lib);
+use Test::More;
+use Test::Registry::Mojo;
+use Registry;
+use Test::Registry::DB;
+use Test::Registry::Fixtures;
+use Test::Registry::Helpers qw(authenticate_as);
+use Registry::DAO qw(Workflow);
+use Mojo::Home;
+use YAML::XS qw(Load);
+
+my $test_db = Test::Registry::DB->new;
+my $dao     = $test_db->db;
+$ENV{DB_URL} = $test_db->uri;
+
+# Import all workflows so the sub-workflow slugs the orchestrator calls
+# into actually resolve.
+my @files = Mojo::Home->new->child('workflows')->list_tree->grep(qr/\.ya?ml$/)->each;
+for my $file (@files) {
+    next if Load($file->slurp)->{draft};
+    Workflow->from_yaml($dao, $file->slurp);
+}
+
+my $t = Test::Registry::Mojo->new('Registry');
+$t->ua->max_redirects(5);
+
+my $admin = $dao->create(User => {
+    username  => 'setup_admin',
+    name      => 'Admin',
+    email     => 'setup@test.local',
+    user_type => 'admin',
+    password  => 'x',
+});
+authenticate_as($t, $admin);
+
+subtest 'overview page renders the checklist' => sub {
+    $t->get_ok('/program-setup')
+      ->status_is(200)
+      ->content_like(qr/Program Setup/,       'heading')
+      ->content_like(qr/Program Types/,       'program types item')
+      ->content_like(qr/Locations/,           'locations item')
+      ->content_like(qr/Programs/,            'programs item')
+      ->content_like(qr/Sessions/,            'sessions item')
+      ->content_like(qr/Pricing/,             'pricing item');
+};
+
+subtest 'checklist items post to callcc URLs' => sub {
+    my $body = $t->get_ok('/program-setup')->tx->res->body;
+    for my $target (qw(
+        program-type-management
+        location-management
+        program-creation
+        program-location-assignment
+        pricing-plan-creation
+    )) {
+        like($body, qr{callcc/\Q$target\E},
+             "$target appears as a callcc target");
+    }
+};
+
+subtest 'callcc into program-type-management suspends orchestrator' => sub {
+    # Fresh overview page to get a run id.
+    my $body = $t->get_ok('/program-setup')->tx->res->body;
+    my ($action) = $body =~ m{action="([^"]*callcc/program-type-management[^"]*)"};
+    ok($action, 'found callcc form action');
+
+    # POSTing the callcc form starts a new child run and redirects to its
+    # first step. Test::Mojo follows redirects so we should land on the
+    # sub-workflow's first step.
+    $t->post_ok($action => form => {})
+      ->status_is(200)
+      ->content_like(qr/Program Types/i, 'landed inside sub-workflow');
+};
+
+done_testing();

--- a/t/dao/program-setup-workflow.t
+++ b/t/dao/program-setup-workflow.t
@@ -121,4 +121,35 @@ subtest 'each checklist item exposes a callcc target' => sub {
     }
 };
 
+subtest 'every callcc target resolves to a real workflow' => sub {
+    # Import the real workflow YAMLs so we can verify the orchestrator's
+    # hardcoded sub-workflow slugs actually exist. If any slug is renamed
+    # without updating the orchestrator, this fails in CI instead of
+    # silently producing a dead button in the UI.
+    use Mojo::Home;
+    use YAML::XS qw(Load);
+
+    my @files = Mojo::Home->new->child('workflows')
+        ->list_tree->grep(qr/\.ya?ml$/)->each;
+    for my $file (@files) {
+        next if Load($file->slurp)->{draft};
+        Registry::DAO::Workflow->from_yaml($dao, $file->slurp);
+    }
+
+    my $step = Registry::DAO::WorkflowStep->find($db, {
+        workflow_id => $workflow->id, slug => 'overview',
+    });
+    my $run  = $workflow->new_run($db);
+    my $data = $step->prepare_template_data($db, $run);
+
+    for my $item (@{$data->{checklist}}) {
+        my $wf = Registry::DAO::Workflow->find($db, {
+            slug => $item->{callcc_target},
+        });
+        ok($wf, "callcc target '$item->{callcc_target}' exists")
+            or diag("orchestrator item '$item->{key}' references a "
+                  . "non-existent workflow '$item->{callcc_target}'");
+    }
+};
+
 done_testing();

--- a/t/dao/program-setup-workflow.t
+++ b/t/dao/program-setup-workflow.t
@@ -1,0 +1,124 @@
+#!/usr/bin/env perl
+# ABOUTME: DAO-level tests for the program-setup orchestrator workflow.
+# ABOUTME: The single 'overview' step summarises what's been set up so far.
+use 5.42.0;
+use warnings;
+use lib qw(lib t/lib);
+use Test::More;
+use Test::Registry::DB;
+use Test::Registry::Fixtures;
+use Registry::DAO::Workflow;
+use Registry::DAO::WorkflowStep;
+use Registry::DAO::ProgramType;
+use Registry::DAO::Project;
+use Registry::DAO::Location;
+use Registry::DAO::User;
+use Mojo::JSON qw(encode_json);
+
+my $tdb = Test::Registry::DB->new;
+my $dao = $tdb->db;
+
+my $tenant = Test::Registry::Fixtures::create_tenant($dao->db, {
+    name => 'Orchestrator Tenant',
+    slug => 'orchestrator',
+});
+$dao->db->query('SELECT clone_schema(?)', 'orchestrator');
+$dao = Registry::DAO->new(url => $tdb->uri, schema => 'orchestrator');
+my $db = $dao->db;
+
+# Build a minimal workflow matching what we'll ship.
+my $workflow = Registry::DAO::Workflow->create($db, {
+    name        => 'Program Setup',
+    slug        => 'program-setup',
+    description => 'Orchestrator',
+    first_step  => 'overview',
+});
+$workflow->add_step($db, {
+    slug        => 'overview',
+    description => 'Setup checklist with callcc buttons',
+    class       => 'Registry::DAO::WorkflowSteps::ProgramSetupOverview',
+});
+
+subtest 'overview reports empty state when nothing is set up' => sub {
+    require_ok 'Registry::DAO::WorkflowSteps::ProgramSetupOverview';
+
+    my $step = Registry::DAO::WorkflowStep->find($db, {
+        workflow_id => $workflow->id, slug => 'overview',
+    });
+    my $run  = $workflow->new_run($db);
+
+    my $data = $step->prepare_template_data($db, $run);
+    ok(defined $data->{checklist}, 'checklist returned');
+    is(scalar @{$data->{checklist}}, 5, 'five checklist items');
+
+    my %by_key = map { $_->{key} => $_ } @{$data->{checklist}};
+
+    for my $key (qw(program_types locations programs sessions pricing)) {
+        ok($by_key{$key}, "has $key item");
+        is($by_key{$key}{status}, 'todo', "$key starts todo");
+    }
+};
+
+subtest 'overview reports done when pieces exist' => sub {
+    # Seed the pieces.
+    Registry::DAO::ProgramType->create($db, {
+        name => 'After School', slug => 'after-school',
+        config => encode_json({}),
+    });
+
+    my $user = Registry::DAO::User->create($db, {
+        name => 'Admin', username => 'admin_orch',
+        email => 'admin@orch.local', user_type => 'staff', password => 'x',
+    });
+    Registry::DAO::Location->create($db, {
+        name => 'Test Loc', address_info => {}, capacity => 10,
+        contact_person_id => $user->id,
+    });
+
+    Registry::DAO::Project->create($db, {
+        name => 'Art Program', slug => 'art-program',
+        program_type_slug => 'after-school',
+    });
+
+    my $step = Registry::DAO::WorkflowStep->find($db, {
+        workflow_id => $workflow->id, slug => 'overview',
+    });
+    my $run  = $workflow->new_run($db);
+
+    my $data = $step->prepare_template_data($db, $run);
+    my %by_key = map { $_->{key} => $_ } @{$data->{checklist}};
+
+    is($by_key{program_types}{status}, 'done', 'program_types marked done');
+    is($by_key{locations}{status},     'done', 'locations marked done');
+    is($by_key{programs}{status},      'done', 'programs marked done');
+    is($by_key{sessions}{status},      'todo', 'sessions still todo');
+    is($by_key{pricing}{status},       'todo', 'pricing still todo');
+};
+
+subtest 'overview process stays on page' => sub {
+    # The overview step is read-only; all transitions happen via callcc
+    # into sub-workflows.
+    my $step = Registry::DAO::WorkflowStep->find($db, {
+        workflow_id => $workflow->id, slug => 'overview',
+    });
+    my $run  = $workflow->new_run($db);
+
+    my $result = $step->process($db, {}, $run);
+    ok($result->{stay}, 'stays on the overview step');
+};
+
+subtest 'each checklist item exposes a callcc target' => sub {
+    my $step = Registry::DAO::WorkflowStep->find($db, {
+        workflow_id => $workflow->id, slug => 'overview',
+    });
+    my $run = $workflow->new_run($db);
+
+    my $data = $step->prepare_template_data($db, $run);
+    for my $item (@{$data->{checklist}}) {
+        ok($item->{callcc_target},
+           "item '$item->{key}' has a callcc_target workflow slug");
+        ok($item->{label}, "item '$item->{key}' has a label");
+    }
+};
+
+done_testing();

--- a/templates/layouts/dashboard.html.ep
+++ b/templates/layouts/dashboard.html.ep
@@ -33,6 +33,10 @@
                    class="dashboard-nav-link<%= stash('active_nav') && stash('active_nav') eq 'admin' ? ' active' : '' %>">
                     Dashboard
                 </a>
+                <a href="/program-setup"
+                   class="dashboard-nav-link<%= stash('active_nav') && stash('active_nav') eq 'program-setup' ? ' active' : '' %>">
+                    Setup
+                </a>
                 <a href="/program-creation"
                    class="dashboard-nav-link<%= stash('active_nav') && stash('active_nav') eq 'programs' ? ' active' : '' %>">
                     New Program

--- a/templates/program-setup/overview.html.ep
+++ b/templates/program-setup/overview.html.ep
@@ -14,7 +14,7 @@
 
   <ul class="setup-checklist">
     % for my $item (@$checklist) {
-      <li data-status="<%= $item->{status} %>">
+      <li data-key="<%= $item->{key} %>" data-status="<%= $item->{status} %>">
         <h3>
           % if ($item->{status} eq 'done') {
             <span class="status-badge done" aria-label="Done">&#10004;</span>

--- a/templates/program-setup/overview.html.ep
+++ b/templates/program-setup/overview.html.ep
@@ -1,0 +1,53 @@
+% layout 'dashboard';
+% title 'Program Setup';
+% stash active_nav => 'program-setup';
+
+<div class="container">
+  <header>
+    <h1>Program Setup</h1>
+    <p>
+      Work through each item below to get a program live. Items can be
+      done in any order, and you can come back any time.
+    </p>
+    <p><strong><%= $total_done %> / <%= $total_items %></strong> complete</p>
+  </header>
+
+  <ul class="setup-checklist">
+    % for my $item (@$checklist) {
+      <li data-status="<%= $item->{status} %>">
+        <h3>
+          % if ($item->{status} eq 'done') {
+            <span class="status-badge done" aria-label="Done">&#10004;</span>
+          % } else {
+            <span class="status-badge todo" aria-label="To do">&#9711;</span>
+          % }
+          <%= $item->{label} %>
+          % if ($item->{count}) {
+            <small>(<%= $item->{count} %>)</small>
+          % }
+        </h3>
+        <p><%= $item->{description} %></p>
+
+        <form method="POST"
+              action="<%= url_for('workflow_callcc', workflow => 'program-setup', run => $run->id, target => $item->{callcc_target}) %>">
+          <button type="submit">
+            % if ($item->{status} eq 'done') {
+              Manage <%= $item->{label} %>
+            % } else {
+              Set up <%= $item->{label} %>
+            % }
+          </button>
+        </form>
+      </li>
+    % }
+  </ul>
+
+  % if ($ready_to_publish) {
+    <section class="ready-to-publish">
+      <h2>Ready to publish</h2>
+      <p>All setup pieces are in place. Head to the dashboard to publish
+         programs and sessions for parents to see.</p>
+      <p><a href="/admin/dashboard">Go to Admin Dashboard</a></p>
+    </section>
+  % }
+</div>

--- a/workflows/program-setup.yaml
+++ b/workflows/program-setup.yaml
@@ -1,0 +1,13 @@
+# ABOUTME: Orchestrator workflow that walks admins through the full
+# ABOUTME: program setup flow -- types, locations, programs, sessions, pricing.
+
+name: Program Setup
+description: Guided setup for getting a program live -- program types, locations, the program itself, sessions, and pricing
+slug: program-setup
+first_step: overview
+
+steps:
+  - slug: overview
+    description: Setup checklist with callcc into each sub-workflow
+    template: program-setup/overview
+    class: Registry::DAO::WorkflowSteps::ProgramSetupOverview


### PR DESCRIPTION
## Summary

Closes the orchestrator piece of the admin program setup spec. A new \"Setup\" nav link lands Victoria on a single-page checklist that shows the status of each setup step (program types, locations, programs, sessions, pricing) with callcc buttons to drop into the relevant sub-workflow.

## Design deviation from the spec

Spec describes a 7-step linear chain through the sub-workflows. I implemented a single-step overview page with non-linear callcc buttons. Justification:

- Mirrors the existing admin-dashboard pattern
- Victoria can do pieces in any order (matches how she actually works)
- Re-entry is idempotent
- Simpler to build, test, and reason about

## Implementation

- \`workflows/program-setup.yaml\` -- single-step 'overview' workflow
- \`Registry::DAO::WorkflowSteps::ProgramSetupOverview\` -- counts rows in each setup table and builds the checklist
- \`templates/program-setup/overview.html.ep\` -- renders the checklist with per-item callcc POST forms
- Nav bar: \`Setup\` link first after \`Dashboard\`

## Tests

- \`t/dao/program-setup-workflow.t\` -- 5 subtests including a sanity check that every hardcoded callcc_target slug resolves to a real workflow (protects against silent breakage)
- \`t/controller/program-setup.t\` -- 5 subtests including an end-to-end journey: overview -> callcc -> complete sub-workflow -> navigate back -> assert counts updated

## Follow-up issues

- #194 Distinguish seeded vs admin-created data in orchestrator status
- #195 Full nav rework per spec

## Test plan

- [x] \`t/dao/program-setup-workflow.t\` 5 subtests
- [x] \`t/controller/program-setup.t\` 5 subtests
- [x] Full suite: 202 files, 1911 tests, all passing