### PR TITLE
Quote tenant schema in search_path; stop leaking DB password in deploy logs

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -13,7 +13,10 @@ deploy_schema() {
     local target="${SQITCH_TARGET:-$DB_URL}"
     target="${target/#postgresql:/db:pg:}"
     if [ -n "$target" ]; then
-        echo "Using sqitch target: ${target%%@*}@****"
+        # Log the target with the password masked. The previous form
+        # (${target%%@*}@****) kept everything *before* the @, leaking
+        # user:password into the deploy logs. Mask just the password.
+        echo "Using sqitch target: $(echo "$target" | sed -E 's#(://[^:/@]+):[^@]*@#\1:****@#')"
         if sqitch deploy "$target"; then
             echo "Database schema deployed successfully"
         else

--- a/lib/Registry/DAO/WorkflowSteps/AttendanceCheck/MissingAttendanceProcessor.pm
+++ b/lib/Registry/DAO/WorkflowSteps/AttendanceCheck/MissingAttendanceProcessor.pm
@@ -17,8 +17,10 @@ class Registry::DAO::WorkflowSteps::AttendanceCheck::MissingAttendanceProcessor 
         
         for my $schema (@$tenant_schemas) {
             try {
-                # Set schema search path
-                $db->query("SET search_path TO $schema, registry, public");
+                # Set schema search path. Quote the tenant schema so names
+                # containing hyphens (e.g. "registry-platform") stay valid.
+                my $quoted = $db->dbh->quote_identifier($schema);
+                $db->query("SET search_path TO $quoted, registry, public");
                 
                 my $result = $self->check_tenant_missing_attendance($db, $schema);
                 $processed_count++;

--- a/lib/Registry/DAO/WorkflowSteps/AttendanceCheck/UpcomingEventProcessor.pm
+++ b/lib/Registry/DAO/WorkflowSteps/AttendanceCheck/UpcomingEventProcessor.pm
@@ -17,8 +17,10 @@ class Registry::DAO::WorkflowSteps::AttendanceCheck::UpcomingEventProcessor :isa
         
         for my $schema (@$tenant_schemas) {
             try {
-                # Set schema search path
-                $db->query("SET search_path TO $schema, registry, public");
+                # Set schema search path. Quote the tenant schema so names
+                # containing hyphens (e.g. "registry-platform") stay valid.
+                my $quoted = $db->dbh->quote_identifier($schema);
+                $db->query("SET search_path TO $quoted, registry, public");
                 
                 my $result = $self->check_tenant_upcoming_events($db, $schema);
                 $processed_count++;

--- a/t/dao/attendance-check-search-path.t
+++ b/t/dao/attendance-check-search-path.t
@@ -1,0 +1,71 @@
+#!/usr/bin/env perl
+# ABOUTME: Regression test for tenant schema search_path quoting in AttendanceCheck steps.
+# ABOUTME: A tenant schema whose name contains a hyphen must not break SET search_path.
+
+use 5.42.0;
+use warnings;
+use lib qw(lib t/lib);
+use Test::More;
+use Test::Registry::DB;
+use Registry::DAO::Workflow;
+use Registry::DAO::WorkflowStep;
+use Registry::DAO::WorkflowSteps::AttendanceCheck::MissingAttendanceProcessor;
+use Registry::DAO::WorkflowSteps::AttendanceCheck::UpcomingEventProcessor;
+
+my $test_db = Test::Registry::DB->new;
+my $dao     = $test_db->db;
+my $db      = $dao->db;
+
+# A tenant schema with a hyphen -- e.g. the real "registry-platform" tenant.
+# An unquoted identifier here ("SET search_path TO registry-platform, ...")
+# is a syntax error in PostgreSQL, so the schema must be quoted.
+my $schema = 'test-hyphen-tenant';
+$db->query(qq{CREATE SCHEMA IF NOT EXISTS "$schema"});
+
+my $workflow = Registry::DAO::Workflow->create($db, {
+    name        => 'Attendance Check',
+    slug        => 'attendance-check-test',
+    description => 'Test workflow for attendance check steps',
+});
+
+Registry::DAO::WorkflowStep->create($db, {
+    workflow_id => $workflow->id,
+    slug        => 'missing',
+    class       => 'Registry::DAO::WorkflowSteps::AttendanceCheck::MissingAttendanceProcessor',
+    description => 'Missing attendance processor',
+});
+
+Registry::DAO::WorkflowStep->create($db, {
+    workflow_id => $workflow->id,
+    slug        => 'upcoming',
+    class       => 'Registry::DAO::WorkflowSteps::AttendanceCheck::UpcomingEventProcessor',
+    description => 'Upcoming event processor',
+});
+
+$workflow->update($db, { first_step => 'missing' }, { id => $workflow->id });
+
+subtest 'MissingAttendanceProcessor handles a hyphenated tenant schema' => sub {
+    my $run = $workflow->new_run($db);
+    $run->update_data($db, { tenant_schemas => [$schema] });
+
+    my $step = $workflow->get_step($db, { slug => 'missing' });
+    $step->process($db, {}, $run);
+
+    my $data = $workflow->latest_run($db)->data;
+    is( $data->{missing_attendance_processed}, 1,
+        'hyphenated schema processed (search_path did not error)' );
+};
+
+subtest 'UpcomingEventProcessor handles a hyphenated tenant schema' => sub {
+    my $run = $workflow->new_run($db);
+    $run->update_data($db, { tenant_schemas => [$schema] });
+
+    my $step = $workflow->get_step($db, { slug => 'upcoming' });
+    $step->process($db, {}, $run);
+
+    my $data = $workflow->latest_run($db)->data;
+    is( $data->{upcoming_events_processed}, 1,
+        'hyphenated schema processed (search_path did not error)' );
+};
+
+done_testing;


### PR DESCRIPTION
Two bugs found while verifying the production deploy of the recent payment/webhook hardening. The deploy itself is healthy; these are pre-existing issues surfaced in the worker/deploy logs.

## 1. Unquoted tenant schema in `SET search_path` (live bug)

The attendance-check scheduler steps interpolated the tenant schema name straight into `SET search_path TO $schema, ...`. The live `registry-platform` tenant has a hyphen, which is not a valid unquoted identifier, so **every scheduler run** failed:

```
ERROR: syntax error at or near "-"
LINE 1: SET search_path TO registry-platform, registry, public
```

The per-tenant `try/catch` swallowed the error, so the job reported success while silently skipping missing-attendance and upcoming-event processing for any hyphenated tenant. Fixed by quoting the identifier with `quote_identifier` in both `MissingAttendanceProcessor` and `UpcomingEventProcessor`.

Regression test `t/dao/attendance-check-search-path.t` processes a hyphenated schema and asserts both steps run (fails before the fix, passes after).

## 2. DB password leaked in deploy logs (security hygiene)

`docker-entrypoint.sh` logged the sqitch target as `${target%%@*}@****` — which keeps everything *before* the `@`, i.e. `user:password`, printing the Postgres password in plaintext on every deploy. Now masks just the password, keeping scheme/user/host for debugging.

## Verification

- New test red before / green after; existing `attendance-notifications.t` still passes.
- Mask logic verified: `db:pg://user:secret@host/db` → `db:pg://user:****@host/db`; unchanged when no credentials.
- Full suite runs in CI.