### PR TITLE
Unblock production deploys: fix fix-utf8-mojibake FK violation

### DIFF
--- a/sql/deploy/fix-utf8-mojibake.sql
+++ b/sql/deploy/fix-utf8-mojibake.sql
@@ -5,7 +5,14 @@ BEGIN;
 
 SET search_path TO registry, public;
 
+-- Only delete templates that are NOT referenced by workflow_steps. Deleting a
+-- referenced row violates workflow_steps_template_id_fkey. The referenced
+-- templates are refreshed in place by the `template import` step that runs on
+-- startup (upsert by name), so they still pick up the fixed filesystem content.
 DELETE FROM templates
-WHERE name != 'tenant-storefront/program-listing';
+WHERE name != 'tenant-storefront/program-listing'
+  AND id NOT IN (
+      SELECT template_id FROM workflow_steps WHERE template_id IS NOT NULL
+  );
 
 COMMIT;


### PR DESCRIPTION
## Production incident

`registry-app` has not successfully deployed since ~Apr 20 (every deploy is
`update_failed`). Root cause chain:

1. The sqitch migration `fix-utf8-mojibake` runs
   `DELETE FROM templates WHERE name != 'tenant-storefront/program-listing'`,
   but ~69 of those rows are referenced by `workflow_steps.template_id` →
   **FK violation** → migration aborts → sqitch halts.
2. Because the chain halts here, `program-publish-status` (which adds
   `projects.status`) never deploys. Production's `projects` table has no
   `status` column.
3. The storefront landing query (`ProgramListing.pm`) does
   `... AND p.status = 'published'` → `column p.status does not exist` → the
   landing page errors and renders without its marketing copy.
4. The post-deploy smoke test checks that copy, fails 7/13, and **kills the
   server to trigger a rollback** — so the deploy fails and prod stays on
   ~6-week-old code.

## Fix

Delete only templates **not** referenced by `workflow_steps`. The referenced
rows are refreshed in place by the `template import` step that runs on startup
(upsert by name), so they still pick up corrected filesystem content.

## Verification

- Queried the production DB (read-only): `workflow_steps.template_id` is the
  only FK into `templates`; 69 of the 132 candidate rows are referenced; zero
  templates currently contain the mojibake arrow (so the migration's `verify`
  step passes).
- `make test-schema` deploys the **entire** chain from scratch via sqitch with
  every change `ok`, including `fix-utf8-mojibake`, `update-registry-landing-copy`,
  `program-publish-status`, and `enrollment-confirmation-notification-type`.

## On merge

Merging triggers a production deploy. Expected: the 4 blocked migrations apply,
`projects.status` appears, the landing page renders, the smoke test passes, and
the deploy goes green for the first time since April (also shipping everything
merged since — auth, custom domains, payments, the #178/dashboard fixes).