### PR TITLE
Fix expired date fixtures breaking storefront tests on main

### DIFF
--- a/t/controller/landing-page-cta.t
+++ b/t/controller/landing-page-cta.t
@@ -17,6 +17,7 @@ use Registry;
 use Registry::DAO qw(Workflow);
 use Mojo::Home;
 use YAML::XS qw(Load);
+use DateTime;
 
 # Setup test database for app initialization
 my $t_db = Test::Registry::DB->new;
@@ -58,17 +59,22 @@ my $program = $db->create(Project => { status => 'published',
 
 my $teacher = $db->create(User => { username => 'cta_teacher', user_type => 'staff' });
 
+# Compute future dates relative to today so this test remains valid over time
+my $today        = DateTime->now;
+my $future_start = $today->clone->add(days => 30)->ymd;
+my $future_end   = $today->clone->add(days => 37)->ymd;
+
 my $session = $db->create(Session => {
     name       => 'CTA Test Session',
-    start_date => '2026-06-01',
-    end_date   => '2026-06-05',
+    start_date => $future_start,
+    end_date   => $future_end,
     status     => 'published',
     capacity   => 16,
     metadata   => {},
 });
 
 my $event = $db->create(Event => {
-    time        => '2026-06-01 09:00:00',
+    time        => "$future_start 09:00:00",
     duration    => 420,
     location_id => $location->id,
     project_id  => $program->id,

--- a/t/controller/tenant-storefront.t
+++ b/t/controller/tenant-storefront.t
@@ -20,6 +20,7 @@ use Registry::DAO::Enrollment;
 use Mojo::Home;
 use Mojo::JSON qw(encode_json);
 use YAML::XS qw(Load);
+use DateTime;
 
 # Ensure demo payment mode
 delete $ENV{STRIPE_SECRET_KEY};
@@ -64,18 +65,25 @@ my $program = $dao->create(Project => { status => 'published',
 
 my $teacher = $dao->create(User => { username => 'sf_teacher', user_type => 'staff' });
 
+# Compute future dates relative to today so this test remains valid over time
+my $today        = DateTime->now;
+my $future_start = $today->clone->add(days => 30)->ymd;
+my $future_end   = $today->clone->add(days => 37)->ymd;
+my $full_start   = $today->clone->add(days => 45)->ymd;
+my $full_end     = $today->clone->add(days => 52)->ymd;
+
 # Open session with capacity
 my $session1 = $dao->create(Session => {
-    name       => 'Week 1 - Jun 1-5',
-    start_date => '2026-06-01',
-    end_date   => '2026-06-05',
+    name       => 'Week 1 - Open',
+    start_date => $future_start,
+    end_date   => $future_end,
     status     => 'published',
     capacity   => 16,
     metadata   => {},
 });
 
 my $event1 = $dao->create(Event => {
-    time        => '2026-06-01 09:00:00',
+    time        => "$future_start 09:00:00",
     duration    => 420,
     location_id => $location->id,
     project_id  => $program->id,
@@ -94,16 +102,16 @@ $dao->create(PricingPlan => {
 
 # Full session (capacity 2, filled)
 my $session_full = $dao->create(Session => {
-    name       => 'Week 3 - Jun 15-19',
-    start_date => '2026-06-15',
-    end_date   => '2026-06-19',
+    name       => 'Week 3 - Full',
+    start_date => $full_start,
+    end_date   => $full_end,
     status     => 'published',
     capacity   => 2,
     metadata   => {},
 });
 
 my $event_full = $dao->create(Event => {
-    time        => '2026-06-15 09:00:00',
+    time        => "$full_start 09:00:00",
     duration    => 420,
     location_id => $location->id,
     project_id  => $program->id,
@@ -176,7 +184,7 @@ subtest 'only published sessions with future dates shown' => sub {
       ->status_is(200);
 
     # Published programs with sessions appear (dates visible)
-    $t->content_like(qr/2026-06-01/, 'Published session dates visible');
+    $t->content_like(qr/\Q$future_start\E/, 'Published session dates visible');
 
     # Draft session does NOT appear
     $t->content_unlike(qr/Draft Session/, 'Draft session not visible');

--- a/t/dao/program-listing-filters.t
+++ b/t/dao/program-listing-filters.t
@@ -15,6 +15,7 @@ use Registry::DAO::ProgramType;
 use Registry::DAO::WorkflowSteps::ProgramListing;
 use Mojo::Home;
 use YAML::XS qw(Load);
+use DateTime;
 
 my $test_db = Test::Registry::DB->new;
 my $dao     = $test_db->db;
@@ -115,6 +116,11 @@ my $evt_sunset = $dao->create(Event => {
 });
 $sess_sunset->add_events($dao->db, $evt_sunset->id);
 
+# Compute future dates relative to today so this test remains valid over time
+my $today      = DateTime->now;
+my $camp_start = $today->clone->add(days => 30)->ymd;
+my $camp_end   = $today->clone->add(days => 37)->ymd;
+
 # Summer camp (different program type, at Lincoln)
 my $prog_camp = $dao->create(Project => { status => 'published',
     name              => 'Summer Art Camp',
@@ -127,15 +133,15 @@ my $prog_camp = $dao->create(Project => { status => 'published',
 my $sess_camp = $dao->create(Session => {
     name       => 'Week 1 - June',
     slug       => 'week1-june-filter',
-    start_date => '2026-06-01',
-    end_date   => '2026-06-05',
+    start_date => $camp_start,
+    end_date   => $camp_end,
     status     => 'published',
     capacity   => 16,
     metadata   => {},
 });
 
 my $evt_camp = $dao->create(Event => {
-    time        => '2026-06-01 09:00:00',
+    time        => "$camp_start 09:00:00",
     duration    => 420,
     location_id => $loc_lincoln->id,
     project_id  => $prog_camp->id,

--- a/t/e2e/full-onboarding-pipeline.t
+++ b/t/e2e/full-onboarding-pipeline.t
@@ -29,6 +29,7 @@ use Registry::DAO::Enrollment;
 use Registry::DAO::WorkflowSteps::RegisterTenant;
 use Mojo::Home;
 use YAML::XS qw(Load);
+use DateTime;
 
 # Ensure demo payment mode
 delete $ENV{STRIPE_SECRET_KEY};
@@ -135,11 +136,16 @@ subtest 'admin creates location, program, session, events, pricing' => sub {
     });
     ok $program, 'Program created';
 
+    # Compute future dates relative to today so this test remains valid over time
+    my $today        = DateTime->now;
+    my $future_start = $today->clone->add(days => 30)->ymd;
+    my $future_end   = $today->clone->add(days => 37)->ymd;
+
     # Create session
     my $session = Registry::DAO::Session->create($db, {
         name       => 'Week 1 - Jun 1-5',
-        start_date => '2026-06-01',
-        end_date   => '2026-06-05',
+        start_date => $future_start,
+        end_date   => $future_end,
         status     => 'published',
         capacity   => 16,
         metadata   => {},
@@ -148,7 +154,7 @@ subtest 'admin creates location, program, session, events, pricing' => sub {
 
     # Create event and link to session
     my $event = Registry::DAO::Event->create($db, {
-        time        => '2026-06-01 09:00:00',
+        time        => "$future_start 09:00:00",
         duration    => 420,
         location_id => $location->id,
         project_id  => $program->id,

--- a/t/e2e/tenant-onboarding.t
+++ b/t/e2e/tenant-onboarding.t
@@ -25,6 +25,7 @@ use Registry::DAO::Enrollment;
 use Registry::DAO::WorkflowRun;
 use Mojo::Home;
 use YAML::XS qw(Load);
+use DateTime;
 
 # Ensure demo payment mode
 delete $ENV{STRIPE_SECRET_KEY};
@@ -75,17 +76,22 @@ subtest 'tenant has programs and sessions' => sub {
         username => 'camp_instructor', user_type => 'staff',
     });
 
+    # Compute future dates relative to today so this test remains valid over time
+    my $today        = DateTime->now;
+    my $future_start = $today->clone->add(days => 30)->ymd;
+    my $future_end   = $today->clone->add(days => 37)->ymd;
+
     my $session = $dao->create(Session => {
         name       => 'Week 1 - Jun 1-5',
-        start_date => '2026-06-01',
-        end_date   => '2026-06-05',
+        start_date => $future_start,
+        end_date   => $future_end,
         status     => 'published',
         capacity   => 16,
         metadata   => {},
     });
 
     my $event = $dao->create(Event => {
-        time        => '2026-06-01 09:00:00',
+        time        => "$future_start 09:00:00",
         duration    => 420,
         location_id => $location->id,
         project_id  => $program->id,


### PR DESCRIPTION
## Summary

Fixes the pre-existing `test`-job failures that were red on `main` (and therefore on every PR). Root cause: **expired date fixtures**, not a logic bug.

Several storefront tests hardcoded a "future" published session with `start_date => '2026-06-01'`, `end_date => '2026-06-05'`. The public storefront listing query (`ProgramListing`) filters `WHERE s.end_date >= CURRENT_DATE`. As of 2026-06-06 those `end_date`s are in the **past**, so the sessions are filtered out and every "program is visible / registerable on the storefront" assertion fails.

## Fix

Compute fixture dates relative to `now` (`DateTime->now->add(days => …)->ymd`) so the suite is stable over time, and update the one assertion that checked a literal date string (`tenant-storefront.t`) to match the computed value. Tests that intentionally assert *hidden* sessions keep a clearly-past/draft session.

Files:
- `t/controller/tenant-storefront.t`
- `t/controller/landing-page-cta.t`
- `t/dao/program-listing-filters.t` (#227)
- `t/e2e/tenant-onboarding.t`
- `t/e2e/full-onboarding-pipeline.t`

## Verification

All five pass individually (verified locally). `t/dao/payment-failure-recovery.t` — which logged `no connection to the server` in CI — passes locally, so that error is CI-parallelism/DB-teardown flakiness (`createdb: database "registry_test" already exists`, `terminating connection due to administrator command`), not a code regression. If it recurs in this PR's CI run, it's infra to address separately.

## Notes

The same `2026-06-05` time-bomb literal appears in other tests (e.g. `camp-registration-*`, `drop-request`, `admin-drop-approval`) that enroll/drop directly and don't go through the storefront date filter, so they aren't failing today — but they're latent time-bombs. Left untouched here to keep this PR focused on the actually-failing CI tests; worth a follow-up sweep.

Unblocks the `test` job for #228 (program-location-assignment repair) and #231 (tenant isolation foundation).
