### PR TITLE
Payment failure recovery: let parents retry with a different card

### DIFF
--- a/lib/Registry/DAO/WorkflowSteps/Payment.pm
+++ b/lib/Registry/DAO/WorkflowSteps/Payment.pm
@@ -11,12 +11,19 @@ use Mojo::JSON qw(encode_json);
 
 method process ($db, $form_data, $run = undef) {
     $run //= do { my $w = $self->workflow($db); $w->latest_run($db) };
-    
+
     # Handle Stripe webhook callback
     if ($form_data->{payment_intent_id}) {
         return $self->handle_payment_callback($db, $run, $form_data);
     }
-    
+
+    # Any non-callback interaction (new terms agreement, page view via
+    # process) means the user moved past a prior retry. Clear stale
+    # state so an unrelated navigation can't resurrect a dead intent.
+    if ($run->data->{payment_retry_state}) {
+        $run->update_data($db, { payment_retry_state => undef });
+    }
+
     # Demo mode: when STRIPE_SECRET_KEY is not set, accept terms agreement
     # and create enrollments directly without Stripe processing.
     if ($form_data->{agreeTerms} && !$ENV{STRIPE_SECRET_KEY}) {
@@ -27,9 +34,9 @@ method process ($db, $form_data, $run = undef) {
     if ($form_data->{agreeTerms}) {
         return $self->create_payment($db, $run, $form_data);
     }
-    
+
     # Just show the payment page
-    return { 
+    return {
         next_step => $self->id,
         data => $self->prepare_payment_data($db, $run)
     };
@@ -170,14 +177,14 @@ method handle_payment_callback ($db, $run, $form_data) {
         # being dumped back at the terms-agreement page. The Payment
         # record is reused so we don't orphan it.
         my $user = Registry::DAO::User->find($db, { id => $run->data->{user_id} });
-        my $retry_intent = eval {
-            $payment->create_payment_intent($db, {
+        my $retry_intent;
+        try {
+            $retry_intent = $payment->create_payment_intent($db, {
                 description   => 'Program Enrollment (retry)',
                 receipt_email => $user ? $user->email : undef,
             });
-        };
-
-        if (my $retry_err = $@) {
+        }
+        catch ($retry_err) {
             # Couldn't even create a retry intent -- surface both
             # failures and drop back to the non-retry state. Also
             # clear any stale retry state.

--- a/lib/Registry/DAO/WorkflowSteps/Payment.pm
+++ b/lib/Registry/DAO/WorkflowSteps/Payment.pm
@@ -41,13 +41,28 @@ method prepare_payment_data ($db, $run) {
         children => $run->data->{children} || [],
         session_selections => $run->data->{session_selections} || {},
     };
-    
+
     my $payment_info = Registry::DAO::Payment->calculate_enrollment_total($db, $enrollment_data);
-    
+
     return {
         total => $payment_info->{total},
         items => $payment_info->{items},
         stripe_publishable_key => $ENV{STRIPE_PUBLISHABLE_KEY},
+    };
+}
+
+# Surface the summary data (and any pending retry state) the template
+# needs. Without this override, stash('step_data') is empty on re-entry
+# after a flash-redirect, which is how the no-JS error path works.
+method prepare_template_data ($db, $run, $params = {}) {
+    my $step_data  = $self->prepare_payment_data($db, $run);
+    my $retry_state = $run->data->{payment_retry_state} || {};
+
+    return {
+        step_data => {
+            %$step_data,
+            %$retry_state,
+        },
     };
 }
 
@@ -112,12 +127,13 @@ method create_payment ($db, $run, $form_data) {
 
 method handle_payment_callback ($db, $run, $form_data) {
     my $payment_id = $run->data->{payment_id} or die "No payment_id in workflow data";
-    
-    my $payment = Registry::DAO::Payment->new(id => $payment_id)->load($db);
-    
+
+    my $payment = Registry::DAO::Payment->find($db, { id => $payment_id });
+    die "Payment $payment_id not found" unless $payment;
+
     # Process the payment
     my $result = $payment->process_payment($db, $form_data->{payment_intent_id});
-    
+
     if ($result->{success}) {
         # Create enrollments from the enrollment_items stored by MultiChildSessionSelection
         require Registry::DAO::Enrollment;
@@ -134,7 +150,9 @@ method handle_payment_callback ($db, $run, $form_data) {
             });
         }
 
-        # Payment successful, move to completion
+        # Payment successful, clear any lingering retry state and
+        # move to completion.
+        $run->update_data($db, { payment_retry_state => undef });
         return { next_step => 'complete' };
     } elsif ($result->{processing}) {
         # Payment still processing
@@ -147,11 +165,50 @@ method handle_payment_callback ($db, $run, $form_data) {
             }
         };
     } else {
-        # Payment failed
+        # Payment failed. Re-issue a fresh Stripe PaymentIntent so the
+        # parent can retry with a different card immediately instead of
+        # being dumped back at the terms-agreement page. The Payment
+        # record is reused so we don't orphan it.
+        my $user = Registry::DAO::User->find($db, { id => $run->data->{user_id} });
+        my $retry_intent = eval {
+            $payment->create_payment_intent($db, {
+                description   => 'Program Enrollment (retry)',
+                receipt_email => $user ? $user->email : undef,
+            });
+        };
+
+        if (my $retry_err = $@) {
+            # Couldn't even create a retry intent -- surface both
+            # failures and drop back to the non-retry state. Also
+            # clear any stale retry state.
+            $run->update_data($db, { payment_retry_state => undef });
+            return {
+                next_step => $self->id,
+                errors    => [
+                    $result->{error},
+                    "Retry unavailable: $retry_err",
+                ],
+                data => $self->prepare_payment_data($db, $run),
+            };
+        }
+
+        # Persist retry state so prepare_template_data can surface it
+        # on the subsequent GET (flash-redirect path).
+        my %retry_state = (
+            payment_id       => $payment->id,
+            client_secret    => $retry_intent->{client_secret},
+            show_stripe_form => 1,
+            retry            => 1,
+        );
+        $run->update_data($db, { payment_retry_state => \%retry_state });
+
         return {
             next_step => $self->id,
-            errors => [$result->{error}],
-            data => $self->prepare_payment_data($db, $run),
+            errors    => [$result->{error}],
+            data      => {
+                %{$self->prepare_payment_data($db, $run)},
+                %retry_state,
+            },
         };
     }
 }

--- a/t/controller/payment-retry-render.t
+++ b/t/controller/payment-retry-render.t
@@ -1,0 +1,108 @@
+#!/usr/bin/env perl
+# ABOUTME: Verifies the payment-step template renders the retry UI and
+# ABOUTME: error banner when payment_retry_state is set in run data.
+use 5.42.0;
+use warnings;
+use utf8;
+BEGIN { $ENV{EMAIL_SENDER_TRANSPORT} = 'Test' }
+use lib qw(lib t/lib);
+use Test::More;
+use Test::Registry::Mojo;
+use Registry;
+use Test::Registry::DB;
+use Test::Registry::Fixtures;
+use Registry::DAO qw(Workflow);
+use Registry::DAO::WorkflowRun;
+use Mojo::Home;
+use YAML::XS qw(Load);
+
+my $test_db = Test::Registry::DB->new;
+my $dao     = $test_db->db;
+$ENV{DB_URL} = $test_db->uri;
+
+# Import workflows so the summer-camp-registration slug resolves.
+my @files = Mojo::Home->new->child('workflows')->list_tree->grep(qr/\.ya?ml$/)->each;
+for my $file (@files) {
+    next if Load($file->slurp)->{draft};
+    Workflow->from_yaml($dao, $file->slurp);
+}
+
+my $t = Test::Registry::Mojo->new('Registry');
+$t->ua->max_redirects(5);
+
+# Fetch the payment step id so we can build the run URL.
+my $workflow = $dao->find(Workflow => { slug => 'summer-camp-registration' });
+my $payment_step = Registry::DAO::WorkflowStep->find($dao->db, {
+    workflow_id => $workflow->id, slug => 'payment',
+});
+
+subtest 'retry state in run data renders error banner and stripe form' => sub {
+    # Craft a run whose latest step is payment and whose data already
+    # carries the retry state (as handle_payment_callback would have
+    # written after a card decline).
+    my $run = $workflow->new_run($dao->db);
+    $dao->db->update('workflow_runs',
+        { latest_step_id => $payment_step->id },
+        { id => $run->id },
+    );
+    $run->update_data($dao->db, {
+        user_id             => 'some-user-id',
+        payment_retry_state => {
+            payment_id       => 'pi_fake_payment_id',
+            client_secret    => 'pi_retry_secret_abc',
+            show_stripe_form => 1,
+            retry            => 1,
+        },
+    });
+
+    # Also set an errors flash so the server-side banner renders. We
+    # put a message in session the way the controller would.
+    $t->get_ok("/summer-camp-registration/@{[ $run->id ]}/payment")
+      ->status_is(200)
+      ->content_like(qr/Try a Different Card/,
+                     'heading switches to retry copy when retry state is set')
+      ->content_like(qr/pi_retry_secret_abc/,
+                     'fresh PaymentIntent client_secret reaches the JS init');
+};
+
+subtest 'errors_json decodes into the server-side banner' => sub {
+    my $run = $workflow->new_run($dao->db);
+    $dao->db->update('workflow_runs',
+        { latest_step_id => $payment_step->id },
+        { id => $run->id },
+    );
+    $run->update_data($dao->db, {
+        user_id             => 'some-user-id',
+        payment_retry_state => {
+            payment_id       => 'p2',
+            client_secret    => 'pi_other_secret',
+            show_stripe_form => 1,
+            retry            => 1,
+        },
+    });
+
+    # Without a flash, the banner is absent.
+    $t->get_ok("/summer-camp-registration/@{[ $run->id ]}/payment")
+      ->status_is(200)
+      ->content_like(qr/Try a Different Card/, 'retry heading visible')
+      ->content_unlike(qr/didn't go through/,
+                       'banner absent when no error flash is set');
+
+    # Simulate the controller populating errors_json from a failure.
+    # The GET handler does: my $errors_json = encode_json(flash('validation_errors') || []);
+    # We override via before_render to inject a non-empty errors_json.
+    my $decline = 'Your card was declined.';
+    my $hook = $t->app->hook(before_render => sub ($c, $args) {
+        return unless $c->req->url->path =~ m{/summer-camp-registration/.+/payment};
+        $args->{errors_json} = Mojo::JSON::encode_json([$decline]);
+    });
+
+    $t->get_ok("/summer-camp-registration/@{[ $run->id ]}/payment")
+      ->status_is(200)
+      ->content_like(qr/didn't go through/,
+                     'banner heading appears with retry wording')
+      ->content_like(qr/\Q$decline\E/,
+                     'decline reason surfaces in the banner list');
+};
+
+done_testing();

--- a/t/dao/payment-failure-recovery.t
+++ b/t/dao/payment-failure-recovery.t
@@ -1,0 +1,173 @@
+#!/usr/bin/env perl
+# ABOUTME: When Stripe reports a payment failure, the workflow step
+# ABOUTME: should re-render the payment form with a fresh intent so the
+# ABOUTME: parent can retry -- instead of dumping them at the terms page.
+use 5.42.0;
+use warnings;
+use lib qw(lib t/lib);
+use Test::More;
+use Test::MockObject;
+use Test::Registry::DB;
+use Test::Registry::Fixtures;
+use Registry::DAO::Workflow;
+use Registry::DAO::WorkflowStep;
+use Registry::DAO::Payment;
+use Registry::DAO::WorkflowSteps::Payment;
+
+my $test_db = Test::Registry::DB->new;
+my $dao     = $test_db->db;
+
+my $tenant = Test::Registry::Fixtures::create_tenant($dao->db, {
+    name => 'Retry Test Tenant',
+    slug => 'retry_test',
+});
+$dao->db->query('SELECT clone_schema(?)', 'retry_test');
+$dao = Registry::DAO->new(url => $test_db->uri, schema => 'retry_test');
+my $db = $dao->db;
+
+my $user = Registry::DAO::User->create($db, {
+    name      => 'Parent',
+    username  => 'parent_retry',
+    email     => 'parent@retry.local',
+    user_type => 'parent',
+    password  => 'x',
+});
+
+# Fake payment id -- we mock Payment->find so no row is required.
+my $payment_id = '00000000-0000-0000-0000-000000000001';
+
+# Minimal workflow + run so the step can call $run->data etc.
+my $workflow = Registry::DAO::Workflow->create($db, {
+    name        => 'Retry Test Flow',
+    slug        => 'retry_test_flow',
+    description => 'minimal',
+    first_step  => 'payment',
+});
+$workflow->add_step($db, {
+    slug        => 'payment',
+    description => 'Payment',
+    class       => 'Registry::DAO::WorkflowSteps::Payment',
+});
+my $run = $workflow->new_run($db);
+$run->update_data($db, {
+    user_id    => $user->id,
+    payment_id => $payment_id,
+});
+
+my $step = Registry::DAO::WorkflowStep->find($db, {
+    workflow_id => $workflow->id, slug => 'payment',
+});
+
+# Swap in a Payment whose Stripe methods are mocked. The workflow step
+# loads Payment by id, so we monkey-patch the class methods to inject
+# our mock.
+sub mock_payment_with_outcome ($process_result, %more) {
+    my $mock = Test::MockObject->new;
+    $mock->set_always('id',                    $payment_id);
+    $mock->set_always('process_payment',       $process_result);
+    if (exists $more{retry_intent}) {
+        $mock->set_always('create_payment_intent', $more{retry_intent});
+    }
+    elsif (exists $more{retry_dies}) {
+        $mock->mock('create_payment_intent', sub { die $more{retry_dies} });
+    }
+    return $mock;
+}
+
+subtest 'recoverable failure re-renders form with a fresh client_secret' => sub {
+    my $mock = mock_payment_with_outcome(
+        { success => 0, error => 'Your card was declined.' },
+        retry_intent => {
+            client_secret     => 'pi_new_secret_123',
+            payment_intent_id => 'pi_new_123',
+        },
+    );
+
+    # handle_payment_callback looks up the Payment via Payment->find.
+    # Intercept it for the duration of the test.
+    no warnings 'redefine';
+    local *Registry::DAO::Payment::find = sub { $mock };
+
+    my $result = $step->handle_payment_callback($db, $run, {
+        payment_intent_id => 'pi_old_failed',
+    });
+
+    ok($result->{errors}, 'error array included');
+    like($result->{errors}[0], qr/declined/i, 'message surfaces the decline reason');
+    ok($result->{data}{show_stripe_form},
+       'form stays visible so retry is possible');
+    is($result->{data}{client_secret}, 'pi_new_secret_123',
+       'fresh PaymentIntent client_secret delivered');
+    is($result->{data}{payment_id}, $payment_id,
+       'payment record is reused, not orphaned');
+    ok($result->{data}{retry}, 'retry flag set for template UX');
+};
+
+subtest 'if a new intent cannot be issued, still surface an error' => sub {
+    my $mock = mock_payment_with_outcome(
+        { success => 0, error => 'Network error' },
+        retry_dies => 'Stripe unreachable',
+    );
+
+    no warnings 'redefine';
+    local *Registry::DAO::Payment::find = sub { $mock };
+
+    my $result = $step->handle_payment_callback($db, $run, {
+        payment_intent_id => 'pi_old_failed',
+    });
+
+    ok($result->{errors}, 'error array included');
+    ok(!$result->{data}{show_stripe_form},
+       'form hidden when retry is genuinely impossible');
+};
+
+subtest 'retry state persists in run data for next GET' => sub {
+    my $mock = mock_payment_with_outcome(
+        { success => 0, error => 'Your card was declined.' },
+        retry_intent => {
+            client_secret     => 'pi_retry_secret',
+            payment_intent_id => 'pi_retry',
+        },
+    );
+
+    no warnings 'redefine';
+    local *Registry::DAO::Payment::find = sub { $mock };
+
+    $step->handle_payment_callback($db, $run, {
+        payment_intent_id => 'pi_old_failed',
+    });
+
+    # Reload the run to make sure data was persisted.
+    my $reloaded = Registry::DAO::WorkflowRun->find($db, { id => $run->id });
+    my $retry_state = $reloaded->data->{payment_retry_state};
+    ok($retry_state, 'payment_retry_state stored in run data');
+    is($retry_state->{client_secret}, 'pi_retry_secret',
+       'client_secret persisted for the retry GET');
+    ok($retry_state->{show_stripe_form}, 'show_stripe_form persisted');
+    ok($retry_state->{retry},             'retry flag persisted');
+
+    # prepare_template_data surfaces the retry state into step_data.
+    my $tpl_data = $step->prepare_template_data($db, $reloaded);
+    is($tpl_data->{step_data}{client_secret}, 'pi_retry_secret',
+       'template data carries the retry client_secret');
+    ok($tpl_data->{step_data}{show_stripe_form},
+       'template data flags the stripe form for re-display');
+};
+
+subtest 'successful payment still transitions to complete' => sub {
+    my $mock = Test::MockObject->new;
+    $mock->set_always('id', $payment_id);
+    $mock->set_always('process_payment', { success => 1, payment => $mock });
+
+    no warnings 'redefine';
+    local *Registry::DAO::Payment::find = sub { $mock };
+
+    my $result = $step->handle_payment_callback($db, $run, {
+        payment_intent_id => 'pi_ok',
+    });
+
+    is($result->{next_step}, 'complete',
+       'success still advances to complete step');
+};
+
+done_testing();

--- a/templates/summer-camp-registration/payment.html.ep
+++ b/templates/summer-camp-registration/payment.html.ep
@@ -5,7 +5,11 @@
 <% my $show_stripe = $step_data->{show_stripe_form}; %>
 <% my $processing = $step_data->{processing}; %>
 <% my $retry = $step_data->{retry}; %>
-<% my $server_errors = stash('errors') || []; %>
+%
+% # Server-side errors arrive via the controller's errors_json stash
+% # (populated from $result->{errors} or the validation_errors flash).
+% use Mojo::JSON qw(decode_json);
+% my $server_errors = decode_json(stash('errors_json') || '[]');
 
 <div class="max-w-4xl mx-auto p-6">
     <!-- Loading overlay -->
@@ -123,7 +127,7 @@
             <div id="payment-message" class="hidden text-red-600 mb-4"></div>
             
             <div class="flex justify-between">
-                <a href="<%= url_for('workflow_step', workflow_id => $workflow->id, run_id => $run->id, step_id => 'session-selection') %>" 
+                <a href="<%= url_for("workflow_step", workflow => $workflow, run => $run->id, step => 'session-selection') %>" 
                    class="bg-gray-300 text-gray-700 px-4 py-2 rounded hover:bg-gray-400">
                     Back
                 </a>
@@ -197,7 +201,7 @@
         </script>
     <% } else { %>
         <!-- Initial Agreement Form -->
-        <form method="POST" action="<%= url_for('workflow_step', workflow_id => $workflow->id, run_id => $run->id, step_id => 'payment') %>"
+        <form method="POST" action="<%= url_for("workflow_step", workflow => $workflow, run => $run->id, step => 'payment') %>"
               class="bg-white shadow rounded-lg p-6">
             <h2 class="text-2xl font-semibold mb-4">Payment Method</h2>
             
@@ -216,7 +220,7 @@
             </div>
             
             <div class="flex justify-between">
-                <a href="<%= url_for('workflow_step', workflow_id => $workflow->id, run_id => $run->id, step_id => 'session-selection') %>" 
+                <a href="<%= url_for("workflow_step", workflow => $workflow, run => $run->id, step => 'session-selection') %>" 
                    class="bg-gray-300 text-gray-700 px-4 py-2 rounded hover:bg-gray-400">
                     Back
                 </a>

--- a/templates/summer-camp-registration/payment.html.ep
+++ b/templates/summer-camp-registration/payment.html.ep
@@ -4,6 +4,8 @@
 <% my $step_data = stash('step_data') || {}; %>
 <% my $show_stripe = $step_data->{show_stripe_form}; %>
 <% my $processing = $step_data->{processing}; %>
+<% my $retry = $step_data->{retry}; %>
+<% my $server_errors = stash('errors') || []; %>
 
 <div class="max-w-4xl mx-auto p-6">
     <!-- Loading overlay -->
@@ -58,6 +60,23 @@
 
     <h1 class="text-3xl font-bold mb-6">Payment Information</h1>
 
+    <% if (@$server_errors) { %>
+        <div class="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg mb-6" role="alert">
+            <h3 class="font-semibold mb-1">
+                <% if ($retry) { %>
+                    Your payment didn't go through -- please try a different card.
+                <% } else { %>
+                    We couldn't process your payment.
+                <% } %>
+            </h3>
+            <ul class="list-disc list-inside text-sm">
+                <% for my $err (@$server_errors) { %>
+                    <li><%= $err %></li>
+                <% } %>
+            </ul>
+        </div>
+    <% } %>
+
     <% if ($processing) { %>
         <div class="bg-blue-50 border border-blue-200 p-4 rounded-lg mb-6">
             <p class="text-blue-800">
@@ -93,7 +112,9 @@
     <% if ($show_stripe) { %>
         <!-- Stripe Payment Form -->
         <form id="payment-form" class="bg-white shadow rounded-lg p-6">
-            <h2 class="text-2xl font-semibold mb-4">Payment Details</h2>
+            <h2 class="text-2xl font-semibold mb-4">
+                <%= $retry ? 'Try a Different Card' : 'Payment Details' %>
+            </h2>
             
             <div id="payment-element" class="mb-6">
                 <!-- Stripe Elements will be inserted here -->


### PR DESCRIPTION
## Summary

Closes #200. Card-decline recovery UX in the parent payment step is rewritten from 'dump the parent back at the terms page' to 'show a prominent error banner, keep the enrollment summary visible, re-issue a fresh Stripe PaymentIntent, and let them try a different card immediately.'

## Back-end changes

\`Registry::DAO::WorkflowSteps::Payment\`:

- \`handle_payment_callback\` failure branch:
  - Fixes pre-existing \`Payment->new(id=>X)->load(\$db)\` dead code (no such method; partial resolution of #170). Switched to \`Payment->find(\$db, {id=>X})\`.
  - Re-issues a fresh PaymentIntent on the same Payment record (no orphans).
  - Stores retry state (\`payment_id\`, \`client_secret\`, \`show_stripe_form\`, \`retry\`) in \`\$run->data->{payment_retry_state}\` so it survives the no-JS flash-redirect round trip.
  - Falls back to a combined-errors view if \`create_payment_intent\` itself fails.
- New \`prepare_template_data\` override returns \`{step_data => {...prepare_payment_data + payment_retry_state}}\`, fixing a pre-existing bug where the template's \`stash('step_data')\` was always empty on GET re-entry.
- Clears retry state on success and on any non-callback \`process\` call (so navigating away and coming back doesn't resurrect a dead intent).

## Template changes

\`templates/summer-camp-registration/payment.html.ep\`:

- Page-level error banner reads the controller's \`errors_json\` stash (decoded via Mojo::JSON). Heading swaps to \"Your payment didn't go through -- please try a different card\" when retry is in flight.
- Stripe form heading switches from \"Payment Details\" to \"Try a Different Card\" under retry.
- Fixed 3 latent \`url_for\` bugs (\`workflow_id/run_id/step_id\` aren't route placeholders -- must be \`workflow/run/step\`). These only surface now that \`show_stripe_form\` is ever actually true.

## Tests

- \`t/dao/payment-failure-recovery.t\` -- 4 subtests covering retry payload, retry-intent creation failure, retry-state persistence in run data, and success-path still reaching complete.
- \`t/controller/payment-retry-render.t\` (NEW) -- 2 subtests covering the full render pipeline: retry state produces the \"Try a Different Card\" heading and surfaces the fresh client_secret; errors_json stash produces the banner with the decline reason.

## Follow-up issues

- #202 WorkflowRun needs a \`remove_data\` helper (JSONB merge can't actually delete keys).
- #203 Audit other templates using \`stash('step_data')\` to see which need similar \`prepare_template_data\` overrides.

## Test plan

- [x] \`t/dao/payment-failure-recovery.t\` -- 4 subtests passing
- [x] \`t/controller/payment-retry-render.t\` -- 2 subtests passing
- [x] Full suite: 206 files, 1930 tests, all passing