### PR TITLE
Route subscription webhooks correctly; isolate per-item confirmation emails (F-3, F-13)

### DIFF
--- a/lib/Registry/Controller/Webhooks.pm
+++ b/lib/Registry/Controller/Webhooks.pm
@@ -161,7 +161,7 @@ class Registry::Controller::Webhooks :isa(Registry::Controller) {
         # Check if this event is related to installment payment subscriptions
         my $event_type = $event->{type};
 
-        return 0 unless defined $event_type && $event_type =~ /^(invoice\.paid|invoice\.payment_failed|customer\.subscription\.)$/;
+        return 0 unless defined $event_type && $event_type =~ /^(invoice\.paid|invoice\.payment_failed|customer\.subscription\..+)$/;
 
         # Check if the subscription has payment_schedule_id in metadata
         my $subscription_id;

--- a/lib/Registry/DAO/Payment.pm
+++ b/lib/Registry/DAO/Payment.pm
@@ -182,11 +182,19 @@ field $_stripe_client = undef;
                 payment_id       => $id,
             });
 
-            Registry::DAO::Notification->ensure_enrollment_confirmation($db, {
-                user_id    => $user_id,
-                session_id => $session_id,
-                child_id   => $item->{child_id},
-            });
+            # Confirmation email is best-effort: a failure must not abort
+            # enrollment of remaining items. Enrollment creation above is
+            # the critical step; the email can be retried or re-sent later.
+            try {
+                Registry::DAO::Notification->ensure_enrollment_confirmation($db, {
+                    user_id    => $user_id,
+                    session_id => $session_id,
+                    child_id   => $item->{child_id},
+                });
+            }
+            catch ($e) {
+                warn "finalize_enrollment: enrollment confirmation failed for session $session_id (payment $id): $e";
+            }
         }
     }
 

--- a/lib/Registry/DAO/PaymentSchedule.pm
+++ b/lib/Registry/DAO/PaymentSchedule.pm
@@ -38,8 +38,8 @@ sub find_active ($class, $db) {
 }
 
 sub find_by_stripe_subscription_id ($class, $db, $subscription_id) {
-    my $results = $class->find($db, { stripe_subscription_id => $subscription_id });
-    return $results || [];
+    my @results = $class->find($db, { stripe_subscription_id => $subscription_id });
+    return \@results;
 }
 
 # Instance methods for status management

--- a/t/controller/subscription-webhook-routing.t
+++ b/t/controller/subscription-webhook-routing.t
@@ -1,0 +1,228 @@
+# ABOUTME: Tests F-3 -- subscription webhook events are classified and routed correctly.
+# ABOUTME: Verifies customer.subscription.updated/deleted reach installment handlers.
+BEGIN { $ENV{EMAIL_SENDER_TRANSPORT} = 'Test' }
+
+use 5.42.0;
+use warnings;
+use lib qw(lib t/lib);
+use Test::More;
+use Test::Registry::DB;
+use Test::MockObject;
+use Registry::DAO;
+use Registry::DAO::PricingPlan;
+use Registry::DAO::PaymentSchedule;
+use Registry::Controller::Webhooks;
+
+my $test_db = Test::Registry::DB->new;
+my $dao     = $test_db->db;
+my $db      = $dao->db;
+
+# Stripe env required so modules that load Stripe client don't die
+local $ENV{STRIPE_SECRET_KEY} = 'sk_test_routing_test';
+
+# ---------------------------------------------------------------------------
+# Fixtures: insert a payment_schedule tied to a known Stripe subscription ID.
+# ---------------------------------------------------------------------------
+
+my $parent_user = $dao->create( User => {
+    username  => 'routing_parent',
+    name      => 'Routing Parent',
+    user_type => 'parent',
+    email     => 'routing_p@test.local',
+} );
+
+my $loc = $dao->create( Location => {
+    name         => 'Routing Studio',
+    slug         => 'routing-studio',
+    address_info => {},
+    metadata     => {},
+} );
+
+my $prog = $dao->create( Project => {
+    name              => 'Routing Camp',
+    status            => 'published',
+    program_type_slug => 'summer-camp',
+    metadata          => {},
+} );
+
+my $teacher = $dao->create( User => {
+    username  => 'routing_teacher',
+    name      => 'Routing Teacher',
+    user_type => 'staff',
+    email     => 'routing_t@test.local',
+} );
+
+my $session = $dao->create( Session => {
+    name       => 'Routing Session',
+    start_date => '2026-07-01',
+    end_date   => '2026-07-31',
+    status     => 'published',
+    capacity   => 10,
+    metadata   => {},
+} );
+
+my $event = $dao->create( Event => {
+    time        => '2026-07-01 10:00:00',
+    duration    => 60,
+    location_id => $loc->id,
+    project_id  => $prog->id,
+    teacher_id  => $teacher->id,
+    capacity    => 10,
+    metadata    => {},
+} );
+$session->add_events( $db, $event->id );
+
+# Direct DB insert for enrollment (schema-qualified)
+my $enrollment_id = $db->insert( 'registry.enrollments', {
+    session_id   => $session->id,
+    student_id   => $parent_user->id,
+    parent_id    => $parent_user->id,
+    status       => 'active',
+    metadata     => '{}',
+}, { returning => 'id' } )->hash->{id};
+
+# Create a pricing_plan to satisfy the FK
+my $plan = Registry::DAO::PricingPlan->create( $db, {
+    session_id           => $session->id,
+    plan_name            => 'Routing Plan',
+    plan_type            => 'standard',
+    amount               => 300.00,
+    installments_allowed => 1,
+    installment_count    => 3,
+} );
+
+my $SUB_ID = 'sub_routing_f3_test';
+
+my $schedule = Registry::DAO::PaymentSchedule->create( $db, {
+    enrollment_id          => $enrollment_id,
+    pricing_plan_id        => $plan->id,
+    stripe_subscription_id => $SUB_ID,
+    total_amount           => 300.00,
+    installment_amount     => 100.00,
+    installment_count      => 3,
+    status                 => 'active',
+} );
+ok $schedule, 'payment_schedule fixture created';
+
+# ---------------------------------------------------------------------------
+# Webhook controller with a mock app pointing at our test DAO.
+# Following the pattern used in t/integration/installment-webhook-processing.t.
+# ---------------------------------------------------------------------------
+
+my $mock_app = Test::MockObject->new;
+$mock_app->mock( 'dao', sub { $dao } );
+$mock_app->mock( 'log', sub {
+    my $log = Test::MockObject->new;
+    $log->set_always( 'info',  undef );
+    $log->set_always( 'error', undef );
+    $log->set_always( 'warn',  undef );
+    $log->set_always( 'debug', undef );
+    return $log;
+});
+
+my $wh = Registry::Controller::Webhooks->new;
+$wh->{app} = $mock_app;
+
+# ---------------------------------------------------------------------------
+# Subtest 1: customer.subscription.updated WITH a matching payment_schedule
+# must be classified as an installment event.
+# Under the broken regex (/.subscription\.$/) this returns 0.
+# ---------------------------------------------------------------------------
+
+subtest 'customer.subscription.updated with payment_schedule classified as installment' => sub {
+    my $evt = {
+        type => 'customer.subscription.updated',
+        data => {
+            object => {
+                id     => $SUB_ID,
+                status => 'active',
+            },
+        },
+    };
+
+    my $result = $wh->_is_installment_payment_event($evt);
+    ok $result,
+        'customer.subscription.updated with matching payment_schedule is an installment event';
+};
+
+# ---------------------------------------------------------------------------
+# Subtest 2: customer.subscription.deleted WITH a matching payment_schedule
+# must also be classified as an installment event.
+# ---------------------------------------------------------------------------
+
+subtest 'customer.subscription.deleted with payment_schedule classified as installment' => sub {
+    my $evt = {
+        type => 'customer.subscription.deleted',
+        data => {
+            object => {
+                id     => $SUB_ID,
+                status => 'canceled',
+            },
+        },
+    };
+
+    my $result = $wh->_is_installment_payment_event($evt);
+    ok $result,
+        'customer.subscription.deleted with matching payment_schedule is an installment event';
+};
+
+# ---------------------------------------------------------------------------
+# Subtest 3: customer.subscription.updated with NO payment_schedule must NOT
+# be classified as installment (platform subscription safety check).
+# ---------------------------------------------------------------------------
+
+subtest 'customer.subscription.updated without payment_schedule is not installment' => sub {
+    my $evt = {
+        type => 'customer.subscription.updated',
+        data => {
+            object => {
+                id     => 'sub_platform_no_schedule',
+                status => 'active',
+            },
+        },
+    };
+
+    my $result = $wh->_is_installment_payment_event($evt);
+    ok !$result,
+        'customer.subscription.updated without payment_schedule is not an installment event';
+};
+
+# ---------------------------------------------------------------------------
+# Subtest 4: invoice.paid still classified as installment (regression guard).
+# ---------------------------------------------------------------------------
+
+subtest 'invoice.paid with matching subscription still classified as installment' => sub {
+    my $evt = {
+        type => 'invoice.paid',
+        data => {
+            object => {
+                id           => 'in_routing_test',
+                subscription => $SUB_ID,
+                status       => 'paid',
+            },
+        },
+    };
+
+    my $result = $wh->_is_installment_payment_event($evt);
+    ok $result,
+        'invoice.paid with matching subscription still classified as installment event';
+};
+
+# ---------------------------------------------------------------------------
+# Subtest 5: _handle_installment_subscription_updated updates schedule status.
+# Verifies the handler is reachable and functional once the routing fix allows
+# the event to reach it.
+# ---------------------------------------------------------------------------
+
+subtest '_handle_installment_subscription_updated updates payment schedule status' => sub {
+    $wh->_handle_installment_subscription_updated( $db, {
+        id     => $SUB_ID,
+        status => 'past_due',
+    });
+
+    my $refreshed = Registry::DAO::PaymentSchedule->find( $db, { id => $schedule->id } );
+    is $refreshed->status, 'past_due',
+        'schedule status updated to past_due by the subscription updated handler';
+};
+
+done_testing;

--- a/t/dao/finalize-enrollment-email-isolation.t
+++ b/t/dao/finalize-enrollment-email-isolation.t
@@ -1,0 +1,182 @@
+# ABOUTME: Tests F-13 -- finalize_enrollment email side-effect must not abort remaining items.
+# ABOUTME: If ensure_enrollment_confirmation throws for one item, the rest still enroll.
+BEGIN { $ENV{EMAIL_SENDER_TRANSPORT} = 'Test' }
+
+use 5.42.0;
+use warnings;
+use utf8;
+use lib qw(lib t/lib);
+use Test::More;
+use Test::Registry::DB;
+use Registry::DAO::Family;
+use Registry::DAO::Payment;
+use Registry::DAO::Notification;
+
+my $test_db = Test::Registry::DB->new;
+my $dao     = $test_db->db;
+my $db      = $dao->db;
+
+# ---------------------------------------------------------------------------
+# Fixtures: two sessions, one parent, one child
+# ---------------------------------------------------------------------------
+
+my $loc = $dao->create( Location => {
+    name         => 'F13 Studio',
+    slug         => 'f13-studio',
+    address_info => {},
+    metadata     => {},
+} );
+
+my $prog = $dao->create( Project => {
+    name              => 'F13 Camp',
+    status            => 'published',
+    program_type_slug => 'summer-camp',
+    metadata          => {},
+} );
+
+my $teacher = $dao->create( User => {
+    username  => 'f13_teacher',
+    name      => 'F13 Teacher',
+    user_type => 'staff',
+    email     => 'f13_t@test.local',
+} );
+
+my $session_a = $dao->create( Session => {
+    name       => 'F13 Session A',
+    start_date => '2026-07-01',
+    end_date   => '2026-07-14',
+    status     => 'published',
+    capacity   => 10,
+    metadata   => {},
+} );
+
+my $session_b = $dao->create( Session => {
+    name       => 'F13 Session B',
+    start_date => '2026-07-15',
+    end_date   => '2026-07-28',
+    status     => 'published',
+    capacity   => 10,
+    metadata   => {},
+} );
+
+for my $session ($session_a, $session_b) {
+    my $event = $dao->create( Event => {
+        time        => $session->start_date . ' 09:00:00',
+        duration    => 60,
+        location_id => $loc->id,
+        project_id  => $prog->id,
+        teacher_id  => $teacher->id,
+        capacity    => 10,
+        metadata    => {},
+    });
+    $session->add_events( $db, $event->id );
+}
+
+my $parent = $dao->create( User => {
+    username  => 'f13_parent',
+    name      => 'F13 Parent',
+    user_type => 'parent',
+    email     => 'f13_p@test.local',
+} );
+
+my $child = Registry::DAO::Family->add_child( $db, $parent->id, {
+    child_name         => 'F13 Kid',
+    birth_date         => '2018-05-01',
+    grade              => '2',
+    medical_info       => {},
+    emergency_contact  => { name => 'EC', phone => '555-0001' },
+});
+
+# Payment enrolling the child in both sessions
+my $payment = Registry::DAO::Payment->create( $db, {
+    user_id  => $parent->id,
+    amount   => 200,
+    metadata => {
+        enrollment_items => [
+            { session_id => $session_a->id, child_id => $child->id },
+            { session_id => $session_b->id, child_id => $child->id },
+        ],
+        tenant_slug => undef,
+    },
+});
+
+# ---------------------------------------------------------------------------
+# Capture warnings emitted by the production code during the test so we can
+# assert they appear without letting them pollute TAP output.
+# ---------------------------------------------------------------------------
+
+my @captured_warnings;
+local $SIG{__WARN__} = sub { push @captured_warnings, @_ };
+
+# ---------------------------------------------------------------------------
+# Inject a failure: make ensure_enrollment_confirmation die for the FIRST call
+# (session_a) and succeed normally for subsequent calls. We use a call counter
+# so only the first invocation fails.
+# ---------------------------------------------------------------------------
+
+my $email_call_count = 0;
+no warnings 'redefine';
+local *Registry::DAO::Notification::ensure_enrollment_confirmation = sub {
+    $email_call_count++;
+    if ($email_call_count == 1) {
+        die "Simulated email transport failure for session_a\n";
+    }
+    # All other calls proceed normally (no-op for test isolation)
+};
+use warnings 'redefine';
+
+# ---------------------------------------------------------------------------
+# Subtest 1: both enrollments are created even though the first email fails.
+# Before the fix, the loop aborts after session_a's email throws and
+# session_b's enrollment is never created.
+# ---------------------------------------------------------------------------
+
+subtest 'all enrollment items created when first email confirmation throws' => sub {
+    $payment->finalize_enrollment($db);
+
+    my $enrollments = $db->select(
+        'enrollments', '*', { payment_id => $payment->id }
+    )->hashes;
+
+    is scalar(@$enrollments), 2,
+        'both enrollment items created despite first email failure';
+
+    my %sessions_enrolled = map { $_->{session_id} => 1 } @$enrollments;
+    ok $sessions_enrolled{ $session_a->id }, 'session_a enrollment created';
+    ok $sessions_enrolled{ $session_b->id }, 'session_b enrollment created';
+};
+
+# ---------------------------------------------------------------------------
+# Subtest 2: the email failure is logged via warn (not silently swallowed).
+# Per CLAUDE.md: expected errors in logs must be captured and tested.
+# ---------------------------------------------------------------------------
+
+subtest 'email failure is logged and not silently discarded' => sub {
+    ok @captured_warnings > 0,
+        'at least one warning was emitted when the email call threw';
+
+    my $found = grep { /Simulated email transport failure for session_a|enrollment.*confirmation/i } @captured_warnings;
+    ok $found,
+        'warning includes context about the failing email';
+};
+
+# ---------------------------------------------------------------------------
+# Subtest 3: second call to finalize_enrollment is idempotent (no regressions).
+# ---------------------------------------------------------------------------
+
+subtest 'finalize_enrollment remains idempotent after email isolation fix' => sub {
+    # Reset warning capture for this subtest
+    @captured_warnings = ();
+
+    # On second call, email is no longer overridden to fail (call count > 1 now)
+    $payment->finalize_enrollment($db);
+
+    my $enrollments = $db->select(
+        'enrollments', '*', { payment_id => $payment->id }
+    )->hashes;
+
+    is scalar(@$enrollments), 2,
+        'still exactly two enrollments after second finalize call';
+};
+
+done_testing;


### PR DESCRIPTION
Two correctness fixes on the Stripe money path, surfaced by the architecture review.

## F-3 — subscription webhook events were misrouted (dead regex branches)

`_is_installment_payment_event` classified events with `/^(...|customer\.subscription\.)$/`. The `$` anchor sat immediately after the trailing dot, so it matched only the literal `"customer.subscription."` — never real events like `customer.subscription.updated`/`.deleted`. The explicit handler branches for those events (`_handle_installment_subscription_updated`/`_cancelled`) were therefore unreachable, and real subscription-lifecycle events fell through to the platform path.

Fix: `customer\.subscription\.` → `customer\.subscription\..+`. The method still gates on `PaymentSchedule->find_by_stripe_subscription_id`, which only matches installment subscriptions — platform/tenant-billing subscriptions have no `payment_schedule` and still fall through correctly.

While testing this, found and fixed a **second latent bug** on the same path: `find_by_stripe_subscription_id` called `find` in scalar context (returning a single object via `$c->first`) but both callers treat the result as an arrayref (`@$schedules > 0`, `$schedules->[0]`). It now returns `\@results` from a list-context `find`, which is what both callers require — this also hardens the live `invoice.paid` installment path.

## F-13 — a failed confirmation email could abort enrollment of remaining items

`finalize_enrollment` created each enrollment then sent its confirmation email in the same loop with no isolation. An email exception aborted the loop, leaving later items unenrolled; from `payment_intent.succeeded` that meant a 500 + Stripe retry where the same email kept failing and starved later items.

Fix: wrap only the `ensure_enrollment_confirmation` call in a per-item `try/catch` that logs and continues. Enrollment creation stays unwrapped — a real enrollment failure should still surface and let Stripe retry.

## Tests

- `t/controller/subscription-webhook-routing.t` — `customer.subscription.updated/deleted` with a matching schedule now classify and route as installment; without a schedule they still don't (platform-subscription regression guard). Follows the existing `Test::MockObject`-app-over-real-DAO pattern.
- `t/dao/finalize-enrollment-email-isolation.t` — a payment with multiple items where the first email throws now enrolls all items and logs the failure; idempotent re-run preserved.

29 money-path tests green (`installment-payment-webhooks`, `stripe-webhooks`, `webhooks`, `payment-finalization-idempotency`, `scheduled-payment`) plus full `t/dao/` (735).