### PR TITLE
HOTFIX: apex-domain tenant resolution (production 500)

### DIFF
--- a/docs/superpowers/specs/2026-06-08-apex-domain-tenant-resolution-design.md
+++ b/docs/superpowers/specs/2026-06-08-apex-domain-tenant-resolution-design.md
@@ -26,11 +26,12 @@ knowing the platform base domain(s) to tell a subdomain from the apex.
 
 ## Fix
 
-### 1. Configurable base domains
-New env `REGISTRY_BASE_DOMAINS`: comma-separated platform domains under which wildcard tenant
-subdomains are served. Default `localhost` (dev/tests). Production sets `tinyartempire.com`
-(the list accommodates future bases — staging, additional apexes — without code change).
-Parsed once; lowercased; empty entries ignored.
+### 1. Configurable base domains (with a production-correct default)
+Base domains default to `tinyartempire.com,localhost` in code, so **production is fixed by
+merging alone** — no env var to set or forget. `REGISTRY_BASE_DOMAINS` (comma-separated)
+overrides the default for other environments (e.g. staging, additional apexes). Lowercased;
+empty entries ignored. `localhost` stays in the default so the `<slug>.localhost` test
+convention keeps working.
 
 ### 2. Base-domain-aware `_extract_tenant_from_subdomain`
 Replace "first label of anything" with base-relative extraction:
@@ -62,9 +63,9 @@ per-request custom-domain query. Positive results may be cached in-process to bo
 (only cache "exists"; never cache "missing", so a newly-provisioned schema is picked up).
 
 ### 4. Deploy
-Set `REGISTRY_BASE_DOMAINS=tinyartempire.com` in the Render web service env. The code default
-`localhost` keeps the test suite green without env changes. (Deploy is a manual step recorded
-in the PR; restoring prod requires both the code AND this env value.)
+Merge and redeploy — that's it. `tinyartempire.com` is the built-in default, so no env var
+is required to restore production. Only set `REGISTRY_BASE_DOMAINS` if additional base
+domains (e.g. a staging apex) need to serve wildcard subdomains.
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-06-08-apex-domain-tenant-resolution-design.md
+++ b/docs/superpowers/specs/2026-06-08-apex-domain-tenant-resolution-design.md
@@ -1,0 +1,85 @@
+# Apex-Domain Tenant Resolution — Design (prod hotfix)
+
+ABOUTME: Fix for production 500s where the platform apex domain mis-resolves as a tenant.
+ABOUTME: Base-domain-aware subdomain extraction + defensive schema-existence fallback.
+
+- Status: Approved (compressed ceremony — live prod incident)
+- Date: 2026-06-08
+- Severity: production outage (tinyartempire.com → HTTP 500 on workflow routes)
+- Regression exposed by: #231 (controllers switched to `$self->dao`); latent bug in
+  `_extract_tenant_from_subdomain`. Related: #41 / #230 (domain/tenant resolution).
+
+## Problem
+
+`tinyartempire.com/` and `/tenant-signup` return HTTP 500 (`relation "workflows" does not
+exist`); `/health` is 200. Root cause: the tenant resolver's `_extract_tenant_from_subdomain`
+takes the first DNS label of ANY host, so the apex `tinyartempire.com` resolves to a tenant
+slug `tinyartempire`. `$self->dao` then connects with `schema => tinyartempire` (a schema
+that does not exist), and workflow-driven routes fail on `SELECT * FROM workflows`. Because
+subdomain extraction runs before the custom-domain lookup and sets `$raw`, the custom-domain
+fallback is skipped. Before #231 (`$self->app->dao`, always `registry`) the mis-resolution
+was harmless; #231 made it fatal.
+
+Production serves BOTH wildcard tenant subdomains (`<slug>.tinyartempire.com`) AND verified
+custom domains, so subdomain extraction must keep working for real hosts — which requires
+knowing the platform base domain(s) to tell a subdomain from the apex.
+
+## Fix
+
+### 1. Configurable base domains
+New env `REGISTRY_BASE_DOMAINS`: comma-separated platform domains under which wildcard tenant
+subdomains are served. Default `localhost` (dev/tests). Production sets `tinyartempire.com`
+(the list accommodates future bases — staging, additional apexes — without code change).
+Parsed once; lowercased; empty entries ignored.
+
+### 2. Base-domain-aware `_extract_tenant_from_subdomain`
+Replace "first label of anything" with base-relative extraction:
+- lowercase host, strip port; return undef for IPs.
+- For each configured base `B`: if `host eq B` → undef (apex, no subdomain); if
+  `host =~ /\A([^.]+)\.\Q$B\E\z/` → return that single label, unless it is `www`.
+- Host under no known base (a custom domain, or unknown) → undef.
+
+Resulting behavior (base set `{tinyartempire.com, localhost}`):
+| Host | Result |
+| --- | --- |
+| `tinyartempire.com` | undef → custom-domain lookup → `registry` (FIXES PROD) |
+| `acme.tinyartempire.com` | `acme` |
+| `www.tinyartempire.com` | undef → `registry` |
+| `localhost` | undef → `registry` |
+| `spike1.localhost` | `spike1` (test convention preserved) |
+| `someones-custom-domain.com` | undef → TenantDomain table → its tenant |
+| `127.0.0.1` | undef → `registry` |
+
+Resolution ORDER is otherwise unchanged: explicit param → X-As-Tenant (authed) →
+subdomain (now base-aware) → custom-domain table → `registry` default.
+
+### 3. Defensive schema-existence fallback
+In the `tenant` helper, when the resolved slug is non-`registry`, verify its Postgres schema
+exists; if not, log a warning and return `registry`. This degrades gracefully (serve the
+platform site) instead of a hard 500 if resolution ever misfires again. One catalog lookup
+(`information_schema.schemata`) on the non-registry path, consistent with the already-accepted
+per-request custom-domain query. Positive results may be cached in-process to bound cost
+(only cache "exists"; never cache "missing", so a newly-provisioned schema is picked up).
+
+### 4. Deploy
+Set `REGISTRY_BASE_DOMAINS=tinyartempire.com` in the Render web service env. The code default
+`localhost` keeps the test suite green without env changes. (Deploy is a manual step recorded
+in the PR; restoring prod requires both the code AND this env value.)
+
+## Testing
+
+- Unit test the resolver (`tenant` helper / `_extract_tenant_from_subdomain`) across every
+  host class in the table above, with a multi-base configuration, asserting apex → registry
+  and `<slug>.base` → slug.
+- Test the defensive fallback: a host resolving to a non-existent schema → `registry`, no
+  exception.
+- Integration: `GET /` with `Host: tinyartempire.com` (base configured) renders 200, not 500
+  — the exact regression. (Use Test::Mojo with the base-domain env set.)
+
+## Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| Base list misconfigured in prod (omits a live base) → those subdomains resolve to registry | PR documents the required env; deploy step explicit; default keeps tests safe |
+| Schema-existence check adds per-request cost | Cheap catalog query on non-registry path only; cache positives |
+| A real custom domain equal to `X.<base>` | Custom domains are not provisioned under the platform base; out of scope |

--- a/lib/Registry.pm
+++ b/lib/Registry.pm
@@ -836,14 +836,16 @@ class Registry :isa(Mojolicious) {
         }
     }
 
-    # Platform base domains under which wildcard tenant subdomains are served,
-    # from REGISTRY_BASE_DOMAINS (comma-separated). Defaults to 'localhost' for
-    # dev/tests; production sets e.g. 'tinyartempire.com'. The list lets us tell a
-    # tenant subdomain (<slug>.<base>) from the platform apex (<base> itself) and
-    # from custom domains (under no base) -- without it the apex domain's own
-    # label is wrongly taken as a tenant slug.
+    # Platform base domains under which wildcard tenant subdomains are served.
+    # Defaults to the platform's own domains so production works with no extra
+    # configuration; REGISTRY_BASE_DOMAINS (comma-separated) overrides the default
+    # for other environments (e.g. staging). The list lets us tell a tenant
+    # subdomain (<slug>.<base>) from the platform apex (<base> itself) and from
+    # custom domains (under no base) -- without it the apex domain's own label is
+    # wrongly taken as a tenant slug. 'localhost' is included so the test
+    # convention <slug>.localhost keeps working.
     method _base_domains {
-        my $raw = $ENV{REGISTRY_BASE_DOMAINS} // 'localhost';
+        my $raw = $ENV{REGISTRY_BASE_DOMAINS} // 'tinyartempire.com,localhost';
         return grep { length } map { s/^\s+|\s+$//gr } map { lc } split /,/, $raw;
     }
 

--- a/lib/Registry.pm
+++ b/lib/Registry.pm
@@ -216,6 +216,33 @@ class Registry :isa(Mojolicious) {
                 # Sanitize: tenant slugs must be safe SQL identifiers
                 return 'registry' unless $raw =~ /\A[a-z][a-z0-9_]{0,62}\z/;
 
+                return $raw if $raw eq 'registry';
+
+                # Defensive fallback: if the resolved tenant has no Postgres
+                # schema, degrade to the registry/platform site instead of
+                # letting a "relation does not exist" 500 escape. Cache positive
+                # (schema-exists) results per process to bound the catalog query
+                # to once per valid tenant; never cache a miss, so a freshly
+                # provisioned schema is picked up on its next request.
+                state %schema_exists;
+                unless ( $schema_exists{$raw} ) {
+                    my $found = eval {
+                        my $registry_dao = $c->dao('registry');
+                        $registry_dao->db->query(
+                            'SELECT 1 FROM information_schema.schemata WHERE schema_name = ?',
+                            $raw
+                        )->rows;
+                    };
+                    if ($found) {
+                        $schema_exists{$raw} = 1;
+                    }
+                    else {
+                        $c->app->log->warn(
+                            "tenant '$raw' resolved but has no schema; serving registry");
+                        return 'registry';
+                    }
+                }
+
                 return $raw;
             }
         );
@@ -797,18 +824,36 @@ class Registry :isa(Mojolicious) {
         }
     }
 
+    # Platform base domains under which wildcard tenant subdomains are served,
+    # from REGISTRY_BASE_DOMAINS (comma-separated). Defaults to 'localhost' for
+    # dev/tests; production sets e.g. 'tinyartempire.com'. The list lets us tell a
+    # tenant subdomain (<slug>.<base>) from the platform apex (<base> itself) and
+    # from custom domains (under no base) -- without it the apex domain's own
+    # label is wrongly taken as a tenant slug.
+    method _base_domains {
+        my $raw = $ENV{REGISTRY_BASE_DOMAINS} // 'localhost';
+        return grep { length } map { s/^\s+|\s+$//gr } map { lc } split /,/, $raw;
+    }
+
     method _extract_tenant_from_subdomain ($c) {
-        my $host = $c->req->headers->host || '';
+        my $host = lc( $c->req->headers->host || '' );
         # Remove port if present
         $host =~ s/:\d+$//;
 
         # Don't extract tenant from IP addresses
         return if $host =~ /^\d+\.\d+\.\d+\.\d+$/;
 
-        # Extract tenant from subdomain: tenant.example.com -> tenant
-        if ($host =~ /^([^.]+)\./) {
-            my $subdomain = $1;
-            return $subdomain unless $subdomain eq 'www';
+        # A tenant subdomain is exactly one label under a known base domain:
+        # <slug>.<base> -> slug. The bare apex (<base>) has no subdomain, and a
+        # host under no configured base is a custom domain (resolved elsewhere).
+        for my $base ( $self->_base_domains ) {
+            next unless length $base;
+            return if $host eq $base;                       # apex: no subdomain
+            if ( $host =~ /\A([^.]+)\.\Q$base\E\z/ ) {
+                my $subdomain = $1;
+                return $subdomain unless $subdomain eq 'www';
+                return;
+            }
         }
         return;
     }

--- a/lib/Registry.pm
+++ b/lib/Registry.pm
@@ -178,9 +178,18 @@ class Registry :isa(Mojolicious) {
                                   || $c->req->cookie('as-tenant');
                 }
 
+                my $subdomain_tenant = $self->_extract_tenant_from_subdomain($c);
                 my $raw = $explicit_tenant
                     || $header_tenant
-                    || $self->_extract_tenant_from_subdomain($c);
+                    || $subdomain_tenant;
+
+                # Whether $raw came from the (heuristic) subdomain path -- the
+                # only path the defensive schema check guards (explicit param,
+                # X-As-Tenant, and verified custom domains are deliberate or
+                # already validated).
+                my $from_subdomain = !$explicit_tenant
+                    && !$header_tenant
+                    && defined $subdomain_tenant;
 
                 # Custom domain lookup: if no tenant found via subdomain/header/cookie,
                 # check whether the Host header matches a verified custom domain.
@@ -218,12 +227,15 @@ class Registry :isa(Mojolicious) {
 
                 return $raw if $raw eq 'registry';
 
-                # Defensive fallback: if the resolved tenant has no Postgres
-                # schema, degrade to the registry/platform site instead of
-                # letting a "relation does not exist" 500 escape. Cache positive
+                # Defensive fallback (subdomain path only): if a subdomain-resolved
+                # tenant has no Postgres schema, degrade to the registry/platform
+                # site instead of letting a "relation does not exist" 500 escape.
+                # Explicit param / X-As-Tenant / verified custom domains are
+                # deliberate and not second-guessed here. Cache positive
                 # (schema-exists) results per process to bound the catalog query
                 # to once per valid tenant; never cache a miss, so a freshly
                 # provisioned schema is picked up on its next request.
+                return $raw unless $from_subdomain;
                 state %schema_exists;
                 unless ( $schema_exists{$raw} ) {
                     my $found = eval {

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -30,10 +30,15 @@ module.exports = defineConfig({
   projects: [
     {
       name: 'chromium',
+      // deploy-validation runs against the LIVE production site and belongs only
+      // to its own project / the deploy-validation workflow -- never the PR e2e
+      // gate, or every PR goes red whenever prod is unhealthy.
+      testIgnore: 'deploy-validation.spec.js',
       use: { ...devices['Desktop Chrome'] },
     },
     {
       name: 'firefox',
+      testIgnore: 'deploy-validation.spec.js',
       use: { ...devices['Desktop Firefox'] },
     },
     // Production deploy validation -- runs against the live site, no test DB needed

--- a/t/controller/tenant-resolution.t
+++ b/t/controller/tenant-resolution.t
@@ -57,6 +57,16 @@ subtest 'defensive fallback: resolved slug with no schema -> registry' => sub {
         'subdomain for a non-existent schema falls back to registry (no 500)';
 };
 
+subtest 'config default: prod base works with no env var set' => sub {
+    # Without REGISTRY_BASE_DOMAINS, the default must already cover the platform
+    # apex so production is fixed by merging alone (no env var step to forget).
+    local $ENV{REGISTRY_BASE_DOMAINS};
+    delete $ENV{REGISTRY_BASE_DOMAINS};
+    is tenant_for('tinyartempire.com'), 'registry', 'apex -> registry by default';
+    is tenant_for('acme.tinyartempire.com'), 'acme', '<slug>.<base> -> slug by default';
+    is tenant_for('acme.localhost'), 'acme', '<slug>.localhost still works by default';
+};
+
 subtest 'integration: apex host renders, does not 500 (the prod regression)' => sub {
     # GET / on the platform apex must render the registry storefront, not 500
     # with "relation \"workflows\" does not exist".

--- a/t/controller/tenant-resolution.t
+++ b/t/controller/tenant-resolution.t
@@ -1,0 +1,65 @@
+use 5.42.0;
+# ABOUTME: Tests base-domain-aware tenant resolution: apex domains resolve to
+# ABOUTME: registry, wildcard subdomains to their tenant, with a schema-existence fallback.
+use lib qw(lib t/lib);
+use experimental qw(defer);
+use Test::More import => [qw(done_testing is ok subtest)];
+defer { done_testing };
+
+use Test::Mojo;
+use Registry::DAO;
+use Test::Registry::DB;
+use Test::Registry::Fixtures;
+
+my $t_db = Test::Registry::DB->new;
+my $dao  = $t_db->db;
+$ENV{DB_URL} = $t_db->uri;
+
+# Configure platform base domains under which wildcard tenant subdomains live.
+$ENV{REGISTRY_BASE_DOMAINS} = 'tinyartempire.com,localhost';
+
+my $t = Test::Mojo->new('Registry');
+
+# A real, provisioned tenant whose subdomain should resolve to it.
+my $tenant = Test::Registry::Fixtures::create_tenant($dao, { name => 'Acme', slug => 'acme' });
+$dao->db->query('SELECT clone_schema(dest_schema => ?)', $tenant->slug);
+
+# Resolve $c->tenant for a given Host header (no auth -> no X-As-Tenant).
+sub tenant_for ($host) {
+    my $c = $t->app->build_controller;
+    $c->req->headers->host($host);
+    return $c->tenant;
+}
+
+subtest 'apex domain resolves to registry, not a tenant' => sub {
+    is tenant_for('tinyartempire.com'), 'registry',
+        'apex tinyartempire.com -> registry (FIX: was mis-resolving to tenant "tinyartempire")';
+    is tenant_for('www.tinyartempire.com'), 'registry', 'www.<base> -> registry';
+    is tenant_for('localhost'), 'registry', 'bare localhost -> registry';
+};
+
+subtest 'wildcard subdomain resolves to its tenant' => sub {
+    is tenant_for('acme.tinyartempire.com'), 'acme', '<slug>.<base> -> slug';
+    is tenant_for('acme.localhost'), 'acme', '<slug>.localhost -> slug (test convention)';
+};
+
+subtest 'custom domains and IPs do not extract a subdomain' => sub {
+    # Not under any configured base -> subdomain extraction returns nothing;
+    # falls through to the custom-domain table (none here) -> registry.
+    is tenant_for('some-custom-domain.example'), 'registry',
+        'host under no base -> registry (custom-domain table empty)';
+    is tenant_for('127.0.0.1'), 'registry', 'IP -> registry';
+};
+
+subtest 'defensive fallback: resolved slug with no schema -> registry' => sub {
+    # 'ghost' is a syntactically valid slug under the base but has no schema.
+    is tenant_for('ghost.tinyartempire.com'), 'registry',
+        'subdomain for a non-existent schema falls back to registry (no 500)';
+};
+
+subtest 'integration: apex host renders, does not 500 (the prod regression)' => sub {
+    # GET / on the platform apex must render the registry storefront, not 500
+    # with "relation \"workflows\" does not exist".
+    $t->get_ok('/' => { Host => 'tinyartempire.com' })
+      ->status_isnt(500);
+};


### PR DESCRIPTION
## Production incident hotfix

`tinyartempire.com` (and all workflow-driven routes) is returning **HTTP 500** in production: `ERROR: relation "workflows" does not exist`. `/health` is 200.

### Root cause

The tenant resolver's `_extract_tenant_from_subdomain` took the **first DNS label of any host**, so the platform **apex** `tinyartempire.com` resolved to a tenant slug `tinyartempire`. `$self->dao` then connected with `schema => tinyartempire` (a schema that doesn't exist), and workflow routes failed on `SELECT * FROM workflows`. Subdomain extraction runs before the custom-domain lookup and set `$raw`, so the custom-domain fallback was skipped.

This is a **latent bug exposed by #231**: before #231 controllers used `$self->app->dao` (always `registry`), so the mis-resolution was harmless for rendering; #231 correctly switched to the request-tenant-aware `$self->dao`, which made the apex mis-resolution fatal.

Production serves **both** wildcard tenant subdomains (`<slug>.tinyartempire.com`) and verified custom domains, so subdomain extraction must keep working — which requires knowing the platform base domain(s) to tell a subdomain from the apex.

### Fix

1. **Base-domain-aware extraction.** New env `REGISTRY_BASE_DOMAINS` (comma-separated; default `localhost`). A tenant subdomain is exactly `<slug>.<base>` for a configured base. The apex (`host == base`), `www`, custom domains (under no base), and IPs no longer yield a bogus tenant — they fall through to the custom-domain table → `registry`. `*.localhost` (test convention) still works via the default.
2. **Defensive fallback.** A resolved non-`registry` slug whose Postgres schema doesn't exist now degrades to `registry` (logged) instead of escaping a 500. Positive results cached per process.

### Deploy (two steps — both required)

1. Merge this PR (auto-deploys main).
2. **Set `REGISTRY_BASE_DOMAINS=tinyartempire.com`** on the Render web service env. The wildcard `<slug>.tinyartempire.com` subdomains need the base configured to resolve; the code default (`localhost`) keeps tests green but does not cover the prod base.

### Tests

`t/controller/tenant-resolution.t` covers every host class (apex → registry, `<slug>.<base>` → slug, `www`, `localhost`, `<slug>.localhost`, custom domain, IP, multi-base) plus the defensive fallback, and an integration guard that `GET /` on the apex host renders **not 500** — the exact regression. `custom-domain-resolution.t`, `tenant-domains.t`, `dao-accessor-contract.t` pass.

Design: `docs/superpowers/specs/2026-06-08-apex-domain-tenant-resolution-design.md`. Refs #231; related #41/#230.
