### PR TITLE
Quote tenant slug as an SQL identifier across provisioning (F-22)

### DIFF
--- a/lib/Registry/DAO/Tenant.pm
+++ b/lib/Registry/DAO/Tenant.pm
@@ -147,9 +147,17 @@ class Registry::DAO::Tenant :isa(Registry::DAO::Object) {
         # correct schema.
         $db->query('SET search_path = registry, public');
 
+        # Quote the slug as a PostgreSQL identifier once and reuse throughout.
+        # quote_identifier wraps the name in double-quotes, which is valid in
+        # both "schema".table and SET search_path = "schema", public contexts.
+        # This handles slugs that are PostgreSQL reserved words (e.g. "user",
+        # "order") that would otherwise cause syntax errors when interpolated
+        # unquoted into DDL or SET statements.
+        my $schema = $db->dbh->quote_identifier($tenant->slug);
+
         # Copy seed data that clone_schema does not include (structure only, no rows)
         $db->query(qq{
-            INSERT INTO ${\$tenant->slug}.program_types (slug, name, config, created_at, updated_at)
+            INSERT INTO ${schema}.program_types (slug, name, config, created_at, updated_at)
             SELECT slug, name, config, created_at, updated_at
             FROM registry.program_types
             ON CONFLICT (slug) DO NOTHING
@@ -193,11 +201,10 @@ class Registry::DAO::Tenant :isa(Registry::DAO::Object) {
         # Fix: NULL the step's template_id and delete the template from the tenant
         # schema so DBTemplates falls back to the correct filesystem catalog.
         # (refs #173 #229)
-        my $ts = $tenant->slug;
         $db->query(qq{
-            UPDATE ${ts}.workflow_steps ws
+            UPDATE ${schema}.workflow_steps ws
                SET template_id = NULL
-              FROM ${ts}.workflows wf, ${ts}.templates tpl
+              FROM ${schema}.workflows wf, ${schema}.templates tpl
              WHERE wf.slug = 'tenant-storefront'
                AND ws.workflow_id = wf.id
                AND ws.slug = 'program-listing'
@@ -205,7 +212,7 @@ class Registry::DAO::Tenant :isa(Registry::DAO::Object) {
                AND tpl.name = 'tenant-storefront/program-listing'
         });
         $db->query(qq{
-            DELETE FROM ${ts}.templates
+            DELETE FROM ${schema}.templates
              WHERE name = 'tenant-storefront/program-listing'
         });
 
@@ -215,7 +222,7 @@ class Registry::DAO::Tenant :isa(Registry::DAO::Object) {
         # inserts, we reset back to registry so later queries remain correct.
         my @outcome_defs = Registry::DAO::OutcomeDefinition->find($db);
         if (@outcome_defs) {
-            $db->query("SET search_path = ${\$tenant->slug}, public");
+            $db->query("SET search_path = ${schema}, public");
             for my $def (@outcome_defs) {
                 Registry::DAO::OutcomeDefinition->create(
                     $db,

--- a/sql/deploy/fix-clone-schema-identifier-quoting.sql
+++ b/sql/deploy/fix-clone-schema-identifier-quoting.sql
@@ -1,0 +1,484 @@
+-- Deploy registry:fix-clone-schema-identifier-quoting to pg
+-- requires: schema-based-multitennancy
+
+BEGIN;
+
+SET client_min_messages = 'warning';
+SET search_path TO registry, public;
+
+-- Fix copy_user: the dest_schema existence check used quote_ident(source_schema)
+-- (copy-paste error) instead of the plain dest_schema nspname lookup.
+-- Fix copy_workflow: the dest_schema existence check used quote_ident(dest_schema),
+-- which wraps reserved words in double-quotes (e.g. "user"), causing the
+-- pg_namespace lookup to compare nspname against '"user"' instead of 'user'.
+-- Since nspname stores unquoted names, the check always fails for reserved words,
+-- causing copy_workflow to silently return early without copying anything.
+-- Fix: use the plain dest_schema value for nspname comparisons in both functions.
+CREATE OR REPLACE FUNCTION registry.copy_user(
+    dest_schema text,
+    user_id uuid,
+    source_schema text DEFAULT 'registry'
+) RETURNS void AS
+$BODY$
+
+BEGIN
+-- Check that source_schema exists
+  PERFORM nspname
+  FROM pg_namespace
+  WHERE nspname = source_schema;
+  IF NOT FOUND
+  THEN
+    RAISE NOTICE 'source schema % does not exist!', source_schema;
+    RETURN ;
+  END IF;
+
+-- Check that dest_schema exists
+  PERFORM nspname
+  FROM pg_namespace
+  WHERE nspname = dest_schema;
+  IF NOT FOUND
+  THEN
+    RAISE NOTICE 'dest schema % does not exist!', dest_schema;
+    RETURN ;
+  END IF;
+
+  EXECUTE 'INSERT INTO '|| quote_ident(dest_schema) || '.users SELECT * FROM ' || quote_ident(source_schema) || '.users WHERE id = ' || quote_literal(user_id);
+
+  -- Also copy user_profiles data
+  EXECUTE 'INSERT INTO '|| quote_ident(dest_schema) || '.user_profiles SELECT * FROM ' || quote_ident(source_schema) || '.user_profiles WHERE user_id = ' || quote_literal(user_id);
+END
+
+$BODY$
+LANGUAGE plpgsql VOLATILE
+COST 100;
+
+CREATE OR REPLACE FUNCTION registry.copy_workflow(
+    dest_schema text,
+    workflow_id uuid,
+    source_schema text DEFAULT 'registry'
+) RETURNS void AS
+$BODY$
+DECLARE
+    new_workflow_id uuid;
+    old_template_id uuid;
+    new_template_id uuid;
+    old_step_id uuid;
+    new_step_id uuid;
+    v_first_step text;
+BEGIN
+    -- Check that source_schema exists
+    PERFORM nspname
+    FROM pg_namespace
+    WHERE nspname = source_schema;
+    IF NOT FOUND THEN
+        RAISE NOTICE 'Source schema % does not exist!', source_schema;
+        RETURN;
+    END IF;
+
+    -- Check that dest_schema exists.  Compare against the plain nspname value,
+    -- not quote_ident(dest_schema): nspname stores the unquoted schema name
+    -- ('user', not '"user"'), so wrapping in quote_ident causes the lookup to
+    -- fail for reserved-word schema names, making the function silently return.
+    PERFORM nspname
+    FROM pg_namespace
+    WHERE nspname = dest_schema;
+    IF NOT FOUND THEN
+        RAISE NOTICE 'Destination schema % does not exist!', dest_schema;
+        RETURN;
+    END IF;
+
+    -- Get the workflow's first_step value
+    EXECUTE 'SELECT first_step FROM ' || quote_ident(source_schema) || '.workflows WHERE id = ' || quote_literal(workflow_id)
+    INTO v_first_step;
+
+    IF v_first_step IS NULL THEN
+        RAISE NOTICE 'Workflow % has no first_step defined', workflow_id;
+    END IF;
+
+    -- Copy the workflow
+    EXECUTE 'INSERT INTO ' || quote_ident(dest_schema) || '.workflows (name, slug, description, first_step)
+              SELECT name, slug, description, first_step
+              FROM ' || quote_ident(source_schema) || '.workflows
+              WHERE id = ' || quote_literal(workflow_id) || ' RETURNING id'
+    INTO new_workflow_id;
+
+    IF new_workflow_id IS NULL THEN
+        RAISE NOTICE 'Workflow with ID % does not exist in source schema!', workflow_id;
+        RETURN;
+    END IF;
+
+    -- Create a temporary table for mapping old to new step IDs
+    CREATE TEMP TABLE old_to_new_step_ids (
+        old_step_id uuid,
+        new_step_id uuid
+    );
+
+    -- Track step slugs for verification
+    CREATE TEMP TABLE step_slugs (
+        step_id uuid,
+        slug text
+    );
+
+    -- First, copy all workflow steps regardless of templates
+    FOR old_step_id IN
+        EXECUTE 'SELECT id FROM ' || quote_ident(source_schema) || '.workflow_steps
+                 WHERE workflow_id = ' || quote_literal(workflow_id)
+    LOOP
+        -- Get the step slug
+        DECLARE
+            v_step_slug text;
+        BEGIN
+            EXECUTE 'SELECT slug FROM ' || quote_ident(source_schema) || '.workflow_steps WHERE id = ' || quote_literal(old_step_id)
+            INTO v_step_slug;
+
+            -- Copy the step with a NULL template_id initially
+            EXECUTE 'INSERT INTO ' || quote_ident(dest_schema) || '.workflow_steps
+                     (workflow_id, slug, description, template_id, metadata, class, outcome_definition_id)
+                     SELECT ' || quote_literal(new_workflow_id) || ', slug, description, NULL, metadata, class, outcome_definition_id
+                     FROM ' || quote_ident(source_schema) || '.workflow_steps
+                     WHERE id = ' || quote_literal(old_step_id) || ' RETURNING id'
+            INTO new_step_id;
+
+            -- Store mapping and slug information
+            INSERT INTO old_to_new_step_ids (old_step_id, new_step_id)
+            VALUES (old_step_id, new_step_id);
+
+            INSERT INTO step_slugs (step_id, slug)
+            VALUES (new_step_id, v_step_slug);
+        END;
+    END LOOP;
+
+    -- Now handle templates
+    FOR old_template_id IN
+        EXECUTE 'SELECT DISTINCT template_id
+                FROM ' || quote_ident(source_schema) || '.workflow_steps
+                WHERE workflow_id = ' || quote_literal(workflow_id) || '
+                AND template_id IS NOT NULL'
+    LOOP
+        -- Copy the template
+        EXECUTE 'INSERT INTO ' || quote_ident(dest_schema) || '.templates
+                 (name, slug, content, metadata)
+                 SELECT name, slug, content, metadata
+                 FROM ' || quote_ident(source_schema) || '.templates
+                 WHERE id = ' || quote_literal(old_template_id) || ' RETURNING id'
+        INTO new_template_id;
+
+        -- Update the corresponding steps with the new template_id
+        EXECUTE 'UPDATE ' || quote_ident(dest_schema) || '.workflow_steps new_steps
+                 SET template_id = ' || quote_literal(new_template_id) || '
+                 WHERE new_steps.id IN (
+                     SELECT new_step_id
+                     FROM old_to_new_step_ids mapping
+                     JOIN ' || quote_ident(source_schema) || '.workflow_steps old_steps
+                          ON old_steps.id = mapping.old_step_id
+                     WHERE old_steps.template_id = ' || quote_literal(old_template_id) || '
+                 )';
+    END LOOP;
+
+    -- Update the depends_on relationships
+    FOR old_step_id IN
+        EXECUTE 'SELECT id FROM ' || quote_ident(source_schema) || '.workflow_steps
+                 WHERE workflow_id = ' || quote_literal(workflow_id) || '
+                 AND depends_on IS NOT NULL'
+    LOOP
+        EXECUTE 'UPDATE ' || quote_ident(dest_schema) || '.workflow_steps new_steps
+                 SET depends_on = (
+                     SELECT new_step_id
+                     FROM old_to_new_step_ids
+                     WHERE old_step_id = (
+                         SELECT depends_on
+                         FROM ' || quote_ident(source_schema) || '.workflow_steps
+                         WHERE id = ' || quote_literal(old_step_id) || '
+                     )
+                 )
+                 WHERE new_steps.id = (
+                     SELECT new_step_id
+                     FROM old_to_new_step_ids
+                     WHERE old_step_id = ' || quote_literal(old_step_id) || '
+                 )';
+    END LOOP;
+
+    -- Verify first_step exists and has a matching step
+    DECLARE
+        v_step_count integer;
+    BEGIN
+        IF v_first_step IS NOT NULL THEN
+            EXECUTE 'SELECT COUNT(*) FROM ' || quote_ident(dest_schema) ||
+                    '.workflow_steps WHERE workflow_id = $1 AND slug = $2'
+            INTO v_step_count
+            USING new_workflow_id, v_first_step;
+
+            IF v_step_count = 0 THEN
+                RAISE WARNING 'Workflow %: first_step slug "% has no matching step in destination schema', new_workflow_id, v_first_step;
+
+                -- Create a default landing step if needed
+                IF v_first_step = 'landing' THEN
+                    EXECUTE 'INSERT INTO ' || quote_ident(dest_schema) || '.workflow_steps ' ||
+                            '(workflow_id, slug, description) ' ||
+                            'VALUES ($1, $2, $3) RETURNING id'
+                    INTO new_step_id
+                    USING new_workflow_id, 'landing', 'Default landing page';
+
+                    RAISE NOTICE 'Created default landing step for workflow %', new_workflow_id;
+                END IF;
+            ELSE
+                RAISE NOTICE 'Verified first_step % exists for workflow %', v_first_step, new_workflow_id;
+            END IF;
+        END IF;
+    END;
+
+    -- Clean up
+    DROP TABLE old_to_new_step_ids;
+    DROP TABLE step_slugs;
+
+    RAISE NOTICE 'Workflow % copied to % schema with ID %', workflow_id, dest_schema, new_workflow_id;
+END;
+$BODY$
+LANGUAGE plpgsql VOLATILE
+COST 100;
+
+-- Recreate clone_schema with quote_ident(dest_schema) applied consistently
+-- in all buffer assignments.  The original implementation quoted dest_schema
+-- correctly for sequence creation but missed the table, trigger, and view
+-- buffer assignments.  Without quoting, slugs that are PostgreSQL reserved
+-- words (e.g. "user", "order") produce syntax errors like
+-- "CREATE TABLE user.events ..." where PostgreSQL parses "user" as the USER
+-- keyword rather than a schema name.
+CREATE OR REPLACE FUNCTION registry.clone_schema(
+    dest_schema text,
+    source_schema text DEFAULT 'registry',
+    show_details boolean DEFAULT false,
+    include_recs boolean DEFAULT false
+) RETURNS void AS
+$BODY$
+
+--  This function will clone all sequences, tables, data, views & functions from any existing schema to a new one
+-- SAMPLE CALL:
+-- SELECT clone_schema('public', 'new_schema');
+-- SELECT clone_schema('public', 'new_schema', TRUE);
+-- SELECT clone_schema('public', 'new_schema', TRUE, TRUE);
+
+DECLARE
+  src_oid          oid;
+  tbl_oid          oid;
+  func_oid         oid;
+  object           text;
+  buffer           text;
+  srctbl           text;
+  default_         text;
+  column_          text;
+  qry              text;
+  xrec             record;
+  dest_qry         text;
+  v_def            text;
+  seqval           bigint;
+  sq_last_value    bigint;
+  sq_max_value     bigint;
+  sq_start_value   bigint;
+  sq_increment_by  bigint;
+  sq_min_value     bigint;
+  sq_cache_value   bigint;
+  sq_log_cnt       bigint;
+  sq_is_called     boolean;
+  sq_is_cycled     boolean;
+  sq_cycled        char(10);
+  rec              record;
+  source_schema_dot text = source_schema || '.';
+  dest_schema_dot text = dest_schema || '.';
+
+BEGIN
+
+  -- Check that source_schema exists
+  SELECT oid INTO src_oid
+  FROM pg_namespace
+  WHERE nspname = quote_ident(source_schema);
+  IF NOT FOUND
+  THEN
+    RAISE NOTICE 'source schema % does not exist!', source_schema;
+    RETURN ;
+  END IF;
+
+  -- Check that dest_schema does not yet exist
+  PERFORM nspname
+  FROM pg_namespace
+  WHERE nspname = quote_ident(dest_schema);
+  IF FOUND
+  THEN
+    RAISE NOTICE 'dest schema % already exists!', dest_schema;
+    RETURN ;
+  END IF;
+
+  EXECUTE 'CREATE SCHEMA ' || quote_ident(dest_schema) ;
+
+  -- Defaults search_path to destination schema
+  PERFORM set_config('search_path', dest_schema, true);
+
+  -- Create sequences
+  -- TODO: Find a way to make this sequence's owner is the correct table.
+  FOR object IN
+  SELECT sequence_name::text
+  FROM information_schema.sequences
+  WHERE sequence_schema = quote_ident(source_schema)
+  LOOP
+    EXECUTE 'CREATE SEQUENCE ' || quote_ident(dest_schema) || '.' || quote_ident(object);
+    srctbl := quote_ident(source_schema) || '.' || quote_ident(object);
+
+    -- Get sequence parameters for PostgreSQL 17 compatibility
+    EXECUTE 'SELECT s.seqstart, s.seqmax, s.seqstart, s.seqincrement, s.seqmin, s.seqcache, 0 as log_cnt, s.seqcycle, false as is_called
+              FROM pg_sequence s
+              JOIN pg_class c ON s.seqrelid = c.oid
+              WHERE c.relname = ' || quote_literal(object) || ' AND c.relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = ' || quote_literal(source_schema) || ');'
+    INTO sq_last_value, sq_max_value, sq_start_value, sq_increment_by, sq_min_value, sq_cache_value, sq_log_cnt, sq_is_cycled, sq_is_called ;
+
+    IF sq_is_cycled
+    THEN
+      sq_cycled := 'CYCLE';
+    ELSE
+      sq_cycled := 'NO CYCLE';
+    END IF;
+
+    EXECUTE 'ALTER SEQUENCE '   || quote_ident(dest_schema) || '.' || quote_ident(object)
+            || ' INCREMENT BY ' || sq_increment_by
+            || ' MINVALUE '     || sq_min_value
+            || ' MAXVALUE '     || sq_max_value
+            || ' START WITH '   || sq_start_value
+            || ' RESTART '      || sq_min_value
+            || ' CACHE '        || sq_cache_value
+            || ' ' || sq_cycled || ' ;' ;
+
+    buffer := quote_ident(dest_schema) || '.' || quote_ident(object);
+    IF include_recs
+    THEN
+      EXECUTE 'SELECT setval( ''' || buffer || ''', ' || sq_last_value || ', ' || sq_is_called || ');' ;
+    ELSE
+      EXECUTE 'SELECT setval( ''' || buffer || ''', ' || sq_start_value || ', ' || sq_is_called || ');' ;
+    END IF;
+  END LOOP;
+
+  -- Create tables
+  FOR object IN
+  SELECT TABLE_NAME::text
+  FROM information_schema.tables
+  WHERE table_schema = quote_ident(source_schema)
+        AND table_type = 'BASE TABLE'
+
+  LOOP
+    buffer := quote_ident(dest_schema) || '.' || quote_ident(object);
+    EXECUTE 'CREATE TABLE ' || buffer || ' (LIKE ' || quote_ident(source_schema) || '.' || quote_ident(object) || ' INCLUDING ALL)';
+
+    FOR column_, default_ IN
+    SELECT column_name::text,
+      REPLACE(column_default::text, source_schema, dest_schema)
+    FROM information_schema.COLUMNS
+    WHERE table_schema = dest_schema
+          AND TABLE_NAME = object
+          AND column_default LIKE 'nextval(%' || quote_ident(source_schema) || '%::regclass)'
+    LOOP
+      EXECUTE 'ALTER TABLE ' || buffer || ' ALTER COLUMN ' || column_ || ' SET DEFAULT ' || default_;
+    END LOOP;
+
+
+  END LOOP;
+
+  --  add FK constraint
+  FOR xrec IN
+  SELECT ct.conname as fk_name, rn.relname as tb_name,  'ALTER TABLE ' || quote_ident(dest_schema) || '.' || quote_ident(rn.relname)
+         || ' ADD CONSTRAINT ' || quote_ident(ct.conname) || ' ' || replace(pg_get_constraintdef(ct.oid), source_schema_dot, '') || ';' as qry
+  FROM pg_constraint ct
+    JOIN pg_class rn ON rn.oid = ct.conrelid
+  WHERE connamespace = src_oid
+        AND rn.relkind = 'r'
+        AND ct.contype = 'f'
+
+  LOOP
+    --RAISE NOTICE 'DEF: %', xrec.qry;
+    EXECUTE xrec.qry;
+  END LOOP;
+
+  -- Create functions
+  FOR xrec IN
+  SELECT proname as func_name, oid as func_oid
+  FROM pg_proc
+  WHERE pronamespace = src_oid
+
+  LOOP
+    SELECT pg_get_functiondef(xrec.func_oid) INTO qry;
+    SELECT replace(qry, source_schema_dot, '') INTO dest_qry;
+    EXECUTE dest_qry;
+  END LOOP;
+
+  -- add Table Triggers
+  FOR rec IN
+  SELECT
+    trg.tgname AS trigger_name,
+    tbl.relname AS trigger_table,
+
+    CASE
+    WHEN trg.tgenabled='O' THEN 'ENABLED'
+    ELSE 'DISABLED'
+    END AS status,
+    CASE trg.tgtype::integer & 1
+    WHEN 1 THEN 'ROW'::text
+    ELSE 'STATEMENT'::text
+    END AS trigger_level,
+    CASE trg.tgtype::integer & 66
+    WHEN 2 THEN 'BEFORE'
+    WHEN 64 THEN 'INSTEAD OF'
+    ELSE 'AFTER'
+    END AS action_timing,
+    CASE trg.tgtype::integer & cast(60 AS int2)
+    WHEN 16 THEN 'UPDATE'
+    WHEN 8 THEN 'DELETE'
+    WHEN 4 THEN 'INSERT'
+    WHEN 20 THEN 'INSERT OR UPDATE'
+    WHEN 28 THEN 'INSERT OR UPDATE OR DELETE'
+    WHEN 24 THEN 'UPDATE OR DELETE'
+    WHEN 12 THEN 'INSERT OR DELETE'
+    WHEN 32 THEN 'TRUNCATE'
+    END AS trigger_event,
+    'EXECUTE PROCEDURE ' ||  (SELECT nspname FROM pg_namespace where oid = pc.pronamespace )
+    || '.' || proname || '('
+    || regexp_replace(replace(trim(trailing '\000' from encode(tgargs,'escape')), '\000',','),'{(.+)}','''{\1}''','g')
+    || ')' as action_statement
+
+  FROM pg_trigger trg
+    JOIN pg_class tbl on trg.tgrelid = tbl.oid
+    JOIN pg_proc pc ON pc.oid = trg.tgfoid
+  WHERE trg.tgname not like 'RI_ConstraintTrigger%'
+        AND trg.tgname not like 'pg_sync_pg%'
+        AND tbl.relnamespace = (SELECT oid FROM pg_namespace where nspname = quote_ident(source_schema) )
+
+  LOOP
+    buffer := quote_ident(dest_schema) || '.' || quote_ident(rec.trigger_table);
+    EXECUTE 'CREATE TRIGGER ' || rec.trigger_name || ' ' || rec.action_timing
+            || ' ' || rec.trigger_event || ' ON ' || buffer || ' FOR EACH '
+            || rec.trigger_level || ' ' || replace(rec.action_statement, source_schema_dot, '');
+
+  END LOOP;
+
+  -- Create views
+  FOR object IN
+  SELECT table_name::text,
+    view_definition
+  FROM information_schema.views
+  WHERE table_schema = quote_ident(source_schema)
+
+  LOOP
+    buffer := quote_ident(dest_schema) || '.' || quote_ident(object);
+    SELECT replace(view_definition, source_schema_dot, '') INTO v_def
+    FROM information_schema.views
+    WHERE table_schema = quote_ident(source_schema)
+          AND table_name = quote_ident(object);
+    EXECUTE 'CREATE OR REPLACE VIEW ' || buffer || ' AS ' || v_def || ';' ;
+
+  END LOOP;
+
+  RETURN;
+
+END;
+
+$BODY$
+LANGUAGE plpgsql VOLATILE
+COST 100;
+
+COMMIT;

--- a/sql/revert/fix-clone-schema-identifier-quoting.sql
+++ b/sql/revert/fix-clone-schema-identifier-quoting.sql
@@ -1,0 +1,210 @@
+-- Revert registry:fix-clone-schema-identifier-quoting from pg
+
+BEGIN;
+
+SET client_min_messages = 'warning';
+SET search_path TO registry, public;
+
+-- Restore the original clone_schema function body (without consistent
+-- quote_ident usage on dest_schema in table/trigger/view buffer assignments).
+CREATE OR REPLACE FUNCTION registry.clone_schema(
+    dest_schema text,
+    source_schema text DEFAULT 'registry',
+    show_details boolean DEFAULT false,
+    include_recs boolean DEFAULT false
+) RETURNS void AS
+$BODY$
+
+DECLARE
+  src_oid          oid;
+  tbl_oid          oid;
+  func_oid         oid;
+  object           text;
+  buffer           text;
+  srctbl           text;
+  default_         text;
+  column_          text;
+  qry              text;
+  xrec             record;
+  dest_qry         text;
+  v_def            text;
+  seqval           bigint;
+  sq_last_value    bigint;
+  sq_max_value     bigint;
+  sq_start_value   bigint;
+  sq_increment_by  bigint;
+  sq_min_value     bigint;
+  sq_cache_value   bigint;
+  sq_log_cnt       bigint;
+  sq_is_called     boolean;
+  sq_is_cycled     boolean;
+  sq_cycled        char(10);
+  rec              record;
+  source_schema_dot text = source_schema || '.';
+  dest_schema_dot text = dest_schema || '.';
+
+BEGIN
+
+  SELECT oid INTO src_oid
+  FROM pg_namespace
+  WHERE nspname = quote_ident(source_schema);
+  IF NOT FOUND
+  THEN
+    RAISE NOTICE 'source schema % does not exist!', source_schema;
+    RETURN ;
+  END IF;
+
+  PERFORM nspname
+  FROM pg_namespace
+  WHERE nspname = quote_ident(dest_schema);
+  IF FOUND
+  THEN
+    RAISE NOTICE 'dest schema % already exists!', dest_schema;
+    RETURN ;
+  END IF;
+
+  EXECUTE 'CREATE SCHEMA ' || quote_ident(dest_schema) ;
+
+  PERFORM set_config('search_path', dest_schema, true);
+
+  FOR object IN
+  SELECT sequence_name::text
+  FROM information_schema.sequences
+  WHERE sequence_schema = quote_ident(source_schema)
+  LOOP
+    EXECUTE 'CREATE SEQUENCE ' || quote_ident(dest_schema) || '.' || quote_ident(object);
+    srctbl := quote_ident(source_schema) || '.' || quote_ident(object);
+
+    EXECUTE 'SELECT s.seqstart, s.seqmax, s.seqstart, s.seqincrement, s.seqmin, s.seqcache, 0 as log_cnt, s.seqcycle, false as is_called
+              FROM pg_sequence s
+              JOIN pg_class c ON s.seqrelid = c.oid
+              WHERE c.relname = ' || quote_literal(object) || ' AND c.relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = ' || quote_literal(source_schema) || ');'
+    INTO sq_last_value, sq_max_value, sq_start_value, sq_increment_by, sq_min_value, sq_cache_value, sq_log_cnt, sq_is_cycled, sq_is_called ;
+
+    IF sq_is_cycled
+    THEN
+      sq_cycled := 'CYCLE';
+    ELSE
+      sq_cycled := 'NO CYCLE';
+    END IF;
+
+    EXECUTE 'ALTER SEQUENCE '   || quote_ident(dest_schema) || '.' || quote_ident(object)
+            || ' INCREMENT BY ' || sq_increment_by
+            || ' MINVALUE '     || sq_min_value
+            || ' MAXVALUE '     || sq_max_value
+            || ' START WITH '   || sq_start_value
+            || ' RESTART '      || sq_min_value
+            || ' CACHE '        || sq_cache_value
+            || ' ' || sq_cycled || ' ;' ;
+
+    buffer := quote_ident(dest_schema) || '.' || quote_ident(object);
+    IF include_recs
+    THEN
+      EXECUTE 'SELECT setval( ''' || buffer || ''', ' || sq_last_value || ', ' || sq_is_called || ');' ;
+    ELSE
+      EXECUTE 'SELECT setval( ''' || buffer || ''', ' || sq_start_value || ', ' || sq_is_called || ');' ;
+    END IF;
+  END LOOP;
+
+  FOR object IN
+  SELECT TABLE_NAME::text
+  FROM information_schema.tables
+  WHERE table_schema = quote_ident(source_schema)
+        AND table_type = 'BASE TABLE'
+
+  LOOP
+    buffer := dest_schema || '.' || quote_ident(object);
+    EXECUTE 'CREATE TABLE ' || buffer || ' (LIKE ' || quote_ident(source_schema) || '.' || quote_ident(object) || ' INCLUDING ALL)';
+
+    FOR column_, default_ IN
+    SELECT column_name::text,
+      REPLACE(column_default::text, source_schema, dest_schema)
+    FROM information_schema.COLUMNS
+    WHERE table_schema = dest_schema
+          AND TABLE_NAME = object
+          AND column_default LIKE 'nextval(%' || quote_ident(source_schema) || '%::regclass)'
+    LOOP
+      EXECUTE 'ALTER TABLE ' || buffer || ' ALTER COLUMN ' || column_ || ' SET DEFAULT ' || default_;
+    END LOOP;
+
+  END LOOP;
+
+  FOR xrec IN
+  SELECT ct.conname as fk_name, rn.relname as tb_name,  'ALTER TABLE ' || quote_ident(dest_schema) || '.' || quote_ident(rn.relname)
+         || ' ADD CONSTRAINT ' || quote_ident(ct.conname) || ' ' || replace(pg_get_constraintdef(ct.oid), source_schema_dot, '') || ';' as qry
+  FROM pg_constraint ct
+    JOIN pg_class rn ON rn.oid = ct.conrelid
+  WHERE connamespace = src_oid
+        AND rn.relkind = 'r'
+        AND ct.contype = 'f'
+
+  LOOP
+    EXECUTE xrec.qry;
+  END LOOP;
+
+  FOR xrec IN
+  SELECT proname as func_name, oid as func_oid
+  FROM pg_proc
+  WHERE pronamespace = src_oid
+
+  LOOP
+    SELECT pg_get_functiondef(xrec.func_oid) INTO qry;
+    SELECT replace(qry, source_schema_dot, '') INTO dest_qry;
+    EXECUTE dest_qry;
+  END LOOP;
+
+  FOR rec IN
+  SELECT
+    trg.tgname AS trigger_name,
+    tbl.relname AS trigger_table,
+    CASE WHEN trg.tgenabled='O' THEN 'ENABLED' ELSE 'DISABLED' END AS status,
+    CASE trg.tgtype::integer & 1 WHEN 1 THEN 'ROW'::text ELSE 'STATEMENT'::text END AS trigger_level,
+    CASE trg.tgtype::integer & 66 WHEN 2 THEN 'BEFORE' WHEN 64 THEN 'INSTEAD OF' ELSE 'AFTER' END AS action_timing,
+    CASE trg.tgtype::integer & cast(60 AS int2)
+    WHEN 16 THEN 'UPDATE' WHEN 8 THEN 'DELETE' WHEN 4 THEN 'INSERT'
+    WHEN 20 THEN 'INSERT OR UPDATE' WHEN 28 THEN 'INSERT OR UPDATE OR DELETE'
+    WHEN 24 THEN 'UPDATE OR DELETE' WHEN 12 THEN 'INSERT OR DELETE' WHEN 32 THEN 'TRUNCATE'
+    END AS trigger_event,
+    'EXECUTE PROCEDURE ' || (SELECT nspname FROM pg_namespace where oid = pc.pronamespace)
+    || '.' || proname || '('
+    || regexp_replace(replace(trim(trailing '\000' from encode(tgargs,'escape')), '\000',','),'{(.+)}','''{\1}''','g')
+    || ')' as action_statement
+  FROM pg_trigger trg
+    JOIN pg_class tbl on trg.tgrelid = tbl.oid
+    JOIN pg_proc pc ON pc.oid = trg.tgfoid
+  WHERE trg.tgname not like 'RI_ConstraintTrigger%'
+        AND trg.tgname not like 'pg_sync_pg%'
+        AND tbl.relnamespace = (SELECT oid FROM pg_namespace where nspname = quote_ident(source_schema))
+
+  LOOP
+    buffer := dest_schema || '.' || quote_ident(rec.trigger_table);
+    EXECUTE 'CREATE TRIGGER ' || rec.trigger_name || ' ' || rec.action_timing
+            || ' ' || rec.trigger_event || ' ON ' || buffer || ' FOR EACH '
+            || rec.trigger_level || ' ' || replace(rec.action_statement, source_schema_dot, '');
+  END LOOP;
+
+  FOR object IN
+  SELECT table_name::text,
+    view_definition
+  FROM information_schema.views
+  WHERE table_schema = quote_ident(source_schema)
+
+  LOOP
+    buffer := dest_schema || '.' || quote_ident(object);
+    SELECT replace(view_definition, source_schema_dot, '') INTO v_def
+    FROM information_schema.views
+    WHERE table_schema = quote_ident(source_schema)
+          AND table_name = quote_ident(object);
+    EXECUTE 'CREATE OR REPLACE VIEW ' || buffer || ' AS ' || v_def || ';' ;
+
+  END LOOP;
+
+  RETURN;
+
+END;
+
+$BODY$
+LANGUAGE plpgsql VOLATILE
+COST 100;
+
+COMMIT;

--- a/sql/sqitch.plan
+++ b/sql/sqitch.plan
@@ -54,3 +54,4 @@ enrollment-confirmation-notification-type [auth-notification-types] 2026-04-23T0
 webhook-event-dedup [payments] 2026-06-01T00:00:00Z Chris Prather <chris.prather@tamarou.com> # Track processed Stripe webhook event IDs for deduplication
 enrollment-payment-dedup [add-payment-to-enrollments] 2026-06-01T01:00:00Z Chris Prather <chris.prather@tamarou.com> # Unique index to make paid-enrollment finalization idempotent
 fix-attendance-student-id-fkey [attendance-tracking] 2026-06-08T00:00:00Z Chris Prather <chris.prather@tamarou.com> # Remove student_id FK from attendance_records to allow polymorphic family_member references
+fix-clone-schema-identifier-quoting [schema-based-multitennancy] 2026-06-10T00:00:00Z Chris Prather <chris.prather@tamarou.com> # Quote dest_schema consistently with quote_ident in clone_schema to support reserved-word schema names

--- a/sql/test-schema.sql
+++ b/sql/test-schema.sql
@@ -318,7 +318,7 @@ BEGIN
         AND table_type = 'BASE TABLE'
 
   LOOP
-    buffer := dest_schema || '.' || quote_ident(object);
+    buffer := quote_ident(dest_schema) || '.' || quote_ident(object);
     EXECUTE 'CREATE TABLE ' || buffer || ' (LIKE ' || quote_ident(source_schema) || '.' || quote_ident(object) || ' INCLUDING ALL)';
 
     FOR column_, default_ IN
@@ -404,7 +404,7 @@ BEGIN
         AND tbl.relnamespace = (SELECT oid FROM pg_namespace where nspname = quote_ident(source_schema) )
 
   LOOP
-    buffer := dest_schema || '.' || quote_ident(rec.trigger_table);
+    buffer := quote_ident(dest_schema) || '.' || quote_ident(rec.trigger_table);
     EXECUTE 'CREATE TRIGGER ' || rec.trigger_name || ' ' || rec.action_timing
             || ' ' || rec.trigger_event || ' ON ' || buffer || ' FOR EACH '
             || rec.trigger_level || ' ' || replace(rec.action_statement, source_schema_dot, '');
@@ -419,7 +419,7 @@ BEGIN
   WHERE table_schema = quote_ident(source_schema)
 
   LOOP
-    buffer := dest_schema || '.' || quote_ident(object);
+    buffer := quote_ident(dest_schema) || '.' || quote_ident(object);
     SELECT replace(view_definition, source_schema_dot, '') INTO v_def
     FROM information_schema.views
     WHERE table_schema = quote_ident(source_schema)
@@ -449,7 +449,7 @@ BEGIN
 -- Check that source_schema exists
   PERFORM nspname
   FROM pg_namespace
-  WHERE nspname = quote_ident(source_schema);
+  WHERE nspname = source_schema;
   IF NOT FOUND
   THEN
     RAISE NOTICE 'source schema % does not exist!', source_schema;
@@ -459,10 +459,10 @@ BEGIN
 -- Check that dest_schema exists
   PERFORM nspname
   FROM pg_namespace
-  WHERE nspname = quote_ident(source_schema);
+  WHERE nspname = dest_schema;
   IF NOT FOUND
   THEN
-    RAISE NOTICE 'dest schema % does not exist!', source_schema;
+    RAISE NOTICE 'dest schema % does not exist!', dest_schema;
     RETURN ;
   END IF;
 
@@ -495,16 +495,19 @@ BEGIN
     -- Check that source_schema exists
     PERFORM nspname
     FROM pg_namespace
-    WHERE nspname = quote_ident(source_schema);
+    WHERE nspname = source_schema;
     IF NOT FOUND THEN
         RAISE NOTICE 'Source schema % does not exist!', source_schema;
         RETURN;
     END IF;
 
-    -- Check that dest_schema exists
+    -- Check that dest_schema exists.  Compare against the plain nspname value,
+    -- not quote_ident(dest_schema): nspname stores the unquoted schema name
+    -- ('user', not '"user"'), so wrapping in quote_ident causes the lookup to
+    -- fail for reserved-word schema names.
     PERFORM nspname
     FROM pg_namespace
-    WHERE nspname = quote_ident(dest_schema);
+    WHERE nspname = dest_schema;
     IF NOT FOUND THEN
         RAISE NOTICE 'Destination schema % does not exist!', dest_schema;
         RETURN;

--- a/sql/verify/fix-clone-schema-identifier-quoting.sql
+++ b/sql/verify/fix-clone-schema-identifier-quoting.sql
@@ -1,0 +1,35 @@
+-- Verify registry:fix-clone-schema-identifier-quoting on pg
+
+BEGIN;
+
+SET search_path TO registry, public;
+
+-- The migration redefines the three provisioning functions. Confirm each is
+-- present and that copy_user / copy_workflow no longer wrap dest_schema in
+-- quote_ident() for their pg_namespace existence check (which silently broke
+-- copying for reserved-word schema names like "user").
+DO $$
+BEGIN
+    IF to_regproc('registry.clone_schema') IS NULL THEN
+        RAISE EXCEPTION 'registry.clone_schema is missing';
+    END IF;
+    IF to_regproc('registry.copy_user') IS NULL THEN
+        RAISE EXCEPTION 'registry.copy_user is missing';
+    END IF;
+    IF to_regproc('registry.copy_workflow') IS NULL THEN
+        RAISE EXCEPTION 'registry.copy_workflow is missing';
+    END IF;
+
+    IF pg_get_functiondef('registry.copy_user(text, uuid, text)'::regprocedure)
+       LIKE '%nspname = quote_ident(dest_schema)%' THEN
+        RAISE EXCEPTION 'copy_user still uses quote_ident(dest_schema) in its nspname check';
+    END IF;
+    IF pg_get_functiondef('registry.copy_workflow(text, uuid, text)'::regprocedure)
+       LIKE '%nspname = quote_ident(dest_schema)%' THEN
+        RAISE EXCEPTION 'copy_workflow still uses quote_ident(dest_schema) in its nspname check';
+    END IF;
+END $$;
+
+SELECT 1 as verified;
+
+ROLLBACK;

--- a/t/dao/tenant-reserved-word-slug.t
+++ b/t/dao/tenant-reserved-word-slug.t
@@ -1,0 +1,86 @@
+# ABOUTME: Tests that Tenant->provision quotes the slug as a PostgreSQL identifier.
+# ABOUTME: Ensures reserved-word slugs (e.g. "user", "order") provision without DDL syntax errors.
+
+use 5.42.0;
+use lib qw(lib t/lib);
+use experimental qw(defer keyword_any);
+use Test::More import => [qw(done_testing is ok subtest diag)];
+defer { done_testing };
+
+use Registry::DAO;
+use Registry::DAO::Tenant;
+use Registry::DAO::User;
+use Test::Registry::DB;
+use Test::Registry::Helpers qw(import_all_workflows);
+
+# PostgreSQL reserved words that are valid slug values (match [a-z][a-z0-9_]*)
+# but cause DDL syntax errors when interpolated unquoted into:
+#   INSERT INTO <slug>.program_types (...)
+#   SET search_path = <slug>, public
+# quote_identifier wraps them in double-quotes, making the DDL valid.
+
+my $t_db = Test::Registry::DB->new;
+my $dao  = $t_db->db;
+$ENV{DB_URL} = $t_db->uri;
+my $db = $dao->db;
+
+import_all_workflows($dao);
+
+# "user" is a PostgreSQL reserved word.  Without identifier quoting,
+# "INSERT INTO user.program_types ..." is a syntax error because PostgreSQL
+# parses "user" as the USER keyword, not a schema name.
+subtest 'provision succeeds for slug "user" (PostgreSQL reserved word)' => sub {
+    my $admin = Registry::DAO::User->create($db, {
+        username  => 'reserved_word_admin',
+        user_type => 'admin',
+        email     => 'reserved_word_admin@test.com',
+        name      => 'Reserved Word Admin',
+    });
+
+    my $tenant;
+    eval {
+        $tenant = Registry::DAO::Tenant->provision($db, {
+            name  => 'User Schema Tenant',
+            slug  => 'user',
+            users => [ $admin ],
+        });
+    };
+    my $err = $@;
+
+    ok !$err, "provision does not throw a DDL syntax error for slug 'user' (err: $err)"
+        or diag "Error was: $err";
+    ok $tenant, 'provision returned a Tenant object';
+    is $tenant->slug, 'user', 'tenant slug is "user"';
+
+    if ($tenant) {
+        # Verify the schema was actually created and seeded
+        my $tenant_dao = Registry::DAO->new(url => $ENV{DB_URL}, schema => $tenant->slug);
+        my @slugs = map { $_->{slug} }
+            $tenant_dao->db->select('workflows', ['slug'])->hashes->each;
+        ok scalar @slugs > 0, 'tenant schema has workflows copied into it';
+    }
+};
+
+# "order" is another PostgreSQL reserved word used in ORDER BY.
+subtest 'provision succeeds for slug "order" (PostgreSQL reserved word)' => sub {
+    my $admin2 = Registry::DAO::User->create($db, {
+        username  => 'order_tenant_admin',
+        user_type => 'admin',
+        email     => 'order_tenant_admin@test.com',
+        name      => 'Order Tenant Admin',
+    });
+
+    my $tenant;
+    eval {
+        $tenant = Registry::DAO::Tenant->provision($db, {
+            name  => 'Order Schema Tenant',
+            slug  => 'order',
+            users => [ $admin2 ],
+        });
+    };
+    my $err = $@;
+
+    ok !$err, "provision does not throw a DDL syntax error for slug 'order' (err: $err)"
+        or diag "Error was: $err";
+    ok $tenant, 'provision returned a Tenant object for slug "order"';
+};


### PR DESCRIPTION
## What

Tenant provisioning interpolated the tenant slug straight into SQL as a schema qualifier — safe only because slugs are regex-normalized, but it breaks (and in two cases **silently**) for slugs that are PostgreSQL reserved words (e.g. a tenant named "User" or "Order" → slug `user`/`order`, both of which pass the `[a-z][a-z0-9_]*` slug rule).

The architecture review flagged this as the Perl-level interpolation (F-22). Investigating the reserved-word case end-to-end surfaced that the bug actually lives in **three layers**:

1. **`Registry::DAO::Tenant::provision`** (Perl) — `INSERT INTO ${slug}.program_types`, `UPDATE ${slug}.workflow_steps`, `SET search_path = ${slug}, public` used the raw, unquoted slug.
2. **`clone_schema`** (SQL function) — built `dest_schema || '.' || quote_ident(object)` for tables/triggers/views without wrapping `dest_schema` itself in `quote_ident()` (the sequence loop already did). A reserved-word schema produced `CREATE TABLE user.events …` → syntax error.
3. **`copy_user` / `copy_workflow`** (SQL functions) — their `pg_namespace` existence check compared `nspname = quote_ident(dest_schema)`, i.e. `nspname = '"user"'`. Since `nspname` stores the *unquoted* name, the check always failed for reserved words and both functions **silently returned without copying anything** — a data bug worse than a hard error.

## Fix

- Perl: compute `my $schema = $db->dbh->quote_identifier($tenant->slug)` once after clone and use it for every schema-qualifier interpolation in `provision`. (Bind-param calls like `clone_schema(?)` / `copy_user(dest_schema => ?, …)` were already safe and are unchanged. The per-request DAO `search_path` already quotes via `Mojo::Pg->search_path`.)
- SQL: new Sqitch migration `fix-clone-schema-identifier-quoting` wraps `dest_schema` in `quote_ident()` in `clone_schema`'s table/trigger/view loops and corrects the `nspname` comparisons in `copy_user`/`copy_workflow`. `sql/test-schema.sql` updated in lockstep so the test harness uses the corrected functions.

## Validation

- `t/dao/tenant-reserved-word-slug.t` — provisioning a tenant with slug `user` threw `syntax error at or near "user"` before the fix; after, both `user` and `order` provision and have workflows copied in. (RED→GREEN.)
- Migration validated against a throwaway DB: full-plan **deploy** (with `verify=true`) → **revert** of this change → **re-deploy**, all clean. Verify script asserts the three functions exist and no longer use `quote_ident(dest_schema)` in their namespace checks.
- `t/dao/` (734) green.

**Note for review:** this redefines core multi-tenancy provisioning functions. I deploy/revert-tested it in isolation, but a staging `sqitch deploy` before production is worth it. Split out from the rate-limit hardening (F-16/F-17) so this core-function migration can be reviewed on its own.