### PR TITLE
Refuse live Stripe keys outside production (#159)

### DIFF
--- a/lib/Registry/DAO/Payment.pm
+++ b/lib/Registry/DAO/Payment.pm
@@ -51,6 +51,16 @@ field $_stripe_client = undef;
         my $api_key = $ENV{STRIPE_SECRET_KEY} || die "STRIPE_SECRET_KEY not set";
         my $webhook_secret = $ENV{STRIPE_WEBHOOK_SECRET};
 
+        # Safety guard: a live key (sk_live_) must never be used outside
+        # production. Development and test environments routinely inherit a live
+        # key from the shell, and using it would hit the real Stripe API and can
+        # create real charges. Require MOJO_MODE=production to opt in.
+        if ($api_key =~ /^sk_live_/ && ($ENV{MOJO_MODE} // '') ne 'production') {
+            die "Refusing to use a live Stripe key (sk_live_) outside production "
+              . "(MOJO_MODE=" . ($ENV{MOJO_MODE} // 'unset') . "); "
+              . "set a Stripe test key (sk_test_) for development and tests.\n";
+        }
+
         # Handle SSL requirement gracefully in test environments
         eval {
             $_stripe_client = Registry::Service::Stripe->new(

--- a/t/security/stripe-test-keys.t
+++ b/t/security/stripe-test-keys.t
@@ -1,0 +1,57 @@
+#!/usr/bin/env perl
+# ABOUTME: Tests that a live Stripe key (sk_live_) is refused outside production.
+# ABOUTME: Guards dev/test environments that inherit a live key from the shell.
+
+use 5.42.0;
+use warnings;
+use utf8;
+
+use lib qw(lib t/lib);
+use Test::More;
+
+# Build the Stripe client in a child process so each case gets a clean,
+# fully-controlled environment (the parent shell may export a real live key).
+# Single-quoted here-string: $vars below are literal, evaluated by the child.
+my $build_client = 'require Registry::DAO::Payment;'
+    . 'my $p = Registry::DAO::Payment->new;'
+    . 'my $ok = eval { $p->stripe_client; 1 };'
+    . 'print $ok ? "OK\n" : "ERR: $@";';
+
+subtest 'live key outside production is refused' => sub {
+    local $ENV{STRIPE_SECRET_KEY} = 'sk_live_fake_for_guard_test';
+    delete local $ENV{MOJO_MODE};
+
+    my $out = `carton exec perl -Ilib -e '$build_client' 2>&1`;
+    like $out, qr/Refusing to use a live Stripe key/,
+        'sk_live_ with no MOJO_MODE is refused';
+    like $out, qr/sk_test_/, 'error message points at the test-key fix';
+};
+
+subtest 'live key in development mode is refused' => sub {
+    local $ENV{STRIPE_SECRET_KEY} = 'sk_live_fake_for_guard_test';
+    local $ENV{MOJO_MODE} = 'development';
+
+    my $out = `carton exec perl -Ilib -e '$build_client' 2>&1`;
+    like $out, qr/Refusing to use a live Stripe key/,
+        'sk_live_ with MOJO_MODE=development is refused';
+};
+
+subtest 'test key outside production is allowed' => sub {
+    local $ENV{STRIPE_SECRET_KEY} = 'sk_test_fake_for_guard_test';
+    delete local $ENV{MOJO_MODE};
+
+    my $out = `carton exec perl -Ilib -e '$build_client' 2>&1`;
+    unlike $out, qr/Refusing to use a live Stripe key/,
+        'sk_test_ key passes the live-key guard';
+};
+
+subtest 'live key in production mode is allowed past the guard' => sub {
+    local $ENV{STRIPE_SECRET_KEY} = 'sk_live_fake_for_guard_test';
+    local $ENV{MOJO_MODE} = 'production';
+
+    my $out = `carton exec perl -Ilib -e '$build_client' 2>&1`;
+    unlike $out, qr/Refusing to use a live Stripe key/,
+        'sk_live_ with MOJO_MODE=production is permitted';
+};
+
+done_testing;


### PR DESCRIPTION
Closes #159.

## Problem

Dev and test environments routinely inherit a live Stripe key (`sk_live_`) from
the shell. Any code path that builds the Stripe client then hits the **real**
Stripe API and can create real charges — this is how `tenant-create-session.t`
was silently exercising the live account.

## Fix

`Registry::DAO::Payment->stripe_client` now dies with a clear, actionable
message when `STRIPE_SECRET_KEY` is a live key and `MOJO_MODE` is not
`production` — mirroring the existing `MOJO_SECRET` production guard. This
prevents the live call at the point of construction, so no test (or dev-server
request) can charge a real card by inheriting a live key. Test keys (`sk_test_`)
and genuine production runs are unaffected.

## Tests

`t/security/stripe-test-keys.t` (mirrors `mojo-secret.t`): live key refused with
no `MOJO_MODE`, refused in development, allowed past the guard in production, and
test keys always permitted.

## Verification

Full suite green with the guard active **and** a live key still in the shell:
**210 files, 1948 tests, 0 failures**. Confirms no existing test relies on live
keys (they mock, use demo mode, or set local `sk_test_fake` keys).

## Note for developers

Set Stripe **test** keys in your shell to exercise payments in dev:
`STRIPE_SECRET_KEY=sk_test_…`, `STRIPE_PUBLISHABLE_KEY=pk_test_…`
(already documented in CONTRIBUTING.md).