### PR TITLE
Fix CI postgres teardown noise and un-skip the Stripe tests (#186)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,9 @@ jobs:
         export PGPASSWORD=postgres
         export DB_URL="postgresql://postgres:postgres@localhost:5432/registry_test"
         export EMAIL_SENDER_TRANSPORT=Test
+        # Dummy test key so the Stripe DAO constructs; these tests make no real
+        # API calls. A live key (sk_live_) would be refused outside production.
+        export STRIPE_SECRET_KEY=sk_test_dummy
         # Run tests sequentially to avoid database conflicts
         timeout 20m carton exec prove -lr t/ --formatter=TAP::Formatter::Console
 
@@ -340,7 +343,8 @@ jobs:
         export PGPASSWORD=postgres
         export DB_URL="postgresql://postgres:postgres@localhost:5432/registry_test"
         export EMAIL_SENDER_TRANSPORT=Test
-        
+        export STRIPE_SECRET_KEY=sk_test_dummy
+
         # Run a sample of tests with coverage
         carton exec cover -test -report html_basic -ignore_re '^t/' || true
         

--- a/t/dao/stripe-subscription.t
+++ b/t/dao/stripe-subscription.t
@@ -5,13 +5,6 @@ use lib qw(lib t/lib);
 use experimental qw(defer);
 use Test::More;
 
-# Skip in CI: the postgres service container drops connections
-# mid-test ("terminating connection due to administrator command"),
-# which is likely OOM-killer behaviour or a Mojo::Pg connection leak
-# in the Stripe/Minion code. Passes locally every time. Tracked in #186.
-plan skip_all => 'flaky in CI postgres container; see #186'
-    if $ENV{CI} || $ENV{GITHUB_ACTIONS};
-
 use Test::Registry::DB;
 use Test::Registry::Fixtures;
 use Registry::DAO::Subscription;

--- a/t/integration/stripe-webhook-integration.t
+++ b/t/integration/stripe-webhook-integration.t
@@ -4,10 +4,6 @@ use 5.42.0;
 use lib qw(lib t/lib);
 use Test::More;
 
-# Skip in CI: see t/dao/stripe-subscription.t for rationale. #186.
-plan skip_all => 'flaky in CI postgres container; see #186'
-    if $ENV{CI} || $ENV{GITHUB_ACTIONS};
-
 use Registry::DAO;
 use Registry::Controller::Webhooks;
 use Test::Registry::DB;

--- a/t/lib/Test/Registry/DB.pm
+++ b/t/lib/Test/Registry/DB.pm
@@ -8,11 +8,17 @@ use DBI ();
 package Test::Registry::DB {
     use File::Basename qw(dirname);
     use File::Spec ();
+    use Scalar::Util ();
 
     # Path to the pre-generated schema dump (relative to repo root)
     my $DUMP_FILE = File::Spec->catfile(
         dirname(__FILE__), '..', '..', '..', '..', 'sql', 'test-schema.sql'
     );
+
+    # Live instances, tracked weakly so the END block below can stop their
+    # ephemeral postgres servers deterministically -- before global
+    # destruction -- and keep teardown noise out of the process exit code.
+    my @LIVE_INSTANCES;
 
     sub _find_pg_tool {
         my ($tool) = @_;
@@ -69,6 +75,10 @@ package Test::Registry::DB {
 
         $self->_fix_pricing_validation_trigger();
         $ENV{DB_URL} = $self->{pgsql}->uri;
+
+        push @LIVE_INSTANCES, $self;
+        Scalar::Util::weaken( $LIVE_INSTANCES[-1] );
+
         return $self;
     }
 
@@ -104,7 +114,40 @@ package Test::Registry::DB {
     sub cleanup_test_database {
         my $self = shift;
         if ($self->{pgsql}) {
+            # Silence DBD::Pg destructors before stopping the server, so cached
+            # statement/connection handles destroyed afterwards don't print
+            # "terminating connection due to administrator command" noise.
+            _neutralize_dbi_handles();
+            # Stopping the server reaps the postmaster; localize $? so a
+            # non-zero reap status cannot leak into the process exit code,
+            # which prove would treat as a failed test file. See issue #186.
+            local $?;
             undef $self->{pgsql};
+        }
+    }
+
+    # Mark every open DBI connection InactiveDestroy so DBD::Pg's destructors
+    # never execute against an about-to-stop server and emit "terminating
+    # connection due to administrator command" -- noise that dirties the exit
+    # code. See issue #186.
+    sub _neutralize_dbi_handles {
+        DBI->visit_handles(sub {
+            my $h = shift;
+            $h->{InactiveDestroy} = 1 if ( $h->{Type} // '' ) eq 'db';
+            return 1;
+        });
+    }
+
+    # Deterministic teardown at process exit. This runs before global
+    # destruction, so we control the order: first silence the DBI handles,
+    # then stop each ephemeral server under local $?. Without this, teardown
+    # noise dirties the exit code and prove fails an otherwise-passing test
+    # file -- the root cause behind #186.
+    END {
+        local $?;
+        _neutralize_dbi_handles();
+        for my $instance ( grep { defined } @LIVE_INSTANCES ) {
+            $instance->cleanup_test_database;
         }
     }
 

--- a/t/robustness/db-teardown-clean-exit.t
+++ b/t/robustness/db-teardown-clean-exit.t
@@ -1,0 +1,81 @@
+#!/usr/bin/env perl
+# ABOUTME: Regression test for the Test::Registry::DB teardown-order exit-code bug (#186).
+# ABOUTME: Verifies handles are neutralized at exit so the ephemeral server stop can't dirty $?.
+
+use 5.42.0;
+use warnings;
+
+use lib qw(lib t/lib);
+use Test::More;
+use Test::Registry::DB;
+
+# Background: under the CI postgres environment, a DBD::Pg connection handle
+# destroyed against an about-to-stop (or already terminated) server emits
+# "terminating connection due to administrator command" / "no connection to
+# the server" and dirties the process exit code. prove then reports the test
+# file as failed even though every assertion passed. This was the root cause
+# behind the chronically-skipped Stripe tests (#186).
+#
+# Test::Registry::DB defends against this by marking all open DBI connection
+# handles InactiveDestroy at process exit (before global destruction), so the
+# handle destructors never talk to the server. These tests pin that behaviour.
+
+subtest 'teardown marks db handles InactiveDestroy' => sub {
+    my $t   = Test::Registry::DB->new;
+    my $dao = $t->db;
+    my $dbh = $dao->db->dbh;
+
+    ok( !$dbh->{InactiveDestroy}, 'db handle is active during the test' );
+
+    Test::Registry::DB::_neutralize_dbi_handles();
+
+    ok( $dbh->{InactiveDestroy},
+        'neutralize marks the db handle InactiveDestroy so DESTROY is silent' );
+};
+
+# Invariant check: a process that retains a DB handle and stops the ephemeral
+# server must still exit cleanly, with no DBD::Pg teardown noise on stderr.
+subtest 'child process exits cleanly after server teardown' => sub {
+    use File::Temp qw(tempfile);
+
+    my $child = <<'PERL';
+use lib qw(lib t/lib);
+use Test::Registry::DB;
+
+my $t   = Test::Registry::DB->new;
+my $dao = $t->db;
+my $db  = $dao->db;              # retained Mojo::Pg connection
+$db->query('SELECT 1');          # connection is live
+$db->query('BEGIN');             # leave a transaction open so teardown must
+$db->query('CREATE TEMP TABLE t (x int)');   # roll back against the server
+
+$t->cleanup_test_database;       # stop the ephemeral server while $db is open
+exit 0;                          # $db destroyed during exit, server already gone
+PERL
+
+    my ( $fh, $script ) = tempfile( SUFFIX => '.pl', UNLINK => 1 );
+    print {$fh} $child;
+    close $fh;
+
+    my $stderr_file = "$script.err";
+    my $status      = system("$^X $script 2>$stderr_file");
+    my $exit        = $status >> 8;
+
+    my $stderr = do {
+        open my $e, '<', $stderr_file or die "open $stderr_file: $!";
+        local $/;
+        <$e>;
+    } // '';
+    unlink $stderr_file;
+
+    is( $exit, 0, 'child process exits 0 after DB teardown' )
+        or diag "child stderr:\n$stderr";
+
+    unlike(
+        $stderr,
+        qr/no connection to the server|terminating connection due to administrator command/,
+        'no DBD::Pg teardown noise on child stderr'
+    ) or diag "child stderr:\n$stderr";
+};
+
+done_testing;


### PR DESCRIPTION
Closes #186.

## Root cause

The two Stripe tests weren't flaky because of Stripe, Minion, or a connection leak. When an ephemeral `Test::PostgreSQL` server is stopped while a `Mojo::Pg` connection is still open, the DBD::Pg handles destroyed afterwards print `terminating connection due to administrator command` / `no connection to the server` and leave a **non-zero exit status** behind. `prove` reads that status and marks the file as failed even though every assertion passed.

The five prior attempts (TODO subtests → force `$? = 0` → `POSIX::_exit` → flush + `_exit` → `skip_all`) all fought the exit code instead of the teardown order. The Stripe tests were the ones that surfaced it because they retain several long-lived DAO/db handles and let teardown happen during global destruction, where the order is racy — reliable in CI, hidden locally.

## Fix

`Test::Registry::DB` now tears down deterministically. Before stopping a server — both in the explicit `cleanup_test_database` path and in a new `END` block that runs ahead of global destruction — it marks every open DBI connection `InactiveDestroy` (so the destructors stay silent) and stops the server under `local $?` (so the postmaster reap can't leak into the exit code). Live instances are tracked weakly so the `END` block can reach them.

With the root cause fixed, the Stripe tests are un-skipped. CI never set `STRIPE_SECRET_KEY` (the `Subscription` DAO dies without one), so a dummy `sk_test_` key is added to the test and coverage jobs. These tests make no real Stripe calls, and a live key would be refused outside production anyway (the `#159` Payment guard).

## Verification

- Full suite: **213 files, 1955 tests, pass, exit 0.**
- A full run before the complete fix emitted `(in cleanup) DBD::Pg DESTROY failed` noise from `user-preferences.t` and `domain-verification.t` under load; with this change the run is completely clean — no `terminating connection` / `no connection to the server` anywhere.
- Stripe tests pass with `CI=true STRIPE_SECRET_KEY=sk_test_dummy`.
- New `t/robustness/db-teardown-clean-exit.t` pins the behaviour.

Note: I couldn't reproduce the exit-code symptom on my machine (it only manifests under the CI environment's timing), so this CI run is the first true end-to-end confirmation — worth a look at the test job before merge.