### PR TITLE
Harden rate limiting: real client IP + throttle magic-link requests (F-16, F-17)

### DIFF
--- a/lib/Registry/Middleware/RateLimit.pm
+++ b/lib/Registry/Middleware/RateLimit.pm
@@ -40,14 +40,24 @@ sub new ($class, %args) {
 }
 
 # Returns the rate-limit key for a request context.
-# Uses authenticated user ID when available, otherwise falls back to IP.
+# Uses the TCP connection peer address ($c->tx->remote_address) as the key.
+#
+# Trust model: Mojolicious populates remote_address from X-Forwarded-For only
+# when reverse-proxy mode is enabled (MOJO_REVERSE_PROXY=1 or
+# $app->config->{hypnotoad}{proxy} = 1).  In that mode Mojolicious trusts the
+# first hop's XFF header because the connection peer is a known trusted proxy.
+# Reading the raw X-Forwarded-For header here instead would let any client
+# rotate the header to obtain a fresh counter on every request, defeating the
+# per-IP auth limit entirely.
+#
+# DEPLOYMENT NOTE: Registry runs behind Render's HTTP proxy.  MOJO_REVERSE_PROXY
+# must be set to 1 in the production environment so that remote_address resolves
+# to the real client IP rather than the proxy IP.  Without it every client will
+# share the proxy's address as the key, which would allow only a small number of
+# requests before the limit trips for all users simultaneously.  See render.yaml
+# and the app startup block for where to add this env var.
 sub _request_key ($class_or_self, $c) {
-    my $ip = $c->req->headers->header('X-Forwarded-For')
-          // $c->tx->remote_address
-          // '127.0.0.1';
-    # Take only the first IP in case of a list ("client, proxy1, proxy2")
-    $ip =~ s/,.*$//;
-    $ip =~ s/\s+//g;
+    my $ip = $c->tx->remote_address // '127.0.0.1';
     return $ip;
 }
 

--- a/lib/Registry/Middleware/RateLimit.pm
+++ b/lib/Registry/Middleware/RateLimit.pm
@@ -137,7 +137,14 @@ sub before_dispatch ($class_or_self, $c) {
     my $key   = $class_or_self->_request_key($c);
     my $limit = $class_or_self->_limit_for_path($path);
 
-    my %result = $class_or_self->check($key, $limit);
+    # Scope the counter by limit class so ordinary browsing (general limit)
+    # does not consume the much smaller auth budget.  With a single shared
+    # counter per IP, a user who viewed a dozen pages would be rejected on
+    # their first login attempt because the combined count already exceeded
+    # the auth limit.
+    my $class = $limit == $AUTH_LIMIT ? 'auth' : 'general';
+
+    my %result = $class_or_self->check("$class:$key", $limit);
 
     unless ($result{allowed}) {
         my $retry_after = $result{retry_after};

--- a/lib/Registry/Middleware/RateLimit.pm
+++ b/lib/Registry/Middleware/RateLimit.pm
@@ -7,13 +7,20 @@ package Registry::Middleware::RateLimit;
 
 # --- Configuration constants ---
 
-# Credential-sensitive route patterns (login, password reset) - tighter limit.
-# Only paths where brute-forcing credentials is a meaningful threat belong here.
-# Signup/registration flows require many sequential requests per legitimate user
-# and should use the general (higher) limit instead.
+# Credential-sensitive route patterns - tighter limit.
+# Only paths where brute-forcing credentials or issuing auth tokens is a
+# meaningful threat belong here.  Signup/registration flows require many
+# sequential requests per legitimate user and should use the general (higher)
+# limit instead.
+#
+# "magic/request" matches /auth/magic/request (the magic-link token-issuance
+# endpoint) precisely.  The _limit_for_path regex anchors on path segments so
+# it does NOT match /auth/magic/poll/ (which is already in @EXCLUDED_PREFIXES)
+# or other /auth/magic/... routes.
 our @AUTH_PATHS = qw(
     login
     password
+    magic/request
 );
 
 # Route prefixes that bypass rate limiting entirely

--- a/render.yaml
+++ b/render.yaml
@@ -58,6 +58,13 @@ services:
         value: 10000
       - key: SERVICE_TYPE
         value: web
+      # Render terminates TLS and proxies to the app. Enable Mojolicious
+      # reverse-proxy mode so tx->remote_address reflects the real client IP
+      # (from Render's trusted X-Forwarded-For) instead of the proxy address.
+      # The rate limiter keys on remote_address, so this is required for the
+      # per-client limit to apply per user rather than collectively.
+      - key: MOJO_REVERSE_PROXY
+        value: 1
     healthCheckPath: /health
     autoDeploy: true
     disk:

--- a/t/security/rate-limit-class-isolation.t
+++ b/t/security/rate-limit-class-isolation.t
@@ -1,0 +1,97 @@
+# ABOUTME: Tests that general traffic does not consume the (smaller) auth rate-limit budget.
+# ABOUTME: The counter must be scoped per limit class, not shared across all paths for an IP.
+
+use 5.42.0;
+use FindBin qw($Bin);
+use lib "$Bin/../../lib", "$Bin/../lib", "lib", "t/lib";
+use experimental qw(defer);
+use Test::More import => [qw( done_testing is ok subtest )];
+defer { done_testing };
+
+use Registry::Middleware::RateLimit;
+
+# Minimal controller stub sufficient for before_dispatch: a path, a peer
+# address, and enough of the render plumbing to observe a 429.
+
+package Fake::Path;
+sub new { my ($class, $path) = @_; bless { path => $path }, $class }
+sub to_string { $_[0]->{path} }
+
+package Fake::Url;
+sub new { my ($class, $path) = @_; bless { path => Fake::Path->new($path) }, $class }
+sub path { $_[0]->{path} }
+
+package Fake::Headers;
+sub new { bless {}, shift }
+sub header { undef }
+
+package Fake::Request;
+sub new { my ($class, $path) = @_; bless { path => $path }, $class }
+sub url { Fake::Url->new( $_[0]->{path} ) }
+sub headers { Fake::Headers->new }
+
+package Fake::ResHeaders;
+sub new { bless {}, shift }
+sub header { }
+
+package Fake::Response;
+sub new { bless {}, shift }
+sub headers { Fake::ResHeaders->new }
+
+package Fake::Tx;
+sub new { my ($class, $ip) = @_; bless { ip => $ip }, $class }
+sub remote_address { $_[0]->{ip} }
+
+package Fake::Controller;
+sub new {
+    my ($class, %args) = @_;
+    bless { %args, rendered_status => undef }, $class;
+}
+sub req { Fake::Request->new( $_[0]->{path} ) }
+sub tx  { Fake::Tx->new( $_[0]->{ip} ) }
+sub res { Fake::Response->new }
+sub render   { my ($self, %args) = @_; $self->{rendered_status} = $args{status}; }
+sub rendered { my ($self, $status) = @_; $self->{rendered_status} //= $status; }
+sub was_limited { ($_[0]->{rendered_status} // 0) == 429 }
+
+package main;
+
+# Drive a request through the real before_dispatch hook and report whether
+# it was rejected with a 429.
+sub request_limited ($rl, $ip, $path) {
+    my $c = Fake::Controller->new( ip => $ip, path => $path );
+    $rl->before_dispatch($c);
+    return $c->was_limited;
+}
+
+subtest 'general traffic does not consume the auth budget' => sub {
+    my $rl = Registry::Middleware::RateLimit->new;
+
+    # 20 ordinary page requests from one client: legitimate browsing, well
+    # under the general limit of 100.
+    for my $i (1 .. 20) {
+        ok !request_limited($rl, '198.51.100.7', '/programs/some-page'),
+            "general request $i is allowed";
+    }
+
+    # The client now tries to log in.  The auth limit (10) must apply to AUTH
+    # traffic only; the 20 general requests must not have consumed it.
+    ok !request_limited($rl, '198.51.100.7', '/auth/magic/request'),
+        'auth request after heavy general browsing is still allowed';
+};
+
+subtest 'auth budget is still enforced independently' => sub {
+    my $rl = Registry::Middleware::RateLimit->new;
+
+    for my $i (1 .. $Registry::Middleware::RateLimit::AUTH_LIMIT) {
+        ok !request_limited($rl, '198.51.100.8', '/auth/magic/request'),
+            "auth request $i within the limit is allowed";
+    }
+
+    ok request_limited($rl, '198.51.100.8', '/auth/magic/request'),
+        'auth request beyond the limit is rejected';
+
+    # Exhausting the auth budget must not block ordinary browsing.
+    ok !request_limited($rl, '198.51.100.8', '/programs/some-page'),
+        'general request is unaffected by an exhausted auth budget';
+};

--- a/t/security/rate-limit-magic-request.t
+++ b/t/security/rate-limit-magic-request.t
@@ -1,0 +1,50 @@
+# ABOUTME: Tests that /auth/magic/request uses the tight auth rate limit (10/min).
+# ABOUTME: Verifies the magic-link request endpoint is not left on the general 100/min limit.
+
+use 5.42.0;
+use FindBin qw($Bin);
+use lib "$Bin/../../lib", "$Bin/../lib", "lib", "t/lib";
+use experimental qw(defer);
+use Test::More import => [qw( done_testing is isnt ok plan subtest )];
+defer { done_testing };
+
+use Registry::Middleware::RateLimit;
+
+# /auth/magic/request issues a magic-link email and consumes a token-generation
+# budget.  It must be limited at the AUTH_LIMIT (10/min), not the GENERAL_LIMIT
+# (100/min), to prevent email bombing and account enumeration.
+
+subtest '_limit_for_path returns AUTH_LIMIT for /auth/magic/request' => sub {
+    my $rl = Registry::Middleware::RateLimit->new;
+
+    my $limit = $rl->_limit_for_path('/auth/magic/request');
+    is $limit, $Registry::Middleware::RateLimit::AUTH_LIMIT,
+        '/auth/magic/request gets the AUTH_LIMIT (10), not the GENERAL_LIMIT (100)';
+};
+
+subtest '_limit_for_path returns GENERAL_LIMIT for unrelated auth paths' => sub {
+    my $rl = Registry::Middleware::RateLimit->new;
+
+    # /auth/magic/poll/ is in @EXCLUDED_PREFIXES and never reaches _limit_for_path,
+    # but if it did it must NOT accidentally match the magic/request pattern.
+    my $poll_limit = $rl->_limit_for_path('/auth/magic/poll/abc123');
+    is $poll_limit, $Registry::Middleware::RateLimit::GENERAL_LIMIT,
+        '/auth/magic/poll/... does not match the magic/request auth pattern';
+
+    # Other /auth/ paths that are not login, password, or magic/request
+    my $other_limit = $rl->_limit_for_path('/auth/webauthn/auth/begin');
+    is $other_limit, $Registry::Middleware::RateLimit::GENERAL_LIMIT,
+        'non-auth-sensitive /auth/... paths still get GENERAL_LIMIT';
+};
+
+subtest '_limit_for_path still returns AUTH_LIMIT for existing auth patterns' => sub {
+    my $rl = Registry::Middleware::RateLimit->new;
+
+    is $rl->_limit_for_path('/login'),
+        $Registry::Middleware::RateLimit::AUTH_LIMIT,
+        '/login still gets AUTH_LIMIT after adding magic/request';
+
+    is $rl->_limit_for_path('/auth/password'),
+        $Registry::Middleware::RateLimit::AUTH_LIMIT,
+        '/auth/password still gets AUTH_LIMIT after adding magic/request';
+};

--- a/t/security/rate-limit-xff-spoof.t
+++ b/t/security/rate-limit-xff-spoof.t
@@ -1,0 +1,102 @@
+# ABOUTME: Tests that rate-limit key uses connection peer address, not X-Forwarded-For.
+# ABOUTME: Proves header spoofing does not allow a single client to reset its rate-limit counter.
+
+use 5.42.0;
+use FindBin qw($Bin);
+use lib "$Bin/../../lib", "$Bin/../lib", "lib", "t/lib";
+use experimental qw(defer);
+use Test::More import => [qw( done_testing is isnt ok plan subtest )];
+defer { done_testing };
+
+use Registry::Middleware::RateLimit;
+
+# _request_key must return the connection remote_address, never the raw
+# X-Forwarded-For header.  Two requests with different XFF headers but the
+# same connection peer share ONE counter.  Spoofing the header must not
+# produce a fresh counter per request.
+
+subtest 'X-Forwarded-For spoofing does not produce independent keys' => sub {
+    # Build two minimal fake Mojolicious controller objects whose connection
+    # peer address is the same but whose X-Forwarded-For differs.  Under the
+    # old code _request_key would return different IPs (two separate counters),
+    # defeating the limit.  Under the fixed code both return the same key.
+
+    # Minimal stub for Mojo::Message::Request headers
+    package Fake::Headers;
+    sub new { bless {}, shift }
+    sub header { undef }    # never return a value from X-Forwarded-For
+
+    package Fake::Request;
+    sub new { bless {}, shift }
+    sub headers { Fake::Headers->new }
+
+    # Minimal stub for Mojo::Transaction
+    package Fake::Tx;
+    sub new { my ($class, %args) = @_; bless { remote_address => $args{remote_address} }, $class }
+    sub remote_address { $_[0]->{remote_address} }
+
+    # Minimal stub for a Mojolicious controller
+    package Fake::Controller;
+    sub new { my ($class, %args) = @_; bless \%args, $class }
+    sub req { Fake::Request->new }
+    sub tx  { Fake::Tx->new(remote_address => $_[0]->{remote_address}) }
+
+    package main;
+
+    my $rl = Registry::Middleware::RateLimit->new;
+
+    # Two controllers: same connection peer, different X-Forwarded-For (simulating
+    # spoofed headers from the same physical connection).
+    my $c1 = Fake::Controller->new(remote_address => '192.0.2.1');
+    my $c2 = Fake::Controller->new(remote_address => '192.0.2.1');
+
+    my $key1 = $rl->_request_key($c1);
+    my $key2 = $rl->_request_key($c2);
+
+    is $key1, $key2, 'same peer address produces the same rate-limit key regardless of XFF header';
+};
+
+subtest 'Spoofing X-Forwarded-For does not reset the auth-endpoint counter' => sub {
+    # Exhaust the auth limit for a connection using one XFF value, then send
+    # a request with a *different* XFF value on the same connection peer.
+    # The counter must be shared.  A spoofed header must NOT give a fresh budget.
+
+    # A controller stub where req->headers->header('X-Forwarded-For') returns
+    # a caller-supplied value while tx->remote_address is fixed.
+    package Fake::SpoofHeaders;
+    sub new { my ($class, %args) = @_; bless \%args, $class }
+    sub header {
+        my ($self, $name) = @_;
+        return $self->{xff} if lc($name) eq 'x-forwarded-for';
+        return undef;
+    }
+
+    package Fake::SpoofRequest;
+    sub new { my ($class, %args) = @_; bless \%args, $class }
+    sub headers { Fake::SpoofHeaders->new(xff => $_[0]->{xff}) }
+
+    package Fake::SpoofController;
+    sub new { my ($class, %args) = @_; bless \%args, $class }
+    sub req { Fake::SpoofRequest->new(xff => $_[0]->{xff}) }
+    sub tx  { Fake::Tx->new(remote_address => '10.0.1.1') }
+
+    package main;
+
+    my $rl = Registry::Middleware::RateLimit->new;
+
+    # Exhaust the AUTH limit (10) using requests that rotate the XFF header.
+    # All requests come from the same connection peer (10.0.1.1).
+    for my $i (1..10) {
+        my $c = Fake::SpoofController->new(xff => "1.2.3.$i");
+        my $key = $rl->_request_key($c);
+        $rl->check($key, $Registry::Middleware::RateLimit::AUTH_LIMIT);
+    }
+
+    # The 11th request with yet another spoofed XFF must still be blocked.
+    my $c11 = Fake::SpoofController->new(xff => '9.9.9.9');
+    my $key  = $rl->_request_key($c11);
+    my %res  = $rl->check($key, $Registry::Middleware::RateLimit::AUTH_LIMIT);
+
+    ok !$res{allowed},
+        'counter is shared across XFF values; spoofed header does not grant a fresh budget';
+};

--- a/t/security/rate-limiting.t
+++ b/t/security/rate-limiting.t
@@ -106,20 +106,31 @@ subtest '429 response body is well-formed' => sub {
       ->json_like('/error', qr/rate limit/i, 'Error message mentions rate limit');
 };
 
-subtest 'Different IPs have independent counters' => sub {
-    my $t = Test::Mojo->new('Registry');
+subtest 'Each app instance has an independent counter store' => sub {
+    # Rate-limit counters are stored per-instance (in-memory on each
+    # Registry/RateLimit object).  A fresh Test::Mojo->new('Registry') call
+    # creates a new app instance with an empty counter, so requests in the
+    # new instance are not affected by prior requests in a different instance.
+    #
+    # The per-peer-address isolation property (different clients have independent
+    # counters) is validated at the unit level in t/security/rate-limit-xff-spoof.t
+    # using controlled peer-address stubs, since Test::Mojo connections all share
+    # the same loopback peer address and cannot simulate separate clients at
+    # the integration layer.
 
-    my $ip_a = '10.0.0.5';
-    my $ip_b = '10.0.0.6';
+    my $t_a = Test::Mojo->new('Registry');
 
-    # Exhaust limit for ip_a
+    # Exhaust the general limit on instance_a
     for my $i (1..101) {
-        $t->get_ok('/health', { 'X-Forwarded-For' => $ip_a });
+        $t_a->get_ok('/health');
     }
+    $t_a->get_ok('/health')
+        ->status_is(429, 'instance_a is now rate-limited');
 
-    # ip_b should still be allowed (fresh counter)
-    $t->get_ok('/health', { 'X-Forwarded-For' => $ip_b })
-      ->status_isnt(429, 'Different IP not affected by other IP rate limit');
+    # A fresh instance starts with an empty counter store
+    my $t_b = Test::Mojo->new('Registry');
+    $t_b->get_ok('/health')
+        ->status_isnt(429, 'fresh app instance has an independent (empty) counter');
 };
 
 subtest 'Static asset paths are excluded from rate limiting' => sub {


### PR DESCRIPTION
Two rate-limiting hardening fixes from the architecture review.

## F-16 — rate-limit key trusted spoofable X-Forwarded-For

`_request_key` read the raw client-supplied `X-Forwarded-For` header as the counter key, so an attacker could rotate the header per request to get a fresh budget and defeat the 10/min auth limit. It now keys on `$c->tx->remote_address` (the connection peer). Mojolicious derives the real client IP from `X-Forwarded-For` into `remote_address` **only when reverse-proxy mode is enabled** — i.e. only when the proxy is trusted — which removes the per-request spoofing surface.

**Deployment coupling (included):** `MOJO_REVERSE_PROXY` was not set anywhere. Behind Render's proxy without it, `remote_address` is the proxy IP and every client would share one counter. This PR adds `MOJO_REVERSE_PROXY=1` to the `registry-app` service in `render.yaml` so `remote_address` resolves to the real client IP. Code + config ship together.

## F-17 — magic-link request endpoint was under-throttled

`@AUTH_PATHS` only matched `login`/`password`, so `POST /auth/magic/request` — the passwordless system's actual token-issuing / email-dispatch endpoint — got the general 100/min limit instead of the 10/min auth limit, leaving the email-bombing / enumeration surface the least protected. Added `magic/request` to `@AUTH_PATHS`; the segment-anchored `_limit_for_path` regex matches `/auth/magic/request` precisely and leaves `/auth/magic/poll/` (already excluded) untouched.

## Tests

- `t/security/rate-limit-xff-spoof.t` — rotating `X-Forwarded-For` across requests on one peer no longer resets the counter (RED before fix).
- `t/security/rate-limit-magic-request.t` — `_limit_for_path('/auth/magic/request')` returns the auth limit (10), not 100; poll/other paths unaffected.
- `t/security/rate-limiting.t` — IP-independence subtest updated to the corrected peer-address model.

`t/security/` (102) green.