### PR TITLE
Fix program-location-assignment templates that 500 on render

### DIFF
--- a/templates/program-location-assignment/choose-locations.html.ep
+++ b/templates/program-location-assignment/choose-locations.html.ep
@@ -8,7 +8,7 @@
         <h2 class="text-2xl font-semibold mb-4">Choose Locations for <%= stash('step_data')->{project_name} %></h2>
         <p class="text-gray-600 mb-6">Select one or more locations where this program will be offered. You'll configure specific details for each location in the next step.</p>
 
-        <form method="POST" action="<%= url_for('workflow_step', workflow_id => $workflow->id, run_id => $run->id, step_id => 'choose-locations') %>">
+        <form method="POST" action="<%= $action %>">
             <div class="space-y-4">
                 <% my $locations = stash('step_data')->{locations} || []; %>
                 <% for my $location (@$locations) { %>
@@ -39,7 +39,7 @@
             </div>
 
             <div class="mt-6 flex justify-between">
-                <a href="<%= url_for('workflow_step', workflow_id => $workflow->id, run_id => $run->id, step_id => 'select-program') %>"
+                <a href="<%= url_for('workflow_step', workflow => $workflow, run => $run->id, step => 'select-program') %>"
                    class="bg-gray-300 text-gray-700 px-6 py-2 rounded hover:bg-gray-400">
                     Back
                 </a>

--- a/templates/program-location-assignment/configure-location.html.ep
+++ b/templates/program-location-assignment/configure-location.html.ep
@@ -8,7 +8,7 @@
         <h2 class="text-2xl font-semibold mb-4">Configure Location Details for <%= stash('step_data')->{project_name} %></h2>
         <p class="text-gray-600 mb-6">Set specific capacity, schedule, and pricing for each selected location.</p>
 
-        <form method="POST" action="<%= url_for('workflow_step', workflow_id => $workflow->id, run_id => $run->id, step_id => 'configure-location') %>">
+        <form method="POST" action="<%= $action %>">
             <% my $selected_locations = stash('step_data')->{selected_locations} || []; %>
             <% my $standard_times = stash('step_data')->{standard_times} || {}; %>
             <% my $program_type_config = stash('step_data')->{program_type_config} || {}; %>
@@ -102,7 +102,7 @@
             </div>
 
             <div class="mt-8 flex justify-between">
-                <a href="<%= url_for('workflow_step', workflow_id => $workflow->id, run_id => $run->id, step_id => 'choose-locations') %>"
+                <a href="<%= url_for('workflow_step', workflow => $workflow, run => $run->id, step => 'choose-locations') %>"
                    class="bg-gray-300 text-gray-700 px-6 py-2 rounded hover:bg-gray-400">
                     Back
                 </a>

--- a/templates/program-location-assignment/generate-events.html.ep
+++ b/templates/program-location-assignment/generate-events.html.ep
@@ -30,7 +30,7 @@
             </div>
         </div>
 
-        <form method="POST" action="<%= url_for('workflow_step', workflow_id => $workflow->id, run_id => $run->id, step_id => 'generate-events') %>">
+        <form method="POST" action="<%= $action %>">
             <!-- Generation Parameters -->
             <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
                 <div>
@@ -110,7 +110,7 @@
             </div>
 
             <div class="flex justify-between">
-                <a href="<%= url_for('workflow_step', workflow_id => $workflow->id, run_id => $run->id, step_id => 'configure-location') %>"
+                <a href="<%= url_for('workflow_step', workflow => $workflow, run => $run->id, step => 'configure-location') %>"
                    class="bg-gray-300 text-gray-700 px-6 py-2 rounded hover:bg-gray-400">
                     Back
                 </a>

--- a/templates/program-location-assignment/select-program.html.ep
+++ b/templates/program-location-assignment/select-program.html.ep
@@ -8,7 +8,7 @@
         <h2 class="text-2xl font-semibold mb-4">Select Program</h2>
         <p class="text-gray-600 mb-6">Choose an existing program to assign to one or more locations.</p>
 
-        <form method="POST" action="<%= url_for('workflow_step', workflow_id => $workflow->id, run_id => $run->id, step_id => 'select-program') %>">
+        <form method="POST" action="<%= $action %>">
             <div class="space-y-4">
                 <% my $projects = stash('step_data')->{projects} || []; %>
                 <% for my $project (@$projects) { %>


### PR DESCRIPTION
The `program-location-assignment` workflow (a core manager flow: assign a program to locations and generate sessions) **500s on every step's render** and has, as far as I can tell, never worked through the UI.

## Cause
The four step templates build their form `action` and back-link URLs as:
```perl
url_for('workflow_step', workflow_id => $workflow->id, run_id => $run->id, step_id => '...')
```
But the controller stashes `workflow` as the **slug string** (not an object), so `$workflow->id` dies with `Can't locate object method "id" via package "program-location-assignment"`. The `url_for` param names are also wrong (`workflow_id`/`run_id`/`step_id` vs. the route's `workflow`/`run`/`step`).

## Fix
- Form posts use the controller-provided `$action` (the correct POST URL), matching the working `program-creation` templates.
- Back-links use `url_for('workflow_step', workflow => $workflow, run => $run->id, step => '...')` with correct params.

Affects `select-program`, `choose-locations`, `configure-location`, `generate-events`.

## How it was found
Building the Phase 2 lifecycle E2E (the "Morgan builds a program" leg). With this fixed, the workflow's pages render and the program-creation portion of the manager flow works end-to-end; the remaining program-location-assignment behaviour and the full Morgan E2E are a tracked follow-up.