### PR TITLE
Wire log correlation; disambiguate tenant DB errors; real /health probe (F-5, F-15, F-24)

### DIFF
--- a/lib/Registry.pm
+++ b/lib/Registry.pm
@@ -249,9 +249,6 @@ class Registry :isa(Mojolicious) {
 
                     if ($found) {
                         # Query succeeded and found the schema -- cache the hit.
-                        # set_context replaces context each request, so stale
-                        # context cannot leak across requests even if after_dispatch
-                        # is skipped on error.
                         $schema_exists{$raw} = 1;
                     }
                     elsif ($eval_err) {

--- a/lib/Registry.pm
+++ b/lib/Registry.pm
@@ -574,10 +574,25 @@ class Registry :isa(Mojolicious) {
 
         # Legacy school route removed -- storefront at / replaces it
 
-        # Health check endpoint (no auth required)
+        # Health check / readiness probe endpoint (no auth required).
+        # Performs a trivial SELECT 1 against the registry DB so that the probe
+        # reflects actual database reachability, not just process liveness.
+        # Returns HTTP 200 on success, HTTP 503 when the DB is unavailable.
         $self->routes->get('/health')->to(cb => sub ($c) {
-            # Simple health check - just verify app is responding
-            $c->render(json => { status => 'ok', timestamp => time() });
+            my $ts = time();
+            eval {
+                $c->dao('registry')->db->query('SELECT 1');
+            };
+            if ($@) {
+                my $err = $@;
+                $c->app->log->error("Health check DB probe failed: $err");
+                $c->render(
+                    json   => { status => 'error', db => 'down', timestamp => $ts },
+                    status => 503,
+                );
+                return;
+            }
+            $c->render(json => { status => 'ok', db => 'ok', timestamp => $ts });
         })->name('health_check');
 
         # Webhook routes (no auth required)

--- a/lib/Registry.pm
+++ b/lib/Registry.pm
@@ -245,10 +245,26 @@ class Registry :isa(Mojolicious) {
                             $raw
                         )->rows;
                     };
+                    my $eval_err = $@;
+
                     if ($found) {
+                        # Query succeeded and found the schema -- cache the hit.
+                        # set_context replaces context each request, so stale
+                        # context cannot leak across requests even if after_dispatch
+                        # is skipped on error.
                         $schema_exists{$raw} = 1;
                     }
+                    elsif ($eval_err) {
+                        # The eval threw: a DB or infrastructure error, not a
+                        # schema miss.  Log distinctly at ERROR so operators can
+                        # tell "tenant schema genuinely absent" from "DB is down".
+                        # Resilience is preserved either way (serve registry).
+                        $c->app->log->error(
+                            "schema-existence check failed for tenant '$raw': $eval_err; serving registry");
+                        return 'registry';
+                    }
                     else {
+                        # Query succeeded but returned 0 rows: schema genuinely absent.
                         $c->app->log->warn(
                             "tenant '$raw' resolved but has no schema; serving registry");
                         return 'registry';

--- a/lib/Registry.pm
+++ b/lib/Registry.pm
@@ -388,6 +388,38 @@ class Registry :isa(Mojolicious) {
             }
         );
 
+        # Wire per-request log correlation context so every JSON log line carries
+        # request_id, user_id, and tenant_id for distributed tracing / log analysis.
+        # Registered after the user-loading hook above so current_user is known.
+        # set_context replaces context each request, so stale context cannot leak
+        # across requests even if after_dispatch is skipped on error.
+        $self->hook(
+            before_dispatch => sub ($c) {
+                $c->app->log->set_context({
+                    request_id => $c->req->request_id,
+                    user_id    => $c->session('user_id'),
+                    tenant_id  => $c->tenant,
+                }) if $c->app->log->can('set_context');
+            }
+        );
+
+        $self->hook(
+            after_dispatch => sub ($c) {
+                # Emit a structured access log line while context is still set,
+                # so every request produces at least one line carrying request_id,
+                # user_id, and tenant_id for correlation in log analysis tools.
+                $c->app->log->debug(
+                    sprintf '%s %s %s',
+                        $c->req->method,
+                        $c->req->url->path,
+                        $c->res->code // 0,
+                ) if $c->app->log->can('set_context');
+
+                $c->app->log->clear_context()
+                    if $c->app->log->can('clear_context');
+            }
+        );
+
         # Helper: require an authenticated session.
         # Redirects browsers to login; sends 401 JSON to API clients.
         # Returns true if authenticated, false (and terminates dispatch) otherwise.

--- a/t/controller/health-check.t
+++ b/t/controller/health-check.t
@@ -1,0 +1,36 @@
+#!/usr/bin/env perl
+# ABOUTME: Tests for the /health readiness probe endpoint.
+# ABOUTME: Verifies the endpoint performs a DB check and returns appropriate status/fields.
+
+use 5.42.0;
+use warnings;
+use utf8;
+
+use lib qw(lib t/lib);
+use Test::More;
+use Test::Registry::Mojo;
+use Test::Registry::DB;
+
+my $test_db = Test::Registry::DB->new;
+$ENV{DB_URL} = $test_db->uri;
+
+my $t = Test::Registry::Mojo->new('Registry');
+
+subtest 'GET /health returns 200 with db ok on healthy app' => sub {
+    $t->get_ok('/health')
+      ->status_is(200)
+      ->json_is('/status', 'ok')
+      ->json_is('/db', 'ok', 'health response includes db field')
+      ->json_has('/timestamp');
+};
+
+subtest '/health requires no authentication' => sub {
+    # A brand-new client with no session should still get 200
+    my $t2 = Test::Registry::Mojo->new('Registry');
+    $t2->get_ok('/health')
+       ->status_is(200)
+       ->json_is('/status', 'ok')
+       ->json_is('/db', 'ok');
+};
+
+done_testing();

--- a/t/controller/log-correlation-context.t
+++ b/t/controller/log-correlation-context.t
@@ -1,0 +1,71 @@
+#!/usr/bin/env perl
+# ABOUTME: Tests that per-request log correlation fields (request_id, tenant_id) appear in log output.
+# ABOUTME: Verifies the before_dispatch/after_dispatch hooks wire Logger::set_context correctly.
+
+use 5.42.0;
+use warnings;
+use utf8;
+
+use lib qw(lib t/lib);
+use Test::More;
+use Test::Registry::Mojo;
+use Test::Registry::DB;
+use Mojo::JSON qw(decode_json);
+use Registry::Utility::Logger;
+
+my $test_db = Test::Registry::DB->new;
+$ENV{DB_URL} = $test_db->uri;
+
+my $t = Test::Registry::Mojo->new('Registry');
+
+subtest 'JSON log lines carry request_id and tenant_id during a request' => sub {
+    # Redirect the app logger to a string buffer so we can inspect output.
+    my $log_buf = '';
+    open my $log_fh, '>', \$log_buf or die "Cannot open string buffer: $!";
+
+    my $logger = Registry::Utility::Logger->new(level => 'debug');
+    $logger->handle($log_fh);
+    $t->app->log($logger);
+
+    # Make a request -- /health is auth-free and guaranteed to reach dispatch
+    $t->get_ok('/health')->status_is(200);
+
+    close $log_fh;
+
+    # Parse log lines and find at least one that carries request_id
+    my @lines = split /\n/, $log_buf;
+    my @entries = grep { defined } map { eval { decode_json($_) } } @lines;
+
+    ok scalar(@entries) > 0, 'logger produced at least one JSON log line';
+
+    my @with_request_id = grep { defined $_->{request_id} } @entries;
+    ok scalar(@with_request_id) > 0,
+        'at least one log line carries a request_id field'
+        or diag "Log output:\n$log_buf";
+
+    my $entry = $with_request_id[0];
+    ok defined($entry->{request_id}), 'request_id is defined';
+    ok defined($entry->{tenant_id}),  'tenant_id is defined';
+};
+
+subtest 'context is cleared after request (no stale fields)' => sub {
+    my $logger = $t->app->log;
+
+    # After the previous request, context should be cleared
+    ok $logger->can('clear_context'), 'logger has clear_context method';
+
+    # Log a line outside of a request -- it should NOT carry request_id
+    my $out_buf = '';
+    open my $out_fh, '>', \$out_buf or die "Cannot open string buffer: $!";
+    my $bare_logger = Registry::Utility::Logger->new(level => 'debug');
+    $bare_logger->handle($out_fh);
+    $bare_logger->info('outside request');
+    close $out_fh;
+
+    my ($entry) = grep { defined } map { eval { decode_json($_) } } split(/\n/, $out_buf);
+    ok $entry, 'parsed log entry';
+    ok !defined($entry->{request_id}), 'no request_id outside a request context'
+        or diag "entry: " . encode_json($entry);
+};
+
+done_testing();

--- a/t/security/tenant-schema-error-logging.t
+++ b/t/security/tenant-schema-error-logging.t
@@ -1,0 +1,118 @@
+#!/usr/bin/env perl
+# ABOUTME: Tests that tenant resolver logs DB errors at ERROR level, not as schema-missing warnings.
+# ABOUTME: Regression guard: missing-schema path still serves registry; DB errors are distinctly logged.
+
+use 5.42.0;
+use warnings;
+use utf8;
+
+use lib qw(lib t/lib);
+use Test::More;
+use Test::Registry::Mojo;
+use Test::Registry::DB;
+use Mojo::JSON qw(decode_json);
+use Registry::Utility::Logger;
+
+my $test_db = Test::Registry::DB->new;
+$ENV{DB_URL} = $test_db->uri;
+
+my $t = Test::Registry::Mojo->new('Registry');
+
+# Helper: redirect app logger to a string buffer, run $cb, restore, return
+# the parsed JSON log entries emitted during the callback.
+my sub with_captured_log ($app, $level, $cb) {
+    my $buf = '';
+    open my $fh, '>', \$buf or die "Cannot open log buffer: $!";
+    my $logger = Registry::Utility::Logger->new(level => $level);
+    $logger->handle($fh);
+    my $prev_log = $app->log;
+    $app->log($logger);
+    eval { $cb->() };
+    my $err = $@;
+    $app->log($prev_log);
+    close $fh;
+    die $err if $err;
+    return grep { defined } map { eval { decode_json($_) } } split /\n/, $buf;
+}
+
+subtest 'schema miss (subdomain, no schema) degrades to registry with a WARN' => sub {
+    # Build a controller with a Host header that _extract_tenant_from_subdomain
+    # will parse as slug 'ghosttenant'.  The real DB has no such schema, so the
+    # query returns 0 rows and the tenant helper should:
+    #   - return 'registry' (resilience)
+    #   - emit a warn (not an error) with the slug name
+
+    my @entries = with_captured_log($t->app, 'warn', sub {
+        my $c = $t->app->build_controller;
+        $c->req->headers->header('Host' => 'ghosttenant.localhost');
+        my $result = $c->tenant;
+        is $result, 'registry', 'ghost tenant degrades to registry';
+    });
+
+    my @miss_warns = grep {
+        defined $_->{message}
+        && $_->{message} =~ /ghosttenant/i
+    } @entries;
+
+    ok scalar(@miss_warns) > 0,
+        'warn emitted for missing schema tenant'
+        or diag "All log entries:\n" . join("\n", map { Mojo::JSON::encode_json($_) } @entries);
+
+    my $w = $miss_warns[0];
+    is $w->{level}, 'warn', 'schema-miss log is at warn level (not error)';
+    unlike $w->{message}, qr/failed|error/i,
+        'schema-miss message does not say "failed" or "error"';
+};
+
+subtest 'DB error during schema check is logged at ERROR level, not as schema-miss' => sub {
+    # Override the dao helper to simulate a DB that throws during query execution.
+    # The tenant helper must:
+    #   - still return 'registry' (resilience preserved)
+    #   - log at ERROR level with a message distinguishable from a schema miss
+
+    {
+        # Minimal broken DAO stubs -- these are test-only, not production code.
+        package t::MockBrokenDB;
+        sub query { die "simulated DB connection failure\n" }
+    }
+    {
+        package t::MockBrokenDAO;
+        sub db { bless {}, 't::MockBrokenDB' }
+    }
+
+    # Temporarily replace the 'dao' helper with one that returns the broken DAO
+    my $orig_dao_helper = $t->app->renderer->helpers->{dao};
+    $t->app->helper(dao => sub { bless {}, 't::MockBrokenDAO' });
+
+    my $tenant_result;
+    my @entries = with_captured_log($t->app, 'warn', sub {
+        my $c = $t->app->build_controller;
+        $c->req->headers->header('Host' => 'errortest.localhost');
+        $tenant_result = $c->tenant;
+    });
+
+    # Restore original dao helper
+    $t->app->helper(dao => $orig_dao_helper);
+
+    is $tenant_result, 'registry',
+        'DB error still degrades to registry (resilience preserved)';
+
+    my @error_entries = grep {
+        defined $_->{level} && $_->{level} eq 'error'
+    } @entries;
+
+    ok scalar(@error_entries) > 0,
+        'DB error during schema check emits an ERROR-level log entry'
+        or diag "All captured log entries:\n" . join("\n", map { Mojo::JSON::encode_json($_) } @entries);
+
+    if (@error_entries) {
+        like $error_entries[0]{message},
+            qr/schema.existence check failed|failed.*errortest|errortest.*failed/i,
+            'error message identifies the failure as a schema-check failure';
+        unlike $error_entries[0]{message},
+            qr/resolved but has no schema/,
+            'error message does not mislabel a DB error as a missing schema';
+    }
+};
+
+done_testing();


### PR DESCRIPTION
Three observability / error-handling fixes from the architecture review.

## F-5 — log correlation context was built but never wired

`Registry::Utility::Logger` has `set_context`/`clear_context` that merge `request_id`/`user_id`/`tenant_id` into every JSON line, but they had **zero callers** — so no log line carried any correlation id. Wired them into the request lifecycle: a `before_dispatch` hook (registered after the `current_user` loader) sets the context per request; an `after_dispatch` hook emits a debug access-log line (so each request yields at least one correlated line) and clears the context. `set_context` replaces context each request, so stale fields can't leak across requests even if `after_dispatch` is skipped on error. Existing error/warn lines now carry `request_id`/`tenant_id`/`user_id`.

## F-15 — tenant resolver swallowed DB errors as "schema missing"

The per-process schema-existence check used a bare `eval` with no `$@` inspection, so a transient DB error and a genuinely-absent schema both logged the same WARN. Now `$@` is captured: a thrown error logs distinctly at **ERROR** ("schema-existence check failed … DB is down"), a clean 0-row result keeps the existing WARN. Serve-registry resilience is preserved in both cases; only real hits are cached.

## F-24 — /health was process-liveness only

`/health` returned `{status:ok}` without touching the DB. It now runs `SELECT 1` against the registry DB: 200 `{status:ok, db:ok}` on success, **503** `{status:error, db:down}` on failure (logged). Kept auth-free and minimal — no Stripe/Minion probes.

## Tests

- `t/controller/log-correlation-context.t` — routes the logger to a buffer, asserts an emitted JSON line carries `request_id`.
- `t/security/tenant-schema-error-logging.t` — proves the DB-error path logs at ERROR (not the missing-schema WARN) and still serves registry; failure injected via test-only stub packages (no production mock).
- `t/controller/health-check.t` — `/health` returns 200 + `db:ok` on a healthy app.

`t/controller/` (561) and `t/security/` (99, incl. `tenant-header-auth.t`) green; `t/dao/` unaffected.