### PR TITLE
Payment-required decision step: drive payment-or-not by pricing, not env

### DIFF
--- a/lib/Registry/DAO/Enrollment.pm
+++ b/lib/Registry/DAO/Enrollment.pm
@@ -86,6 +86,30 @@ class Registry::DAO::Enrollment :isa(Registry::DAO::Object) {
         $db->insert( $class->table, $data, { on_conflict => undef } );
     }
 
+    # Enroll a list of children into sessions with no payment: create each active
+    # enrollment and queue its confirmation email. Shared by the free-enrollment
+    # workflow step and the Payment step's demo path. $items is an arrayref of
+    # { child_id => ..., session_id => ... }. Returns the number enrolled.
+    sub enroll_children ( $class, $db, $parent_id, $items ) {
+        require Registry::DAO::Notification;
+        my $count = 0;
+        for my $item (@$items) {
+            $class->create( $db, {
+                session_id       => $item->{session_id},
+                family_member_id => $item->{child_id},
+                parent_id        => $parent_id,
+                status           => 'active',
+            } );
+            Registry::DAO::Notification->ensure_enrollment_confirmation( $db, {
+                user_id    => $parent_id,
+                session_id => $item->{session_id},
+                child_id   => $item->{child_id},
+            } );
+            $count++;
+        }
+        return $count;
+    }
+
     method update ( $db, $data, $filter = { id => $self->id } ) {
         # Encode metadata as JSON if it's a hashref
         if (exists $data->{metadata} && ref $data->{metadata} eq 'HASH') {

--- a/lib/Registry/DAO/WorkflowSteps/CheckEnrollmentPayment.pm
+++ b/lib/Registry/DAO/WorkflowSteps/CheckEnrollmentPayment.pm
@@ -1,0 +1,25 @@
+# ABOUTME: Registration workflow decision step -- routes by whether payment is due.
+# ABOUTME: $0 enrollment total -> free-enrollment; >$0 -> payment. Independent of STRIPE_SECRET_KEY.
+use 5.42.0;
+
+use Object::Pad;
+
+class Registry::DAO::WorkflowSteps::CheckEnrollmentPayment :isa(Registry::DAO::WorkflowStep) {
+    use Registry::DAO::Payment;
+
+    method process ( $db, $form_data, $run = undef ) {
+        $run //= do { my $w = $self->workflow($db); $w->latest_run($db) };
+
+        # Whether payment is required is a property of the program's pricing, not
+        # of the deployment environment. Compute the total the same way the
+        # payment step does, then branch to the matching step.
+        my $enrollment_data = {
+            children           => $run->data->{children}           || [],
+            session_selections => $run->data->{session_selections} || {},
+        };
+        my $info  = Registry::DAO::Payment->calculate_enrollment_total( $db, $enrollment_data );
+        my $total = $info->{total} // 0;
+
+        return { next_step => $total > 0 ? 'payment' : 'free-enrollment' };
+    }
+}

--- a/lib/Registry/DAO/WorkflowSteps/FreeEnrollment.pm
+++ b/lib/Registry/DAO/WorkflowSteps/FreeEnrollment.pm
@@ -1,0 +1,22 @@
+# ABOUTME: Registration workflow step that enrolls children with no payment ($0 programs).
+# ABOUTME: Reached from CheckEnrollmentPayment when the enrollment total is zero.
+use 5.42.0;
+
+use Object::Pad;
+
+class Registry::DAO::WorkflowSteps::FreeEnrollment :isa(Registry::DAO::WorkflowStep) {
+    use Registry::DAO::Enrollment;
+
+    method process ( $db, $form_data, $run = undef ) {
+        $run //= do { my $w = $self->workflow($db); $w->latest_run($db) };
+
+        my $user_id = $run->data->{user_id} or die "No user_id in workflow data";
+        my $items   = $run->data->{enrollment_items} || [];
+
+        Registry::DAO::Enrollment->enroll_children( $db, $user_id, $items );
+
+        # Advance straight to the shared "Registration Complete" page; this step
+        # renders nothing of its own.
+        return { next_step => 'complete' };
+    }
+}

--- a/lib/Registry/DAO/WorkflowSteps/Payment.pm
+++ b/lib/Registry/DAO/WorkflowSteps/Payment.pm
@@ -222,23 +222,11 @@ method handle_payment_callback ($db, $run, $form_data) {
 
 method create_demo_enrollments ($db, $run, $form_data) {
     my $user_id = $run->data->{user_id} or die "No user_id in workflow data";
-    my $enrollment_items = $run->data->{enrollment_items} || [];
 
     require Registry::DAO::Enrollment;
-    require Registry::DAO::Notification;
-    for my $item (@$enrollment_items) {
-        Registry::DAO::Enrollment->create($db, {
-            session_id       => $item->{session_id},
-            family_member_id => $item->{child_id},
-            parent_id        => $user_id,
-            status           => 'active',
-        });
-        Registry::DAO::Notification->ensure_enrollment_confirmation($db, {
-            user_id    => $user_id,
-            session_id => $item->{session_id},
-            child_id   => $item->{child_id},
-        });
-    }
+    Registry::DAO::Enrollment->enroll_children(
+        $db, $user_id, $run->data->{enrollment_items} || []
+    );
 
     return { next_step => 'complete' };
 }

--- a/t/dao/check-enrollment-payment-workflow-step.t
+++ b/t/dao/check-enrollment-payment-workflow-step.t
@@ -1,0 +1,146 @@
+#!/usr/bin/env perl
+# ABOUTME: Tests the CheckEnrollmentPayment decision step routes by enrollment total.
+# ABOUTME: $0 total -> free-enrollment; >$0 -> payment, decoupled from STRIPE_SECRET_KEY.
+
+use 5.42.0;
+use warnings;
+use lib qw(lib t/lib);
+use Test::More;
+use Test::Registry::DB;
+use Test::Registry::Fixtures;
+use Registry::DAO::Workflow;
+use Registry::DAO::WorkflowStep;
+use Registry::DAO::User;
+use Registry::DAO::Family;
+use Registry::DAO::Session;
+use Registry::DAO::PricingPlan;
+use Registry::DAO::Project;
+use Registry::DAO::Event;
+use Registry::DAO::Location;
+
+my $test_db = Test::Registry::DB->new;
+my $dao     = $test_db->db;
+
+my $tenant = Test::Registry::Fixtures::create_tenant( $dao->db, {
+    name => 'Test Check Payment Tenant',
+    slug => 'test_check_payment',
+} );
+$dao->db->query( 'SELECT clone_schema(?)', 'test_check_payment' );
+
+$dao = Registry::DAO->new( url => $test_db->uri, schema => 'test_check_payment' );
+my $db = $dao->db;
+
+my $location = Registry::DAO::Location->create( $db, {
+    name         => 'Test Location',
+    address_info => { street_address => '123 Main St', city => 'Test City', state => 'TS', postal_code => '12345' },
+    metadata     => {},
+} );
+my $teacher = Registry::DAO::User->create( $db, {
+    name => 'Test Teacher', username => 'testteacher', email => 'teacher@test.com', user_type => 'staff',
+} );
+my $project = Registry::DAO::Project->create( $db, { name => 'Test Project', metadata => {} } );
+my $event = Registry::DAO::Event->create( $db, {
+    time => '2024-07-01 10:00:00', duration => 120,
+    location_id => $location->id, project_id => $project->id, teacher_id => $teacher->id,
+    metadata => {}, capacity => 20,
+} );
+
+# Free session ($0 pricing) and paid session ($150).
+my $free_session = Registry::DAO::Session->create( $db, {
+    name => 'Free Session', start_date => '2024-07-02', end_date => '2024-07-09', status => 'published', metadata => {},
+} );
+$free_session->add_events( $db, $event->id );
+Registry::DAO::PricingPlan->create( $db, {
+    session_id => $free_session->id, plan_name => 'Free', plan_type => 'standard', amount => 0.00,
+} );
+
+my $paid_session = Registry::DAO::Session->create( $db, {
+    name => 'Paid Session', start_date => '2024-07-16', end_date => '2024-07-23', status => 'published', metadata => {},
+} );
+$paid_session->add_events( $db, $event->id );
+Registry::DAO::PricingPlan->create( $db, {
+    session_id => $paid_session->id, plan_name => 'Standard', plan_type => 'standard', amount => 150.00,
+} );
+
+my $workflow = Registry::DAO::Workflow->create( $db, {
+    name => 'Test Check Payment Workflow', slug => 'test-check-payment-workflow',
+    description => 'Test workflow for the enrollment payment decision',
+} );
+my $selection = Registry::DAO::WorkflowStep->create( $db, {
+    workflow_id => $workflow->id, slug => 'session-selection',
+    class => 'Registry::DAO::WorkflowSteps::MultiChildSessionSelection', description => 'Session selection',
+} );
+my $check = Registry::DAO::WorkflowStep->create( $db, {
+    workflow_id => $workflow->id, slug => 'check-enrollment-payment',
+    class => 'Registry::DAO::WorkflowSteps::CheckEnrollmentPayment', description => 'Check if payment required',
+    depends_on => $selection->id,
+} );
+my $payment = Registry::DAO::WorkflowStep->create( $db, {
+    workflow_id => $workflow->id, slug => 'payment',
+    class => 'Registry::DAO::WorkflowSteps::Payment', description => 'Payment', depends_on => $check->id,
+} );
+my $free = Registry::DAO::WorkflowStep->create( $db, {
+    workflow_id => $workflow->id, slug => 'free-enrollment',
+    class => 'Registry::DAO::WorkflowSteps::FreeEnrollment', description => 'Free enrollment', depends_on => $check->id,
+} );
+Registry::DAO::WorkflowStep->create( $db, {
+    workflow_id => $workflow->id, slug => 'complete',
+    class => 'Registry::DAO::WorkflowStep', description => 'Complete', depends_on => $payment->id,
+} );
+$workflow->update( $db, { first_step => 'session-selection' }, { id => $workflow->id } );
+
+my $parent = Registry::DAO::User->create( $db, {
+    email => 'parent@example.com', username => 'testparent', password => 'password123',
+    name => 'Test Parent', user_type => 'parent',
+} );
+my $child = Registry::DAO::Family->add_child( $db, $parent->id, {
+    child_name => 'Alice Smith', birth_date => '2016-03-15', grade => '3',
+    medical_info => {}, emergency_contact => { name => 'Emergency', phone => '555-0123' },
+} );
+
+subtest 'a $0 enrollment routes to free-enrollment' => sub {
+    my $run = $workflow->new_run($db);
+    $run->update_data( $db, {
+        user_id            => $parent->id,
+        children           => [ { id => $child->id } ],
+        session_selections => { $child->id => $free_session->id },
+        enrollment_items   => [ { child_id => $child->id, session_id => $free_session->id } ],
+    } );
+    my $step   = $workflow->get_step( $db, { slug => 'check-enrollment-payment' } );
+    my $result = $step->process( $db, {}, $run );
+    is $result->{next_step}, 'free-enrollment', 'routes to free-enrollment for a $0 total';
+};
+
+subtest 'a priced enrollment routes to payment' => sub {
+    my $run = $workflow->new_run($db);
+    $run->update_data( $db, {
+        user_id            => $parent->id,
+        children           => [ { id => $child->id } ],
+        session_selections => { $child->id => $paid_session->id },
+        enrollment_items   => [ { child_id => $child->id, session_id => $paid_session->id } ],
+    } );
+    my $step   = $workflow->get_step( $db, { slug => 'check-enrollment-payment' } );
+    my $result = $step->process( $db, {}, $run );
+    is $result->{next_step}, 'payment', 'routes to payment for a >$0 total';
+};
+
+subtest 'free-enrollment step creates an active enrollment with no payment' => sub {
+    my $run = $workflow->new_run($db);
+    $run->update_data( $db, {
+        user_id          => $parent->id,
+        enrollment_items => [ { child_id => $child->id, session_id => $free_session->id } ],
+    } );
+    my $step   = $workflow->get_step( $db, { slug => 'free-enrollment' } );
+    my $result = $step->process( $db, {}, $run );
+    is $result->{next_step}, 'complete', 'free-enrollment advances to complete';
+
+    my $enrollment = $db->query(
+        'SELECT status, payment_id FROM enrollments WHERE session_id = ? AND family_member_id = ?',
+        $free_session->id, $child->id
+    )->hash;
+    ok $enrollment, 'enrollment row created';
+    is $enrollment->{status},     'active', 'enrollment is active';
+    is $enrollment->{payment_id}, undef,    'no payment associated';
+};
+
+done_testing;


### PR DESCRIPTION
First, focused piece of Phase 2 (the E2E lifecycle initiative): make "does this registration require payment?" a property of the program's **pricing**, expressed as workflow **steps**, rather than keyed off `STRIPE_SECRET_KEY`.

## What this adds
- **`CheckEnrollmentPayment`** — a decision step that computes the enrollment total (via `Registry::DAO::Payment->calculate_enrollment_total`) and returns `next_step => 'free-enrollment'` when the total is $0, or `'payment'` when > $0. No env var involved.
- **`FreeEnrollment`** — enrolls the children with no payment and advances to `complete`.
- **`Enrollment->enroll_children`** — a shared helper that creates active enrollments and queues the confirmation email. The Payment step's demo path now delegates to it (DRY; previously duplicated).

## Tests
`t/dao/check-enrollment-payment-workflow-step.t` (TDD): a $0 session routes to `free-enrollment`, a priced session routes to `payment`, and the free path creates an active enrollment with no `payment_id`. Existing payment/enrollment/registration tests still pass (the demo-path refactor is behavior-preserving).

## Deliberately scoped out (follow-up)
Wiring these steps into `summer-camp-registration.yaml` changes the live parent-registration flow and the step-by-step controller tests, and needs the workflow controller's handling of a templateless auto-advancing decision step verified end-to-end. That integration lands with the **Nancy registration E2E leg** of Phase 2, where it's browser-verified. The step classes here are unit-tested and ready to wire.

## Context
Part of the Morgan -> Nancy -> Amara lifecycle gate (Phase 1 shipped the harness in #216). The manager-setup leg also surfaced a real bug, filed separately as #218 (pricing_override never creates a linked PricingPlan).