### PR TITLE
Make the waitlist sweep iterate tenant schemas (F-2)

### DIFF
--- a/lib/Registry/Job/ProcessWaitlist.pm
+++ b/lib/Registry/Job/ProcessWaitlist.pm
@@ -16,26 +16,59 @@ class Registry::Job::ProcessWaitlist {
     sub perform ($class, $job, $session_id = undef, $enrollment_id = undef) {
         my $app = $job->app;
         my $log = $app->log;
-        
+
         try {
             my $dao = $app->dao;
-            
+
             if ($session_id) {
-                # Process specific session waitlist
+                # NOTE: session_id/enrollment_id callers must supply a tenant-scoped
+                # dao (via $app->dao->connect_schema($slug)) so the unqualified table
+                # references in process_session_waitlist resolve to the correct tenant
+                # schema.  There are currently no enqueue callers that pass these args;
+                # if you add one, thread the tenant slug and call connect_schema here.
                 $class->process_session_waitlist($dao, $session_id, $log);
             } elsif ($enrollment_id) {
-                # Process waitlist due to enrollment cancellation
+                # See NOTE above re: tenant-scoped dao requirement.
                 $class->process_enrollment_cancellation($dao, $enrollment_id, $log);
             } else {
-                # Process all sessions with cancellations in last hour
-                $class->process_recent_cancellations($dao, $log);
+                # Global sweep: iterate every tenant schema so cancellations in any
+                # tenant are processed.  Tenant data lives in per-tenant schemas, not
+                # in registry, so a registry-scoped dao would find nothing.
+                $class->process_all_tenant_cancellations($dao, $log);
             }
-            
+
             $job->finish('Waitlist processing completed successfully');
         }
         catch ($e) {
             $log->error("ProcessWaitlist job failed: $e");
             $job->fail("Waitlist processing failed: $e");
+        }
+    }
+
+    # Iterate every tenant schema and run process_recent_cancellations for each.
+    # The registry schema itself is skipped because tenant enrollment data lives
+    # in per-tenant schemas, not in registry.  Per-tenant failures are caught and
+    # logged so one broken tenant does not abort the sweep for the others.
+    sub process_all_tenant_cancellations ($class, $dao, $log) {
+        require Registry::DAO::Tenant;
+
+        my $tenants = Registry::DAO::Tenant->get_all_tenant_schemas($dao->db);
+
+        for my $tenant (@$tenants) {
+            my $slug = $tenant->{slug};
+
+            # Enrollment data lives in each tenant's own schema, not in registry.
+            next if $slug eq 'registry';
+
+            try {
+                $log->info("Processing waitlist cancellations for tenant: $slug");
+                my $tenant_dao = $dao->connect_schema($slug);
+                $class->process_recent_cancellations($tenant_dao, $log);
+            }
+            catch ($e) {
+                $log->error("ProcessWaitlist failed for tenant $slug: $e");
+                # Continue to the next tenant rather than aborting the sweep.
+            }
         }
     }
     

--- a/t/job/process-waitlist-tenant.t
+++ b/t/job/process-waitlist-tenant.t
@@ -1,0 +1,185 @@
+#!/usr/bin/env perl
+# ABOUTME: Tests that the ProcessWaitlist job's global sweep iterates all tenant schemas.
+# ABOUTME: Verifies fix for F-2: the sweep was blind to every tenant schema.
+use 5.42.0;
+
+BEGIN { $ENV{EMAIL_SENDER_TRANSPORT} = 'Test' }
+
+use lib qw(lib t/lib);
+use Test::More;
+use Test::Registry::DB;
+use Test::Registry::Fixtures;
+use Registry::DAO;
+use Registry::DAO::Tenant;
+use Registry::DAO::Waitlist;
+use Registry::DAO::Location;
+use Registry::DAO::Session;
+use Registry::DAO::Enrollment;
+use Registry::Job::ProcessWaitlist;
+
+# ---- database setup --------------------------------------------------------
+
+my $t   = Test::Registry::DB->new;
+my $dao = $t->db;    # registry-schema DAO
+
+# Provision a real tenant so get_all_tenant_schemas returns it.
+my $parent = Test::Registry::Fixtures::create_user( $dao, {
+    username  => 'wl_parent_' . $$,
+    password  => 'pw',
+    user_type => 'parent',
+});
+
+my $student = Test::Registry::Fixtures::create_user( $dao, {
+    username  => 'wl_student_' . $$,
+    password  => 'pw',
+    user_type => 'student',
+});
+
+my $tenant = Registry::DAO::Tenant->provision( $dao->db, {
+    name  => 'WaitlistTestTenant_' . $$,
+    slug  => 'wl_test_' . $$,
+    users => [ $parent ],
+});
+
+my $slug  = $tenant->slug;
+my $t_dao = $dao->connect_schema($slug);   # tenant-scoped DAO
+my $t_db  = $t_dao->db;
+
+# Copy the student into the tenant schema so FK constraints are satisfied.
+$dao->db->query('SELECT copy_user(dest_schema => ?, user_id => ?)', $slug, $student->id);
+
+# ---- minimal tenant-schema test data ----------------------------------------
+
+my $location = Registry::DAO::Location->create( $t_db, {
+    name         => 'WL Test Location',
+    slug         => 'wl-test-loc-' . $$,
+    address_info => { street => '1 Test St' },
+});
+
+my $session = Registry::DAO::Session->create( $t_db, {
+    name => 'WL Test Session',
+    slug => 'wl-test-session-' . $$,
+});
+
+# Create a cancelled enrollment with updated_at = NOW() (within the last hour).
+# This enrollment lives in the tenant schema, not in registry.
+my $enrollment = Registry::DAO::Enrollment->create( $t_db, {
+    session_id  => $session->id,
+    student_id  => $student->id,
+    parent_id   => $parent->id,
+    status      => 'cancelled',
+});
+
+ok $enrollment, 'cancelled enrollment created in tenant schema';
+
+# Create a waitlist entry for the same session in the tenant schema.
+my $wl_entry = Registry::DAO::Waitlist->create( $t_db, {
+    session_id  => $session->id,
+    location_id => $location->id,
+    student_id  => $student->id,
+    parent_id   => $parent->id,
+    position    => 1,
+    status      => 'waiting',
+});
+
+ok $wl_entry, 'waitlist entry created in tenant schema';
+
+# ---- minimal mock infrastructure -------------------------------------------
+
+{
+    package MockLogger;
+    sub new   { bless {}, shift }
+    sub info  { }
+    sub debug { }
+    sub warn  { }
+    sub error { }
+}
+
+{
+    package MockJob;
+    sub new    { bless { app => $_[1] }, $_[0] }
+    sub app    { $_[0]->{app} }
+    sub finish { }
+    sub fail   { }
+}
+
+{
+    package MockApp;
+    sub new { bless { dao => $_[1], log => $_[2] }, $_[0] }
+    sub dao { $_[0]->{dao} }
+    sub log { $_[0]->{log} }
+}
+
+my $log = MockLogger->new;
+my $app = MockApp->new( $dao, $log );
+my $job = MockJob->new( $app );
+
+# ---- Unit test: process_recent_cancellations is schema-aware ----------------
+#
+# The core of F-2: unqualified SQL in process_recent_cancellations resolves
+# against the current search_path.  With a registry-scoped DAO the tenant's
+# enrollments table is invisible; with a tenant-scoped DAO it is found.
+
+subtest 'process_recent_cancellations: registry-scoped dao finds no sessions (F-2)' => sub {
+    # Capture sessions by subclassing process_session_waitlist to collect args
+    my @found_sessions;
+    {
+        no warnings 'redefine';
+        local *Registry::Job::ProcessWaitlist::process_session_waitlist = sub {
+            my ($class, $dao, $session_id, $log) = @_;
+            push @found_sessions, $session_id;
+        };
+
+        Registry::Job::ProcessWaitlist->process_recent_cancellations( $dao, $log );
+    }
+
+    is scalar(@found_sessions), 0,
+        'registry-scoped sweep finds 0 sessions - tenant enrollments invisible (F-2 confirmed)';
+};
+
+subtest 'process_recent_cancellations: tenant-scoped dao finds the cancelled session' => sub {
+    my @found_sessions;
+    {
+        no warnings 'redefine';
+        local *Registry::Job::ProcessWaitlist::process_session_waitlist = sub {
+            my ($class, $dao, $session_id, $log) = @_;
+            push @found_sessions, $session_id;
+        };
+
+        Registry::Job::ProcessWaitlist->process_recent_cancellations( $t_dao, $log );
+    }
+
+    is scalar(@found_sessions), 1,
+        'tenant-scoped sweep finds 1 session with recent cancellation';
+    is $found_sessions[0], $session->id,
+        'found the correct session id in the tenant schema';
+};
+
+# ---- Integration test: perform() with no args routes through all tenants ----
+
+subtest 'perform: global sweep calls process_recent_cancellations per tenant' => sub {
+    my @called_schemas;
+    {
+        no warnings 'redefine';
+        local *Registry::Job::ProcessWaitlist::process_recent_cancellations = sub {
+            my ($class, $tenant_dao, $log) = @_;
+            push @called_schemas, $tenant_dao->current_tenant;
+        };
+
+        Registry::Job::ProcessWaitlist->perform( $job );
+    }
+
+    ok scalar(@called_schemas) > 0,
+        'perform called process_recent_cancellations at least once';
+
+    my @tenant_calls = grep { $_ eq $slug } @called_schemas;
+    is scalar(@tenant_calls), 1,
+        "process_recent_cancellations was called for tenant schema '$slug'";
+
+    my @registry_calls = grep { $_ eq 'registry' } @called_schemas;
+    is scalar(@registry_calls), 0,
+        'registry schema is not included in the sweep (tenant data is not there)';
+};
+
+$t->cleanup_test_database;
+done_testing;


### PR DESCRIPTION
## What

Automated waitlist progression never fired for any real tenant. Registry is multi-tenant by Postgres schema — `enrollments`/`events`/`waitlist` live in each **tenant** schema — but `ProcessWaitlist`'s only enqueue site is the global recurring sweep (`lib/Registry.pm:830`, no args). In a Minion worker `$app->dao` resolves to the **registry** schema, so `process_recent_cancellations` ran its unqualified `FROM enrollments WHERE status='cancelled'` against registry, found nothing, and offered no waitlist spots anywhere.

## Fix

The no-arg sweep now routes through a new `process_all_tenant_cancellations`, which lists every tenant via `Registry::DAO::Tenant->get_all_tenant_schemas`, skips the registry schema (no tenant data there), builds a tenant-scoped dao with `connect_schema($slug)`, and runs the cancellation sweep per tenant inside a try/catch so one broken tenant can't abort the rest.

The unused `session_id`/`enrollment_id` branches (no enqueue callers exist) are left structurally unchanged but annotated that any future caller must thread a tenant slug through `connect_schema`.

## Tests

New `t/job/process-waitlist-tenant.t` (matches the existing `t/job/` harness style): a real provisioned tenant with a recently-cancelled enrollment and a waiting entry. It proves the schema-awareness directly — a registry-scoped sweep finds **0** sessions, a tenant-scoped sweep finds the cancelled session, and `perform`'s global sweep calls the per-tenant path for the tenant slug and **not** for registry. Fails before the fix, passes after. `t/job/`, `t/dao/waitlist*.t`, and full `t/dao/` all green.

Surfaced by the architecture review (F-2). Note: the sibling `WaitlistExpiration` job (`lib/Registry.pm:813`) has the identical tenant-blindness and is tracked separately.