### PR TITLE
Create a session-linked PricingPlan from pricing_override (#218)

### DIFF
--- a/lib/Registry/DAO/WorkflowSteps/GenerateEvents.pm
+++ b/lib/Registry/DAO/WorkflowSteps/GenerateEvents.pm
@@ -82,7 +82,22 @@ method create_session_for_location ($db, $project_data, $location, $params, $tea
                 notes => $location->{notes}
             }
         });
-        
+
+        # Link a pricing plan to the new session from the per-location override,
+        # so the session is actually priced and appears on the storefront. An
+        # override of 0 produces a free, registerable session. Without this the
+        # override is collected but dropped and the session has no price (#218).
+        my $override = $location->{pricing_override};
+        if ( defined $override && $override ne '' ) {
+            require Registry::DAO::PricingPlan;
+            Registry::DAO::PricingPlan->create($db, {
+                session_id => $session->id,
+                plan_name  => 'Standard',
+                plan_type  => 'standard',
+                amount     => $override + 0,
+            });
+        }
+
         # Generate events based on pattern
         my @events = $self->generate_events_for_session(
             $db, $session, $location, $params, $teacher_id

--- a/t/dao/generate-events-pricing.t
+++ b/t/dao/generate-events-pricing.t
@@ -1,0 +1,77 @@
+#!/usr/bin/env perl
+# ABOUTME: Tests that GenerateEvents creates a session-linked PricingPlan from pricing_override.
+# ABOUTME: Without this, generated sessions have no price and never appear on the storefront (#218).
+
+use 5.42.0;
+use warnings;
+use lib qw(lib t/lib);
+use Test::More;
+use Test::Registry::DB;
+use Test::Registry::Fixtures;
+use Registry::DAO::Workflow;
+use Registry::DAO::WorkflowStep;
+use Registry::DAO::WorkflowSteps::GenerateEvents;
+use Registry::DAO::User;
+use Registry::DAO::Project;
+use Registry::DAO::Location;
+
+my $test_db = Test::Registry::DB->new;
+my $dao     = $test_db->db;
+
+my $tenant = Test::Registry::Fixtures::create_tenant( $dao->db, {
+    name => 'Test Generate Events Pricing', slug => 'test_gen_pricing',
+} );
+$dao->db->query( 'SELECT clone_schema(?)', 'test_gen_pricing' );
+$dao = Registry::DAO->new( url => $test_db->uri, schema => 'test_gen_pricing' );
+my $db = $dao->db;
+
+my $location = Registry::DAO::Location->create( $db, {
+    name         => 'Test Location',
+    address_info => { street_address => '1 Main', city => 'Town', state => 'TS', postal_code => '12345' },
+    metadata     => {},
+} );
+my $teacher = Registry::DAO::User->create( $db, {
+    name => 'Teacher', username => 'teacher_gp', email => 'teacher_gp@test.com', user_type => 'staff',
+} );
+my $project = Registry::DAO::Project->create( $db, { name => 'Free Program', metadata => {} } );
+
+# Build a workflow with the generate-events step so we can call its methods.
+my $workflow = Registry::DAO::Workflow->create( $db, {
+    name => 'Test GenEvents', slug => 'test-gen-events', description => 'test',
+} );
+Registry::DAO::WorkflowStep->create( $db, {
+    workflow_id => $workflow->id, slug => 'generate-events',
+    class => 'Registry::DAO::WorkflowSteps::GenerateEvents', description => 'Generate events',
+} );
+my $step = $workflow->get_step( $db, { slug => 'generate-events' } );
+
+my $project_data = {
+    project_id          => $project->id,
+    project_name        => $project->name,
+    project_description => 'A free program',
+};
+my $location_config = {
+    id               => $location->id,
+    name             => $location->name,
+    capacity         => 16,
+    schedule         => { monday => '15:00' },
+    pricing_override => 0,            # free
+    notes            => '',
+};
+my $params = { start_date => time(), duration_weeks => 1 };
+
+my $result = $step->create_session_for_location( $db, $project_data, $location_config, $params, $teacher->id );
+
+ok !$result->{error}, 'session generated without error'
+    or diag $result->{error};
+ok $result->{session_id}, 'a session was created';
+
+# Pricing plans live in the registry schema (Registry::DAO::PricingPlan::create).
+my $plan = $db->query(
+    'SELECT * FROM registry.pricing_plans WHERE session_id = ?', $result->{session_id}
+)->hash;
+
+ok $plan, 'a PricingPlan is linked to the generated session';
+is( ( $plan->{amount} // -1 ) + 0, 0, 'plan amount matches the pricing_override (free)' );
+
+done_testing;


### PR DESCRIPTION
Closes #218.

## Problem
`GenerateEvents::create_session_for_location` collected the per-location `pricing_override` but stored it only in the session's `metadata` JSONB. It never created a `registry.pricing_plans` row linked to the session, so generated sessions had no price and never appeared on the tenant storefront. A manager could not produce a priced (or explicitly free) registerable session through the UI.

## Fix
After creating the session, create a `PricingPlan` linked to it from the override (when one is provided). `pricing_override => 0` yields a free, registerable session.

## Test
`t/dao/generate-events-pricing.t` (TDD): generating a session with `pricing_override => 0` now creates a linked `registry.pricing_plans` row with amount 0. Existing program-location-assignment / teacher-assignment / program-setup tests still pass.

## Context
Unblocks the "Morgan builds a free program" leg of the Phase 2 lifecycle E2E.