### PR TITLE
Add SACP tenant seed script

### DIFF
--- a/sql/seed/README.md
+++ b/sql/seed/README.md
@@ -30,3 +30,14 @@ Local dev:
 Production (Render):
 
     psql "$PROD_DB_URL" -f sql/seed/sacp-tenant.sql
+
+Safe to re-run on either. Run from a trusted shell (Render shell /
+deploy job / your admin laptop), not a developer's CI environment.
+
+### Data currency
+
+This script captures SACP's offerings as of 2026-04-20, scraped from
+superawesomecool.com. It's a one-time bootstrap, not a source of
+truth -- once Victoria starts authoring programs through the admin
+dashboard, the dashboard wins. Don't treat this file as canonical
+data or try to keep it in sync with the site.

--- a/sql/seed/README.md
+++ b/sql/seed/README.md
@@ -1,0 +1,32 @@
+# Seed scripts
+
+One-off SQL scripts that pre-populate a tenant with real-world data.
+These are not sqitch migrations -- they run by hand against a specific
+environment, typically once, when standing up a new customer.
+
+## `sacp-tenant.sql`
+
+Creates (if missing) the `sacp` tenant for Super Awesome Cool Pottery,
+clones the registry schema, and seeds:
+
+- Program types: afterschool, summer-camp, workshop, wheel-class,
+  pyop, field-trip, birthday-party
+- Locations: the SACP studio (930 Hoffner Ave, Orlando) and
+  Dr Phillips Elementary
+- Draft projects: Summer Camp 2026 and After-School at Dr Phillips,
+  Fall 2026
+
+All projects are created with `status = 'draft'` so nothing goes live
+until Victoria publishes from the admin dashboard.
+
+The script is idempotent -- running it repeatedly leaves the same rows.
+
+### Usage
+
+Local dev:
+
+    psql registry -f sql/seed/sacp-tenant.sql
+
+Production (Render):
+
+    psql "$PROD_DB_URL" -f sql/seed/sacp-tenant.sql

--- a/sql/seed/sacp-tenant.sql
+++ b/sql/seed/sacp-tenant.sql
@@ -1,0 +1,169 @@
+-- ABOUTME: Seed data for Super Awesome Cool Pottery's registry tenant.
+-- ABOUTME: Creates the tenant (if missing) and populates real-world program data.
+--
+-- Usage:
+--     psql 'postgres://...' -v tenant_slug=sacp -f sql/seed/sacp-tenant.sql
+--
+-- Source: https://superawesomecool.com (studio address, programs offered)
+-- Target: populate a single tenant with Super Awesome Cool Pottery's
+-- real locations and program types so Victoria can start testing
+-- with representative data instead of a blank slate.
+--
+-- Safe to re-run: every INSERT uses ON CONFLICT DO NOTHING or UPDATE.
+
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+SET client_min_messages = 'warning';
+
+-- -------------------------------------------------------------------------
+-- Create the SACP tenant and its schema if neither exists yet.
+-- -------------------------------------------------------------------------
+
+DO
+$$
+DECLARE
+    target_slug text := 'sacp';
+    target_name text := 'Super Awesome Cool Pottery';
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM registry.tenants WHERE slug = target_slug) THEN
+        INSERT INTO registry.tenants (slug, name) VALUES (target_slug, target_name);
+    END IF;
+
+    IF to_regnamespace(quote_ident(target_slug)) IS NULL THEN
+        PERFORM registry.clone_schema(target_slug);
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+SET search_path TO sacp, public;
+
+-- -------------------------------------------------------------------------
+-- Program types. clone_schema copies structure only, so seed every type
+-- SACP needs directly into the tenant schema.
+-- -------------------------------------------------------------------------
+
+INSERT INTO program_types (slug, name, config) VALUES
+    ('afterschool',  'After School Program',
+        '{"session_pattern": "weekly_for_x_weeks",
+          "enrollment_rules": {"same_session_for_siblings": true},
+          "standard_times": {
+            "monday":    "15:00",
+            "tuesday":   "15:00",
+            "wednesday": "14:00",
+            "thursday":  "15:00",
+            "friday":    "15:00"
+          }}'::jsonb),
+    ('summer-camp',  'Summer Camp',
+        '{"session_pattern": "daily_for_x_days",
+          "enrollment_rules": {"same_session_for_siblings": false},
+          "standard_times": {"start": "09:00", "end": "16:00"}}'::jsonb),
+    ('workshop',     'Workshop',
+        '{"session_pattern": "one_time", "default_capacity": 12}'::jsonb),
+    ('wheel-class',  'Wheel Class',
+        '{"session_pattern": "weekly", "default_capacity": 8}'::jsonb),
+    ('pyop',         'Paint Your Own Pottery',
+        '{"session_pattern": "walk_in"}'::jsonb),
+    ('field-trip',   'Field Trip',
+        '{"session_pattern": "one_time"}'::jsonb),
+    ('birthday-party','Birthday Party',
+        '{"session_pattern": "one_time", "default_capacity": 15}'::jsonb)
+ON CONFLICT (slug) DO NOTHING;
+
+-- -------------------------------------------------------------------------
+-- Locations.
+-- -------------------------------------------------------------------------
+
+INSERT INTO locations (slug, name, address_info, capacity)
+VALUES (
+    'sacp_studio',
+    'Super Awesome Cool Pottery Studio',
+    '{"street_address": "930 Hoffner Ave",
+      "city": "Orlando",
+      "state": "FL",
+      "postal_code": "32809",
+      "phone": "(407) 720-3699",
+      "email": "studio@superawesomecool.com"}'::jsonb,
+    24  -- studio camp capacity
+)
+ON CONFLICT (slug) DO UPDATE
+SET name         = EXCLUDED.name,
+    address_info = EXCLUDED.address_info,
+    capacity     = EXCLUDED.capacity,
+    updated_at   = now();
+
+INSERT INTO locations (slug, name, address_info, capacity)
+VALUES (
+    'dr_phillips_elementary',
+    'Dr Phillips Elementary',
+    '{"street_address": "6909 Dr Phillips Blvd",
+      "city": "Orlando",
+      "state": "FL",
+      "postal_code": "32819",
+      "district": "Orange County Public Schools"}'::jsonb,
+    20  -- typical afterschool class size
+)
+ON CONFLICT (slug) DO UPDATE
+SET name         = EXCLUDED.name,
+    address_info = EXCLUDED.address_info,
+    capacity     = EXCLUDED.capacity,
+    updated_at   = now();
+
+-- -------------------------------------------------------------------------
+-- Sample program templates so Victoria has something to publish against.
+-- Programs start as 'draft' so nothing goes live until she explicitly
+-- publishes from the admin dashboard.
+-- -------------------------------------------------------------------------
+
+INSERT INTO projects (slug, name, program_type_slug, notes, status, metadata)
+VALUES (
+    'summer_camp_2026',
+    'Summer Camp 2026',
+    'summer-camp',
+    'Full-day summer camp at the studio, grades K-5, Mon-Fri 9am-4pm ' ||
+    '(free extended care 8am-6pm). Weekly themes run June 1 through August 10. ' ||
+    '$300 per student per week including before/after care.',
+    'draft',
+    '{"grades": "K-5",
+      "daily_start": "09:00",
+      "daily_end":   "16:00",
+      "extended_care_start": "08:00",
+      "extended_care_end":   "18:00",
+      "default_price": 300,
+      "themes_2026": [
+        "Rodeo", "Hollywood Movies", "Outdoor Adventure", "Oceans",
+        "Safari", "Hawaiian Sun", "Gardening", "Prehistoric Past",
+        "Lil'' Gems in Nature", "Rainforest", "Architecture"]}'::jsonb
+)
+ON CONFLICT (slug) DO NOTHING;
+
+INSERT INTO projects (slug, name, program_type_slug, notes, status, metadata)
+VALUES (
+    'after_school_dr_phillips_fall_2026',
+    'After-School at Dr Phillips, Fall 2026',
+    'afterschool',
+    'Weekly after-school pottery program at Dr Phillips Elementary. ' ||
+    'Grades K-5, meets 3:00-4:15 PM. Returns August 2026 for the 2026-2027 school year.',
+    'draft',
+    '{"grades": "K-5",
+      "daily_start": "15:00",
+      "daily_end":   "16:15",
+      "sessions_per_year": 6}'::jsonb
+)
+ON CONFLICT (slug) DO NOTHING;
+
+COMMIT;
+
+-- -------------------------------------------------------------------------
+-- Summary (printed outside the transaction).
+-- -------------------------------------------------------------------------
+
+\echo
+\echo 'SACP seed complete. Summary:'
+SELECT 'program_types' AS table_name, COUNT(*) FROM sacp.program_types
+UNION ALL
+SELECT 'locations',     COUNT(*) FROM sacp.locations
+UNION ALL
+SELECT 'projects',      COUNT(*) FROM sacp.projects
+ORDER BY table_name;

--- a/t/seed/sacp-tenant.t
+++ b/t/seed/sacp-tenant.t
@@ -83,7 +83,7 @@ subtest 'seed script is idempotent' => sub {
     my $type_count = $db->query(
         "SELECT COUNT(*) FROM sacp.program_types"
     )->array->[0];
-    cmp_ok($type_count, '>=', 5, 'program types still present, not duplicated');
+    is($type_count, 7, 'program types still present, not duplicated');
 };
 
 done_testing();

--- a/t/seed/sacp-tenant.t
+++ b/t/seed/sacp-tenant.t
@@ -1,0 +1,89 @@
+#!/usr/bin/env perl
+# ABOUTME: Verifies the SACP tenant seed script creates the tenant,
+# ABOUTME: clones the schema, and populates expected rows.
+use 5.42.0;
+use warnings;
+use lib qw(lib t/lib);
+use Test::More;
+use Test::Registry::DB;
+use File::Spec;
+
+my $tdb   = Test::Registry::DB->new;
+my $dao   = $tdb->db;
+my $db    = $dao->db;
+
+my $seed_path = File::Spec->rel2abs('sql/seed/sacp-tenant.sql');
+
+# Test::Registry::DB gives us a Test::PostgreSQL instance with a URI we
+# can hand to psql. Run the seed script against it.
+my $uri = $tdb->uri;
+my $rc  = system(qq{psql -v ON_ERROR_STOP=1 "$uri" -f "$seed_path" >/dev/null 2>&1});
+is($rc, 0, 'seed script runs without error');
+
+subtest 'tenant row created' => sub {
+    my $tenant = $db->query(
+        "SELECT slug, name FROM registry.tenants WHERE slug = 'sacp'"
+    )->hash;
+    ok($tenant, 'sacp tenant exists');
+    is($tenant->{name}, 'Super Awesome Cool Pottery', 'correct name');
+};
+
+subtest 'schema created' => sub {
+    my $exists = $db->query(
+        "SELECT 1 FROM information_schema.schemata WHERE schema_name = 'sacp'"
+    )->hash;
+    ok($exists, 'sacp schema exists');
+};
+
+subtest 'program types seeded' => sub {
+    my $rows = $db->query(
+        "SELECT slug FROM sacp.program_types ORDER BY slug"
+    )->hashes;
+    my @slugs = map { $_->{slug} } @$rows;
+
+    for my $want (qw(afterschool summer-camp workshop wheel-class pyop)) {
+        ok((grep { $_ eq $want } @slugs), "has $want program type");
+    }
+};
+
+subtest 'locations seeded with addresses' => sub {
+    my $studio = $db->query(
+        "SELECT name, address_info FROM sacp.locations WHERE slug = 'sacp_studio'"
+    )->expand->hash;
+    ok($studio, 'studio location exists');
+    is($studio->{name}, 'Super Awesome Cool Pottery Studio', 'studio name');
+    is($studio->{address_info}{street_address}, '930 Hoffner Ave', 'studio address');
+
+    my $drp = $db->query(
+        "SELECT name, address_info FROM sacp.locations WHERE slug = 'dr_phillips_elementary'"
+    )->expand->hash;
+    ok($drp, 'Dr Phillips location exists');
+    is($drp->{address_info}{city}, 'Orlando', 'Dr Phillips city');
+};
+
+subtest 'projects seeded as draft' => sub {
+    my $rows = $db->query(
+        "SELECT slug, status FROM sacp.projects ORDER BY slug"
+    )->hashes;
+    is(scalar @$rows, 2, 'two draft projects seeded');
+    for my $row (@$rows) {
+        is($row->{status}, 'draft', "$row->{slug} is draft");
+    }
+};
+
+subtest 'seed script is idempotent' => sub {
+    my $rc = system(qq{psql -v ON_ERROR_STOP=1 "$uri" -f "$seed_path" >/dev/null 2>&1});
+    is($rc, 0, 'running again is a no-op');
+
+    my $tenant_count = $db->query(
+        "SELECT COUNT(*) FROM registry.tenants WHERE slug = 'sacp'"
+    )->array->[0];
+    is($tenant_count, 1, 'still exactly one sacp tenant row');
+
+    my $type_count = $db->query(
+        "SELECT COUNT(*) FROM sacp.program_types"
+    )->array->[0];
+    cmp_ok($type_count, '>=', 5, 'program types still present, not duplicated');
+};
+
+done_testing();


### PR DESCRIPTION
## Summary

A one-off SQL seed script that pre-populates Super Awesome Cool Pottery's tenant with real data drawn from superawesomecool.com. When Victoria's tenant is provisioned (manually or via the tenant-signup flow), running this script gives her a working setup to start testing against instead of a blank slate.

## What it seeds

- \`sacp\` tenant row and cloned schema (if missing)
- 7 program types: afterschool, summer-camp, workshop, wheel-class, pyop, field-trip, birthday-party
- 2 locations: the studio (930 Hoffner Ave, Orlando) and Dr Phillips Elementary
- 2 draft projects: Summer Camp 2026 and After-School at Dr Phillips Fall 2026 -- both \`status='draft'\` so Victoria has to explicitly publish

## Why not sqitch

This is customer-specific bootstrap data, not a schema migration. Running it on every deploy and every test DB doesn't make sense. \`sql/seed/\` is a new directory for scripts like this -- run by hand against a specific environment, typically once.

## Idempotency

Every INSERT uses \`ON CONFLICT DO NOTHING\` or \`DO UPDATE\`. Running the script twice leaves the same rows. Verified by the test's \"run twice\" subtest.

## Data source

Public pages on superawesomecool.com, captured 2026-04-20. README notes this is a point-in-time bootstrap, not a source of truth -- once Victoria uses the admin dashboard, the dashboard wins.

## Test plan

- [x] \`t/seed/sacp-tenant.t\` invokes psql against a Test::PostgreSQL instance and verifies the tenant, schema, program types, locations, and draft projects exist
- [x] Final subtest re-runs the script and asserts no duplicates (7 program types before and after)
- [x] Full suite: 203 files, 1920 tests, all passing

## Follow-up

- #197 Share psql binary discovery between Test::Registry::DB and seed tests