### PR TITLE
Add Alex (platform owner) user-journey suite

### DIFF
--- a/docs/superpowers/plans/2026-06-11-alex-user-journeys.md
+++ b/docs/superpowers/plans/2026-06-11-alex-user-journeys.md
@@ -25,7 +25,8 @@
   - `t/dao/payment-step-readiness-gate.t` — tenant + paid-session fixtures and the gate's expected error text.
   - `t/integration/tenant-paid-enrollment.t` — Stripe seam interception (`local *Registry::Service::Stripe::create_payment_intent`), fee derivation (`application_fee_cents(_to_cents($PLAN_AMOUNT))`), synthesizing `payment_intent.succeeded` from captured params.
   - `t/job/process-waitlist-tenant.t` + `t/job/waitlist-expiration-tenant.t` — MockLogger/MockJob/MockApp shims, tenant provisioning, sweep assertions.
-- The `TenantPayment` payment step's test seam (production code, `lib/Registry/DAO/WorkflowSteps/TenantPayment.pm:43-46,283-294`): POST `collect_payment_method => 1, setup_intent_id => 'seti_test_...'` → `handle_setup_completion` → `_provision_tenant` → `next_step => 'complete'`. Set `STRIPE_PUBLISHABLE_KEY`/`STRIPE_SECRET_KEY` to test dummies so the no-keys branch is NOT taken (we want the seti_test branch).
+- The `TenantPayment` payment step's test seam (production code, `lib/Registry/DAO/WorkflowSteps/TenantPayment.pm:43-46,283-294`): POST `collect_payment_method => 1, setup_intent_id => 'seti_test_...'` → `handle_setup_completion` → `_provision_tenant` → `next_step => 'complete'`. The seti_test branch wins on **dispatch order** (it is checked before the no-keys branch), so Stripe env keys are irrelevant to this POST — set dummy keys only where a leg exercises the Stripe service path (Leg 2's `create_payment_intent` interception).
+- **Fresh DBs have ZERO platform pricing relationships** (issue #268): `create-default-pricing-relationships.sql` is orphaned from `sqitch.plan`, so `PricingPlanSelection` finds no plans, renders no radios, and silently skips. Any leg that needs plan selection must first seed a platform relationship fixture (Task 3 shows the INSERT).
 - Webhook signing (`lib/Registry/Controller/Webhooks.pm::_verify_stripe_signature`): header `stripe-signature: t=<epoch>,v1=<hmac>` where `<hmac> = hmac_sha256_hex("<epoch>.<raw_json_body>", $ENV{STRIPE_WEBHOOK_SECRET})`; timestamp within 300s.
 - `ag` returns false negatives under `.claude/worktrees/` — verify any negative search result with `grep -r`.
 - Journey failure philosophy (spec): a red assertion against a real flow is a FINDING — fix small/obvious bugs in-branch (own commit), file issues otherwise. Never weaken an assertion; TODO only with an issue reference.
@@ -89,7 +90,7 @@ $ENV{DB_URL} = $test_db->uri;
 #    $t->get_ok('/health')->status_is(200)->json_is('/status','ok')->json_is('/db','ok');
 ```
 
-The bad-row beat needs a real `perform()` run (not just interception) so the try/catch isolation is exercised; capture the error log line (MockLogger collects messages) and assert it mentions the bad slug — pristine output, the error goes to the captured logger, not STDERR.
+The bad-row beat needs a real `perform()` run (not just interception) so the try/catch isolation is exercised. The `t/job` shims are no-op stubs — EXTEND them here: `MockLogger->error` pushes to an array, `MockJob` records whether `finish` or `fail` was called. Assert the captured error mentions the bad slug (`like`) and that `finish` (not `fail`) fired — pristine output, errors land in the captured logger, never STDERR. Add `like` to the Test::More import list and end with `$test_db->cleanup_test_database`.
 - [ ] **Step 2: Run it.** `carton exec prove -lv t/user-journeys/alex/04-platform-health.t`. Expected: PASS (these behaviors all exist). Any red = finding (investigate before touching the test).
 - [ ] **Step 3: Run the sibling suites** to prove no interference: `carton exec prove -lr t/job/`.
 - [ ] **Step 4: Commit** (`Add Alex journey leg 4: platform health automation`).
@@ -141,8 +142,24 @@ post_signed_webhook($t, {
 
 **Files:** Create `t/user-journeys/alex/03-platform-billing.t`
 
-- [ ] **Step 1: Write the test.** Walk `tenant-signup` from the start over HTTP with **minimal form data** (the data-flow test proves minimal input is accepted; same walk shape as Leg 1, registry-context dao pinned via the helper):
-  - POST `/tenant-signup` → profile (`name` only if accepted; otherwise the minimal set the step actually requires — RECORD what each step requires vs accepts empty, this feeds the friction inventory) → users (minimal admin fields, `admin_user_type => 'admin'` to avoid the invite-warn) → pricing: GET the page, **select the seeded plan** (read the form; submit `plan_id`/equivalent — inspect `templates/tenant-signup/pricing.html.ep` and `PricingPlanSelection::process` for the exact field name) → review → payment: POST `collect_payment_method => 1, setup_intent_id => 'seti_test_journey'` (with dummy Stripe env keys set so the seti_test branch runs) → complete.
+- [ ] **Step 1: Write the test.** FIRST seed the platform pricing relationship that signup needs (fresh DBs have none — issue #268; crib the shape from the orphaned `sql/deploy/create-default-pricing-relationships.sql:64-83`):
+
+```perl
+# Fresh deploys carry no platform pricing relationships (issue #268), so the
+# pricing step would render no plans and silently skip. Seed the relationship
+# for the seeded 2% plan, mirroring the orphaned default-relationships migration.
+my $plan_id = $db->query(q{
+    SELECT id FROM registry.pricing_plans
+    WHERE pricing_model_type = 'percentage' AND target_type = 'tenant' LIMIT 1
+})->hash->{id};
+$db->query(q{
+    INSERT INTO registry.pricing_relationships (provider_id, consumer_id, pricing_plan_id, status)
+    VALUES ('00000000-0000-0000-0000-000000000000', ?, ?, 'active')
+}, $consumer_id, $plan_id);
+```
+
+  (Verify the exact column list and whether `consumer_id` may be the platform UUID/NULL for an offer-to-all relationship by reading the orphaned migration and `PricingPlanSelection::prepare_pricing_data` — adapt the INSERT to what the listing query actually matches.) Then walk `tenant-signup` from the start over HTTP with **minimal form data** (same walk shape as Leg 1, registry-context dao pinned via the helper):
+  - POST `/tenant-signup` → profile: submit minimal data but ALWAYS include `name` (`_provision_tenant` falls back to a generic 'Organization' tenant name without it, which would muddy the later assertions); RECORD what each step requires vs accepts empty — this feeds the friction inventory → users (minimal admin fields, `admin_user_type => 'admin'` to avoid the invite-warn) → pricing: GET the page, assert the seeded plan renders, select it with `selected_plan_id => $plan_id` (radio `name="selected_plan_id"`, `templates/tenant-signup/pricing.html.ep:99`; consumed via `exists $form_data->{selected_plan_id}` in `PricingPlanSelection::process`) → review → payment: POST `collect_payment_method => 1, setup_intent_id => 'seti_test_journey'` → complete.
   - **Assertions:**
     1. Run data carries `selected_pricing_plan`; the provisioned tenant row has `stripe_subscription_id` (`sub_test_…`), `billing_status` = `trial`, `trial_ends_at` set.
     2. **#267 dependency comment:** assert (documented, with the issue link) that NO tenant↔plan record exists post-signup — `TODO`-free, asserting current reality so #267's landing flips it consciously: assert absence now, with a comment that #267 strengthens this to assert the persisted link.
@@ -156,7 +173,7 @@ post_signed_webhook($t, {
 
 **Files:** Create `t/user-journeys/alex/01-acquire-tenant.t`
 
-- [ ] **Step 1: Write the walk.** Full `tenant-signup` over HTTP with REALISTIC (non-minimal) data — Portland-Art-Collective-style from the data-flow test — through landing → profile → users → pricing → review → **payment (`seti_test`) → complete**. Stage 1 asserts only HTTP-level health: every POST 302s to the expected next step (`->header_like(Location => qr/...$/)`), the complete page renders 200. Keep the team admin-only (the invite-pending `warn` hazard) OR capture warns if testing invited members.
+- [ ] **Step 1: Write the walk.** Full `tenant-signup` over HTTP with REALISTIC (non-minimal) data — Portland-Art-Collective-style from the data-flow test — through landing → profile → users → pricing → review → **payment (`seti_test`) → complete**. Seed the platform pricing relationship first (the Task 3 fixture — fresh DBs offer no plans, issue #268) and select the plan with `selected_plan_id`. Stage 1 asserts only HTTP-level health: every POST 302s to the expected next step (`->header_like(Location => qr/...$/)`), the complete page renders 200. Keep the team admin-only (the invite-pending `warn` hazard) OR capture warns if testing invited members.
 - [ ] **Step 2: Run it.** This crosses payment→complete over HTTP for the first time. Reds here are the spec's predicted findings: diagnose (the run's `latest_step`, response content), fix small/obvious in their own commits, `gh issue create` for anything larger, and only then stabilize the walk. Do NOT proceed to Task 5 with a red walk.
 - [ ] **Step 3: Commit** the walk (plus any fix commits separately).
 

--- a/docs/superpowers/plans/2026-06-11-alex-user-journeys.md
+++ b/docs/superpowers/plans/2026-06-11-alex-user-journeys.md
@@ -150,7 +150,7 @@ post_signed_webhook($t, {
 # for the seeded 2% plan, mirroring the orphaned default-relationships migration.
 my $plan_id = $db->query(q{
     SELECT id FROM registry.pricing_plans
-    WHERE pricing_model_type = 'percentage' AND target_type = 'tenant' LIMIT 1
+    WHERE pricing_model_type = 'percentage' AND plan_scope = 'tenant' LIMIT 1
 })->hash->{id};
 $db->query(q{
     INSERT INTO registry.pricing_relationships (provider_id, consumer_id, pricing_plan_id, status)
@@ -158,7 +158,7 @@ $db->query(q{
 }, $consumer_id, $plan_id);
 ```
 
-  (Verify the exact column list and whether `consumer_id` may be the platform UUID/NULL for an offer-to-all relationship by reading the orphaned migration and `PricingPlanSelection::prepare_pricing_data` — adapt the INSERT to what the listing query actually matches.) Then walk `tenant-signup` from the start over HTTP with **minimal form data** (same walk shape as Leg 1, registry-context dao pinned via the helper):
+  (Verify the exact column list against the orphaned migration and `PricingPlanSelection::prepare_pricing_data`. `consumer_id` is a NOT NULL FK to `registry.users(id)` — the test dump ships a `system` user whose id works directly; the listing query never filters on consumer_id.) Then walk `tenant-signup` from the start over HTTP with **minimal form data** (same walk shape as Leg 1, registry-context dao pinned via the helper):
   - POST `/tenant-signup` → profile: submit minimal data but ALWAYS include `name` (`_provision_tenant` falls back to a generic 'Organization' tenant name without it, which would muddy the later assertions); RECORD what each step requires vs accepts empty — this feeds the friction inventory → users (minimal admin fields, `admin_user_type => 'admin'` to avoid the invite-warn) → pricing: GET the page, assert the seeded plan renders, select it with `selected_plan_id => $plan_id` (radio `name="selected_plan_id"`, `templates/tenant-signup/pricing.html.ep:99`; consumed via `exists $form_data->{selected_plan_id}` in `PricingPlanSelection::process`) → review → payment: POST `collect_payment_method => 1, setup_intent_id => 'seti_test_journey'` → complete.
   - **Assertions:**
     1. Run data carries `selected_pricing_plan`; the provisioned tenant row has `stripe_subscription_id` (`sub_test_…`), `billing_status` = `trial`, `trial_ends_at` set.

--- a/docs/superpowers/plans/2026-06-11-alex-user-journeys.md
+++ b/docs/superpowers/plans/2026-06-11-alex-user-journeys.md
@@ -1,0 +1,189 @@
+# Alex User Journeys Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Four journey-test legs under `t/user-journeys/alex/` proving the platform-owner outcomes: health automation, activate+collect, platform billing, and the signup funnel producing a working tenant.
+
+**Architecture:** Pure test additions (no production code) following the existing `t/user-journeys/` conventions: per-file `Test::Registry::DB`, `Test::Registry::Mojo`, real workflows over HTTP, Stripe intercepted at the `Registry::Service::Stripe` seam. Build order is cheap-first per the spec: Leg 4 → Leg 2 → Leg 3 → Leg 1 (staged).
+
+**Tech Stack:** Perl 5.42, Test::More, Test::Registry::{DB,Mojo,Helpers,Fixtures}, Mojo::JSON, Digest::SHA (webhook signing).
+
+**Spec:** `docs/superpowers/specs/2026-06-11-alex-user-journeys-design.md` (same branch — READ IT FIRST; its decisions are binding).
+
+**Branch / worktree:** `feature/alex-user-journeys` in `/home/perigrin/dev/Registry/.claude/worktrees/lifecycle`.
+
+---
+
+## Project conventions you must follow
+
+- Read repo `CLAUDE.md`. Highlights: 100% pass rate, pristine output (expected warns must be captured), `carton exec prove -lv t/path` (always `-l`), never `--no-verify`, no mock modes or test-only methods in production code, ABOUTME headers on new files.
+- Journey-test idioms (READ these before writing anything):
+  - `t/user-journeys/morgan/01-program-management.t` — the leg shape: own DB, `$ENV{DB_URL} = $test_db->uri`, workflow import from YAML skipping drafts, `Test::Registry::Mojo->new('Registry')`, walk via `workflow_url`/`workflow_process_step_url`.
+  - `t/controller/tenant-signup-data-flow.t` — the funnel walk backbone: `$t->app->helper(dao => sub { $db })` pins the app to the test DB; POST `/tenant-signup` → 302 → profile (`name`/`description`/`billing_email`) → users (`admin_name`/`admin_email`/`admin_username`/`admin_user_type`) → pricing → review. GET each page before POSTing (session/CSRF).
+  - `t/e2e/tenant-onboarding.t` — registration over HTTP: `summer-camp-registration` via `workflow_process_step_url`, `account-check` step (`action => 'create_account'` then `authenticate_as($t,$user)` + `action => 'continue_logged_in'`), `Family->add_child`, then select-children / session-selection / payment steps.
+  - `t/lib/Test/Registry/Helpers.pm` — `workflow_url`, `workflow_process_step_url`, `authenticate_as`, `import_all_workflows`, `process_workflow`.
+  - `t/dao/payment-step-readiness-gate.t` — tenant + paid-session fixtures and the gate's expected error text.
+  - `t/integration/tenant-paid-enrollment.t` — Stripe seam interception (`local *Registry::Service::Stripe::create_payment_intent`), fee derivation (`application_fee_cents(_to_cents($PLAN_AMOUNT))`), synthesizing `payment_intent.succeeded` from captured params.
+  - `t/job/process-waitlist-tenant.t` + `t/job/waitlist-expiration-tenant.t` — MockLogger/MockJob/MockApp shims, tenant provisioning, sweep assertions.
+- The `TenantPayment` payment step's test seam (production code, `lib/Registry/DAO/WorkflowSteps/TenantPayment.pm:43-46,283-294`): POST `collect_payment_method => 1, setup_intent_id => 'seti_test_...'` → `handle_setup_completion` → `_provision_tenant` → `next_step => 'complete'`. Set `STRIPE_PUBLISHABLE_KEY`/`STRIPE_SECRET_KEY` to test dummies so the no-keys branch is NOT taken (we want the seti_test branch).
+- Webhook signing (`lib/Registry/Controller/Webhooks.pm::_verify_stripe_signature`): header `stripe-signature: t=<epoch>,v1=<hmac>` where `<hmac> = hmac_sha256_hex("<epoch>.<raw_json_body>", $ENV{STRIPE_WEBHOOK_SECRET})`; timestamp within 300s.
+- `ag` returns false negatives under `.claude/worktrees/` — verify any negative search result with `grep -r`.
+- Journey failure philosophy (spec): a red assertion against a real flow is a FINDING — fix small/obvious bugs in-branch (own commit), file issues otherwise. Never weaken an assertion; TODO only with an issue reference.
+
+## File structure
+
+| File | Responsibility |
+| --- | --- |
+| `t/user-journeys/alex/04-platform-health.t` | Leg 4: sweeps process tenants, bad row isolated, /health |
+| `t/user-journeys/alex/02-activate-and-collect.t` | Leg 2: gate → activate (row + signed webhook) → charge → complete |
+| `t/user-journeys/alex/03-platform-billing.t` | Leg 3: minimal-data funnel walk → billing artifacts + #267 TODO drift assertion |
+| `t/user-journeys/alex/01-acquire-tenant.t` | Leg 1: full funnel walk (stage 1) + working-tenant assertions (stage 2) |
+| `t/lib/` helper | ONLY if Legs 1+3 fixture setup genuinely converges (YAGNI) |
+
+No production files change. If a leg surfaces a production bug whose fix is small and obvious, fix it in its own commit with its own targeted test evidence; otherwise `gh issue create` and reference it.
+
+---
+
+### Task 1: Leg 4 — `t/user-journeys/alex/04-platform-health.t`
+
+**Files:** Create `t/user-journeys/alex/04-platform-health.t`
+
+- [ ] **Step 1: Write the test.** Skeleton (adapt mechanics from the two `t/job/*-tenant.t` files — copy their fixture/shim approach exactly):
+
+```perl
+#!/usr/bin/env perl
+# ABOUTME: Alex (platform owner) journey: the automation runs without him.
+# ABOUTME: Tenant-aware sweeps process every tenant, isolate bad rows, and /health probes the DB.
+use 5.42.0;
+use lib qw(lib t/lib);
+use experimental qw(defer);
+use Test::More import => [qw( done_testing is ok subtest )];
+defer { done_testing };
+
+use Test::Registry::Mojo;
+use Test::Registry::DB;
+use Registry::DAO;
+use Registry::DAO::Tenant;
+use Registry::Job::ProcessWaitlist;
+use Registry::Job::WaitlistExpiration;
+
+my $test_db = Test::Registry::DB->new;
+my $dao     = $test_db->db;
+$ENV{DB_URL} = $test_db->uri;
+
+# Tenant A: has sweepable state (offered waitlist entry, past expires_at;
+# cancelled enrollment with a waiting entry) -- build per the t/job fixtures.
+# Tenant B: provisioned, no waitlist state.
+# Bad row: INSERT INTO registry.tenants (name, slug) a slug with NO schema
+# (the #265 shape) -- defense-in-depth: the sweep must never let one bad row
+# break other tenants, regardless of whether such rows turn out to be legal.
+
+# 1. Sweeps reach tenant A's state and survive tenant B + the bad row:
+#    capture per-tenant dispatch with the local-* interception idiom from
+#    t/job/process-waitlist-tenant.t; assert A and B slugs were processed,
+#    'registry' was not, and perform() completed despite the bad row
+#    (MockJob's finish called, not fail).
+# 2. Real effect in tenant A: the expired offer flipped to 'expired'
+#    (WaitlistExpiration) -- assert on the tenant connection.
+# 3. /health: my $t = Test::Registry::Mojo->new('Registry');
+#    $t->get_ok('/health')->status_is(200)->json_is('/status','ok')->json_is('/db','ok');
+```
+
+The bad-row beat needs a real `perform()` run (not just interception) so the try/catch isolation is exercised; capture the error log line (MockLogger collects messages) and assert it mentions the bad slug — pristine output, the error goes to the captured logger, not STDERR.
+- [ ] **Step 2: Run it.** `carton exec prove -lv t/user-journeys/alex/04-platform-health.t`. Expected: PASS (these behaviors all exist). Any red = finding (investigate before touching the test).
+- [ ] **Step 3: Run the sibling suites** to prove no interference: `carton exec prove -lr t/job/`.
+- [ ] **Step 4: Commit** (`Add Alex journey leg 4: platform health automation`).
+
+### Task 2: Leg 2 — `t/user-journeys/alex/02-activate-and-collect.t`
+
+**Files:** Create `t/user-journeys/alex/02-activate-and-collect.t`
+
+- [ ] **Step 1: Write the test.** Structure (fixtures from `t/dao/payment-step-readiness-gate.t`, HTTP walk from `t/e2e/tenant-onboarding.t`):
+
+```perl
+# ABOUTME: Alex (platform owner) journey: activating a tenant's Connect account
+# ABOUTME: unlocks paid enrollment and the platform fee is collected at charge time.
+```
+
+1. **Fixtures:** provision tenant (NOT ready); paid session + pricing plan (`my $PLAN_AMOUNT = 150.00`); import workflows into the tenant schema (provision copies them — verify; if `summer-camp-registration` is missing in the tenant schema, import the YAML into the tenant dao the way the gate test does). Pin the app to the TENANT dao: `$t->app->helper(dao => sub { $tenant_dao })` (the data-flow idiom). `local $ENV{STRIPE_SECRET_KEY} = 'sk_test_dummy'; local $ENV{STRIPE_PUBLISHABLE_KEY} = 'pk_test_dummy'; local $ENV{STRIPE_WEBHOOK_SECRET} = 'whsec_test_journey';`
+2. **Gated:** parent account via the `account-check` step over HTTP (`create_account` → `authenticate_as` → `continue_logged_in`), `Family->add_child`, walk select-children/session-selection to the payment step (exact form data: crib from `t/e2e/tenant-onboarding.t`'s continuation), POST the payment step with `agreeTerms` → assert the response/run shows the gate error (`qr/not yet available/i`) and **no payment row in tenant nor registry schema**.
+3. **Activate:** (a) `UPDATE registry.tenants SET stripe_connect_account_id='acct_journey', stripe_charges_enabled=false, stripe_details_submitted=false WHERE slug=?` (the runbook step); (b) deliver `account.updated` **over HTTP with a real signed payload**:
+
+```perl
+use Mojo::JSON qw(encode_json);
+use Digest::SHA qw(hmac_sha256_hex);
+my sub post_signed_webhook ($t, $event) {
+    my $payload = encode_json($event);
+    my $ts      = time();
+    my $sig     = hmac_sha256_hex("$ts.$payload", $ENV{STRIPE_WEBHOOK_SECRET});
+    return $t->post_ok('/webhooks/stripe',
+        { 'stripe-signature' => "t=$ts,v1=$sig", 'Content-Type' => 'application/json' },
+        $payload);
+}
+post_signed_webhook($t, {
+    id   => 'evt_journey_acct_' . $$,
+    type => 'account.updated',
+    data => { object => { id => 'acct_journey',
+                          charges_enabled => \1, details_submitted => \1 } },
+})->status_is(200);
+# assert registry.tenants row now ready (stripe_connect_ready via fresh Tenant load)
+```
+
+   Note: each event id must be unique (the `webhook_events` dedup claims it).
+4. **Collect:** intercept `local *Registry::Service::Stripe::create_payment_intent` (capture + return `{ id => 'pi_journey', client_secret => 'cs_journey' }`); retry the payment-step POST → assert captured params: `transfer_data[destination] eq 'acct_journey'`, `on_behalf_of eq 'acct_journey'`, `application_fee_amount == Registry::DAO::Payment::application_fee_cents(Registry::DAO::Payment::_to_cents($PLAN_AMOUNT))`, bracket keys `metadata[payment_id]`/`metadata[tenant_slug]` present; payment row exists in the tenant schema, none in registry.
+5. **Complete:** synthesize `payment_intent.succeeded` from the CAPTURED params (`payment_id`/`tenant_slug` read back out of the bracket keys — the integration test's proof shape) and deliver via `post_signed_webhook` → 200; assert payment `completed` and enrollment row exist in the tenant schema; registry has neither.
+
+- [ ] **Step 2: Run it.** Expected: PASS end to end (all behaviors shipped). Reds are findings — the most likely one is the HTTP walk of `summer-camp-registration` inside a *tenant* schema (the e2e runs it in a different context); investigate honestly, fix-or-file.
+- [ ] **Step 3: Regression:** `carton exec prove -lr t/controller/webhook-tenant-payment-finalization.t t/integration/tenant-paid-enrollment.t t/dao/payment-step-readiness-gate.t`.
+- [ ] **Step 4: Commit.**
+
+### Task 3: Leg 3 — `t/user-journeys/alex/03-platform-billing.t`
+
+**Files:** Create `t/user-journeys/alex/03-platform-billing.t`
+
+- [ ] **Step 1: Write the test.** Walk `tenant-signup` from the start over HTTP with **minimal form data** (the data-flow test proves minimal input is accepted; same walk shape as Leg 1, registry-context dao pinned via the helper):
+  - POST `/tenant-signup` → profile (`name` only if accepted; otherwise the minimal set the step actually requires — RECORD what each step requires vs accepts empty, this feeds the friction inventory) → users (minimal admin fields, `admin_user_type => 'admin'` to avoid the invite-warn) → pricing: GET the page, **select the seeded plan** (read the form; submit `plan_id`/equivalent — inspect `templates/tenant-signup/pricing.html.ep` and `PricingPlanSelection::process` for the exact field name) → review → payment: POST `collect_payment_method => 1, setup_intent_id => 'seti_test_journey'` (with dummy Stripe env keys set so the seti_test branch runs) → complete.
+  - **Assertions:**
+    1. Run data carries `selected_pricing_plan`; the provisioned tenant row has `stripe_subscription_id` (`sub_test_…`), `billing_status` = `trial`, `trial_ends_at` set.
+    2. **#267 dependency comment:** assert (documented, with the issue link) that NO tenant↔plan record exists post-signup — `TODO`-free, asserting current reality so #267's landing flips it consciously: assert absence now, with a comment that #267 strengthens this to assert the persisted link.
+    3. **Rate-consistency drift (TODO #267):** extract the displayed rate from the pricing page HTML for the selected plan; compare to `Registry::DAO::Payment::REVENUE_SHARE_PERCENT`. Wrap in `TODO: { local $TODO = 'rate is constant-driven until #267; seeded plan advertises 2%'; ... }` — expected red, the diagnostics print both values.
+  - State the recurring-billing non-goal (#263) in a comment.
+- [ ] **Step 2: Run it.** Expected: PASS with the TODO red visible in diagnostics. Friction notes: collect the required-vs-empty field observations into comments at each step (input to Task 5's issue).
+- [ ] **Step 3: Regression:** `carton exec prove -lr t/controller/tenant-signup-data-flow.t t/dao/tenant-payment-workflow.t`.
+- [ ] **Step 4: Commit.**
+
+### Task 4: Leg 1 stage 1 — funnel walk (`t/user-journeys/alex/01-acquire-tenant.t`)
+
+**Files:** Create `t/user-journeys/alex/01-acquire-tenant.t`
+
+- [ ] **Step 1: Write the walk.** Full `tenant-signup` over HTTP with REALISTIC (non-minimal) data — Portland-Art-Collective-style from the data-flow test — through landing → profile → users → pricing → review → **payment (`seti_test`) → complete**. Stage 1 asserts only HTTP-level health: every POST 302s to the expected next step (`->header_like(Location => qr/...$/)`), the complete page renders 200. Keep the team admin-only (the invite-pending `warn` hazard) OR capture warns if testing invited members.
+- [ ] **Step 2: Run it.** This crosses payment→complete over HTTP for the first time. Reds here are the spec's predicted findings: diagnose (the run's `latest_step`, response content), fix small/obvious in their own commits, `gh issue create` for anything larger, and only then stabilize the walk. Do NOT proceed to Task 5 with a red walk.
+- [ ] **Step 3: Commit** the walk (plus any fix commits separately).
+
+### Task 5: Leg 1 stage 2 — working-tenant assertions + friction inventory
+
+**Files:** Modify `t/user-journeys/alex/01-acquire-tenant.t`
+
+- [ ] **Step 1: Add the outcome assertions** after the walk:
+  1. Tenant row + schema exist; tenant schema has workflows (`SELECT count(*) FROM <slug>.workflows` > 0 via explicit qualification from the registry connection).
+  2. Signup users are dual-resident (same id in `registry.users` and `<slug>.users`).
+  3. Storefront serves: fresh `Test::Registry::Mojo`, request `/` with `Host: <slug>.localhost` (`$t->get_ok('/' => { Host => "$slug.localhost" })`) → 200 and tenant name in content. (`_base_domains` includes `localhost`; the tenant resolver's schema-existence check passes post-provision.)
+- [ ] **Step 2: Run the full leg.** Fix-or-file any reds per the philosophy.
+- [ ] **Step 3: File the funnel-friction issue** (`gh issue create`, labels `enhancement,frontend,low-impact`): the per-step required-vs-accepts-empty inventory from Legs 1+3 walks, noting which fields downstream code consumes (grep the step classes for each field name); explicit framing that removal is decided field-by-field as separate product changes. Reference the spec.
+- [ ] **Step 4: Commit** (mention the issue number).
+
+### Task 6: Whole-suite verification
+
+- [ ] **Step 1:** `carton exec prove -lv t/user-journeys/alex/` — all four legs green/pristine (Leg 3's TODO red visible but the file passes).
+- [ ] **Step 2:** `carton exec prove -lr t/user-journeys/` — all persona suites green.
+- [ ] **Step 3:** `carton exec ./registry workflow import registry && carton exec prove -lr t/` — full suite 100%. Paste the summary.
+- [ ] **Step 4: Commit** anything outstanding; report the branch ready for PR.
+
+---
+
+## Verification (whole feature)
+
+1. Full suite 100% (Task 6 evidence).
+2. Spec acceptance: each spec section's assertions exist in the corresponding leg (the final reviewer walks spec §Design vs the four files).
+3. The friction-inventory issue exists and cites per-field evidence.
+4. Any funnel findings from Leg 1 are fixed in-branch (with their own commits/tests) or filed with issue references; no weakened assertions; the only TODO is Leg 3's #267-gated drift assertion.

--- a/docs/superpowers/specs/2026-06-11-alex-user-journeys-design.md
+++ b/docs/superpowers/specs/2026-06-11-alex-user-journeys-design.md
@@ -53,8 +53,10 @@ stays pristine. Outcome assertions, in Alex's terms:
 3. The new tenant's storefront responds: GET `/` with the tenant's host header renders the
    tenant-storefront workflow page (200, tenant name visible).
 
-This is the first end-to-end HTTP walk of the funnel; the workflow steps are currently
-only unit-tested. Failures here are findings (fix or file), never assertions to weaken.
+This is the first end-to-end HTTP walk of the funnel; the payment→complete steps are
+currently only unit-tested (landing→review has HTTP coverage in
+`t/controller/tenant-signup-data-flow.t`). Failures here are findings (fix or file),
+never assertions to weaken.
 
 ### Leg 2 — `t/user-journeys/alex/02-activate-and-collect.t`
 *Outcome: activating a tenant's Stripe Connect account unlocks paid enrollment, and the
@@ -73,8 +75,8 @@ readiness-gate test's fixture approach), Stripe intercepted at the
    The webhook is delivered **over HTTP with a real signed payload** (set
    `STRIPE_WEBHOOK_SECRET`, compute the `stripe-signature` HMAC the way
    `_verify_stripe_signature` expects) — consistent with the suite's over-HTTP ethos,
-   rather than the direct `_process_account_updated` call idiom used in the integration
-   test.
+   rather than the direct `_process_account_updated` call idiom used in
+   `t/controller/webhook-tenant-payment-finalization.t`.
 3. **Collect:** the parent retries over HTTP → enrollment proceeds; the captured
    PaymentIntent params carry `transfer_data[destination]`, `on_behalf_of`, and
    `application_fee_amount == Registry::DAO::Payment::application_fee_cents(_to_cents($plan_amount))`;

--- a/docs/superpowers/specs/2026-06-11-alex-user-journeys-design.md
+++ b/docs/superpowers/specs/2026-06-11-alex-user-journeys-design.md
@@ -1,0 +1,150 @@
+# Alex User Journeys — Design
+
+ABOUTME: Defines the platform-owner (Alex) user-journey test suite: four business-outcome
+ABOUTME: legs under t/user-journeys/alex/ following the existing persona-journey conventions.
+
+- Status: Draft (pending review)
+- Date: 2026-06-11
+- Persona: `docs/personas/alex.md` (Registry solo founder — platform owner/operator)
+- Pattern: `t/user-journeys/{morgan,nancy,jordan,amara}/` — numbered legs, real HTTP over
+  `Test::Registry::Mojo`, own `Test::Registry::DB` per file, DAO-level outcome assertions.
+
+## Problem
+
+Every persona with in-app flows has journey tests except Alex — yet Alex's stake is the
+largest: the platform must acquire, activate, and bill customers, and run itself while he
+is away. Those guarantees exist today only as scattered unit/integration tests; nothing
+walks them as user-visible stories, and the tenant-signup funnel has never been driven
+end-to-end at the HTTP layer. A regression in any of these breaks Alex's business, not a
+feature.
+
+## Decisions (settled with the requester)
+
+- **Frame:** Alex journeys are **business outcomes** he depends on, not hands-on-keyboard
+  flows. Other personas may be the on-screen actors inside them (Jordan signs up; Nancy
+  enrolls) — each leg's ABOUTME names the outcome from `alex.md` it protects.
+- **Coverage:** all four outcomes — acquire, activate+collect, platform billing, platform
+  health.
+- **Overlap policy:** narrative re-walk via HTTP. Journeys assert the user-visible path even
+  where integration tests cover internals (`t/integration/tenant-paid-enrollment.t`,
+  `t/job/*`). Runtime cost accepted.
+- **Structure:** four numbered legs, one per outcome, each self-contained with its own test
+  DB (option A; matches the existing per-leg convention).
+
+## Design
+
+### Leg 1 — `t/user-journeys/alex/01-acquire-tenant.t`
+*Outcome: the signup funnel produces a working, billable tenant.*
+
+Drive the real `tenant-signup` workflow over HTTP the way Morgan's leg drives
+`project-creation`: POST the workflow start URL, follow each step's redirect, submit each
+form (organization profile → team setup → pricing plan selection → payment → review →
+complete). The `TenantPayment` step is satisfied through its existing test-mode
+`setup_intent` seam (`seti_test…`, supported in production code — no mock mode added).
+Outcome assertions, in Alex's terms:
+
+1. The tenant row and schema exist; `clone_schema` artifacts are present (workflows count
+   > 0 in the tenant schema).
+2. The team users created during signup exist and are dual-resident (registry + tenant).
+3. The new tenant's storefront responds: GET `/` with the tenant's host header renders the
+   tenant-storefront workflow page (200, tenant name visible).
+
+This is the first end-to-end HTTP walk of the funnel; the workflow steps are currently
+only unit-tested. Failures here are findings (fix or file), never assertions to weaken.
+
+### Leg 2 — `t/user-journeys/alex/02-activate-and-collect.t`
+*Outcome: activating a tenant's Stripe Connect account unlocks paid enrollment, and the
+platform's 2.5% is collected at charge time.*
+
+Fixtures: a provisioned tenant with a paid session/pricing plan, a parent + child (the
+readiness-gate test's fixture approach), Stripe intercepted at the
+`Registry::Service::Stripe` seam with `local $ENV{STRIPE_SECRET_KEY} = 'sk_test_dummy'`.
+
+1. **Gated:** the parent attempts paid enrollment through the registration workflow over
+   HTTP → the readiness gate refuses with the friendly message; no payment row in either
+   schema.
+2. **Activate:** Alex records the connected account (tenant-row update mirroring the
+   runbook), then an `account.updated` webhook event flips/confirms
+   `stripe_charges_enabled`/`stripe_details_submitted` — both activation paths exercised.
+3. **Collect:** the parent retries over HTTP → enrollment proceeds; the captured
+   PaymentIntent params carry `transfer_data[destination]`, `on_behalf_of`, and
+   `application_fee_amount == Registry::DAO::Payment::application_fee_cents(_to_cents($plan_amount))`;
+   the payment row lands in the tenant schema.
+
+Distinct from `t/integration/tenant-paid-enrollment.t` by driving the enrollment workflow
+through the HTTP surface rather than calling step classes directly.
+
+### Leg 3 — `t/user-journeys/alex/03-platform-billing.t`
+*Outcome: Registry bills the tenant for the platform subscription.*
+
+Walk the pricing-plan-selection + `TenantPayment` portion of signup (HTTP, as in Leg 1, or
+the narrowest HTTP path that reaches it) and assert the platform-side artifacts:
+
+1. A `PricingRelationship` (and related platform-billing rows) exists in the registry
+   schema linking tenant and plan.
+2. The tenant row's `billing_status` reflects the established subscription/trial state.
+3. The Solo-tier copy shown to the signing-up owner derives from
+   `Registry::DAO::Payment::REVENUE_SHARE_PERCENT` (single source of truth).
+
+**Explicit non-goal (stated in the file):** recurring usage-based billing — the
+`_get_usage_data` branch is deliberately non-functional pending redesign (issue #263).
+The leg asserts the subscription is *established*, not that monthly invoices flow.
+
+### Leg 4 — `t/user-journeys/alex/04-platform-health.t`
+*Outcome: the automation runs without Alex.*
+
+Thin aggregation leg, deliberately:
+
+1. Two provisioned tenants, one with sweepable waitlist state (offered entry with past
+   `expires_at`; cancelled enrollment with waiting entry). Run the no-arg
+   `ProcessWaitlist`/`WaitlistExpiration` performs (the `t/job/*-tenant.t` harness idiom)
+   and assert per-tenant processing reached the tenant with state and did not abort on the
+   other.
+2. A `registry.tenants` row whose schema does not exist (the #265 shape) does not abort
+   either sweep — failure is isolated and logged.
+3. GET `/health` returns 200 with `db: ok`.
+
+### Shared conventions (all legs)
+
+- Own `Test::Registry::DB` + `Test::Registry::Mojo` per file; workflows imported from YAML
+  (`Workflow->from_yaml`, skipping drafts) where the leg uses workflows.
+- Helpers from `Test::Registry::Helpers` (`workflow_url`, `workflow_run_step_url`, …).
+- Stripe never hits the network: `Service::Stripe` seam interception + `sk_test_dummy`;
+  the live-key guard stays effective.
+- `$$`-suffixed identities; pristine output; cleanup via `cleanup_test_database`.
+- No test infrastructure in production code. Shared fixture helpers go to `t/lib/` only if
+  two or more legs genuinely duplicate them (YAGNI otherwise).
+
+## Error handling / failure philosophy
+
+Journey legs assert outcomes, not implementations. When a leg fails:
+- If the user-visible flow is broken, that is a product bug — fix it or file it.
+- Never weaken an assertion or add a TODO to make a journey green without an issue
+  reference.
+
+## Testing strategy
+
+The suite IS tests; its own verification is: each leg green and pristine standalone
+(`carton exec prove -lv t/user-journeys/alex/<leg>.t` after
+`carton exec ./registry workflow import registry` where needed), the whole persona suite
+green (`carton exec prove -lr t/user-journeys/`), and the full suite still 100%
+(`carton exec prove -lr t/`). Leg 1 is expected to surface real funnel bugs on first
+run — budget for fix-or-file work there.
+
+## Non-goals
+
+- Self-service Connect onboarding UI (deferred epic) — Leg 2 activates via the tenant row
+  + `account.updated`, the supported mechanisms today.
+- Recurring usage billing (#263).
+- Playwright/browser coverage — these are server-side journey tests like the rest of
+  `t/user-journeys/`; the Playwright E2E suite is a separate concern.
+- New journeys for Kylie & Rob (students) — out of scope here.
+
+## Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| Leg 1 surfaces real funnel bugs (first HTTP walk) | Treat as findings: fix small/obvious in-branch, file issues otherwise; never weaken assertions. |
+| Runtime growth (~4 extra DB provisions) | Accepted by decision; legs stay narrative-thin, no gratuitous fixtures. |
+| Duplication drift with integration tests | Legs assert outcomes at the HTTP surface only; internals stay in the integration/unit suites. |
+| `tenant-signup` requires registry-context host routing | Legs set the Host header / tenant resolution explicitly the way existing controller tests do; the registry-vs-tenant context per request is part of what's being tested. |

--- a/docs/superpowers/specs/2026-06-11-alex-user-journeys-design.md
+++ b/docs/superpowers/specs/2026-06-11-alex-user-journeys-design.md
@@ -118,21 +118,22 @@ writes billing fields onto the tenant row):
 1. The selected plan is recorded in the workflow run data (`selected_pricing_plan`), and
    the provisioned tenant row carries the billing fields: `stripe_subscription_id`,
    `billing_status` (`trial` on the `seti_test` path), `trial_ends_at`.
-2. **Known gap, asserted deliberately:** no platform-billing row links the tenant to its
-   chosen plan after signup. The leg documents this with a comment; if a tenant↔plan
-   record is later introduced, the assertion gets strengthened. (Fix-or-file policy: if
-   the implementer or reviewers judge this a product bug, file it — do not build the
-   missing feature inside a journey test.)
-3. **Pricing-copy drift detection:** the plan copy shown to the signing-up owner must
-   agree with what the platform actually charges
-   (`Registry::DAO::Payment::REVENUE_SHARE_PERCENT` = 2.5). **This is expected to FAIL
-   today**: the seeded platform plan is "Registry Revenue Share - 2%" with `amount 0.02`
-   (`sql/deploy/unified-pricing-infrastructure.sql:107-113`), while destination charges
-   collect 2.5% — a real, pre-existing drift between displayed price and collected fee.
-   Per the failure philosophy this is a finding: fix the seeded data (and any
-   `pricing_configuration` template copy) to 2.5% in-branch if the requester confirms
-   2.5% is the decided rate, or file an issue and mark the assertion TODO with the issue
-   reference.
+2. **Known gap, now a tracked requirement (issue #267):** no platform-billing row links
+   the tenant to its chosen plan after signup. The requester has decided the revenue-share
+   rate must be **plan-driven, not a constant**, which makes the tenant↔plan link a
+   dependency of #267 (derive the application fee from the tenant's pricing plan). The
+   leg documents the absence with a comment referencing #267; when #267 lands, the
+   assertion gets strengthened to assert the persisted link. Do not build the feature
+   inside a journey test.
+3. **Rate-consistency drift detection:** the rate displayed for the tenant's chosen plan
+   must equal the rate the platform actually charges that tenant. This formulation is
+   rate-value-agnostic and becomes the permanent guard once #267 makes the rate
+   plan-driven. **Expected to FAIL today**: the seeded platform plan advertises 2%
+   (`sql/deploy/unified-pricing-infrastructure.sql:107-113`) while destination charges
+   collect `REVENUE_SHARE_PERCENT` = 2.5% — a real, pre-existing drift between displayed
+   price and collected fee, captured in #267. The assertion lands TODO-marked with the
+   #267 reference (per the failure philosophy: a TODO requires an issue reference) and
+   the TODO comes off when #267 ships.
 
 **Explicit non-goal (stated in the file):** recurring usage-based billing — the
 `_get_usage_data` branch is deliberately non-functional pending redesign (issue #263).

--- a/docs/superpowers/specs/2026-06-11-alex-user-journeys-design.md
+++ b/docs/superpowers/specs/2026-06-11-alex-user-journeys-design.md
@@ -15,8 +15,9 @@ Every persona with in-app flows has journey tests except Alex — yet Alex's sta
 largest: the platform must acquire, activate, and bill customers, and run itself while he
 is away. Those guarantees exist today only as scattered unit/integration tests; nothing
 walks them as user-visible stories, and the tenant-signup funnel has never been driven
-end-to-end at the HTTP layer. A regression in any of these breaks Alex's business, not a
-feature.
+end-to-end at the HTTP layer (`t/controller/tenant-signup-data-flow.t` walks
+landing→review; the payment→complete segment has never been walked over HTTP). A
+regression in any of these breaks Alex's business, not a feature.
 
 ## Decisions (settled with the requester)
 
@@ -38,10 +39,13 @@ feature.
 
 Drive the real `tenant-signup` workflow over HTTP the way Morgan's leg drives
 `project-creation`: POST the workflow start URL, follow each step's redirect, submit each
-form (organization profile → team setup → pricing plan selection → payment → review →
-complete). The `TenantPayment` step is satisfied through its existing test-mode
+form. The funnel's actual step order (per `workflows/tenant-signup.yml`) is
+landing → organization profile → team setup (users) → pricing plan selection → **review →
+payment** → complete. The `TenantPayment` step is satisfied through its existing test-mode
 `setup_intent` seam (`seti_test…`, supported in production code — no mock mode added).
-Outcome assertions, in Alex's terms:
+Note: `TenantPayment` `warn`s a "Would send invitation email" line per `invite_pending`
+team member — the leg either keeps the team admin-only or captures those warns so output
+stays pristine. Outcome assertions, in Alex's terms:
 
 1. The tenant row and schema exist; `clone_schema` artifacts are present (workflows count
    > 0 in the tenant schema).
@@ -66,6 +70,11 @@ readiness-gate test's fixture approach), Stripe intercepted at the
 2. **Activate:** Alex records the connected account (tenant-row update mirroring the
    runbook), then an `account.updated` webhook event flips/confirms
    `stripe_charges_enabled`/`stripe_details_submitted` — both activation paths exercised.
+   The webhook is delivered **over HTTP with a real signed payload** (set
+   `STRIPE_WEBHOOK_SECRET`, compute the `stripe-signature` HMAC the way
+   `_verify_stripe_signature` expects) — consistent with the suite's over-HTTP ethos,
+   rather than the direct `_process_account_updated` call idiom used in the integration
+   test.
 3. **Collect:** the parent retries over HTTP → enrollment proceeds; the captured
    PaymentIntent params carry `transfer_data[destination]`, `on_behalf_of`, and
    `application_fee_amount == Registry::DAO::Payment::application_fee_cents(_to_cents($plan_amount))`;
@@ -78,13 +87,30 @@ through the HTTP surface rather than calling step classes directly.
 *Outcome: Registry bills the tenant for the platform subscription.*
 
 Walk the pricing-plan-selection + `TenantPayment` portion of signup (HTTP, as in Leg 1, or
-the narrowest HTTP path that reaches it) and assert the platform-side artifacts:
+the narrowest HTTP path that reaches it) and assert the platform-side artifacts **that
+actually exist post-signup** (verified against the code: signup does NOT create a
+tenant↔plan `PricingRelationship` — `PricingPlanSelection` only finds the pre-seeded
+platform plans and stashes the choice in run data; `TenantPayment::_provision_tenant`
+writes billing fields onto the tenant row):
 
-1. A `PricingRelationship` (and related platform-billing rows) exists in the registry
-   schema linking tenant and plan.
-2. The tenant row's `billing_status` reflects the established subscription/trial state.
-3. The Solo-tier copy shown to the signing-up owner derives from
-   `Registry::DAO::Payment::REVENUE_SHARE_PERCENT` (single source of truth).
+1. The selected plan is recorded in the workflow run data (`selected_pricing_plan`), and
+   the provisioned tenant row carries the billing fields: `stripe_subscription_id`,
+   `billing_status` (`trial` on the `seti_test` path), `trial_ends_at`.
+2. **Known gap, asserted deliberately:** no platform-billing row links the tenant to its
+   chosen plan after signup. The leg documents this with a comment; if a tenant↔plan
+   record is later introduced, the assertion gets strengthened. (Fix-or-file policy: if
+   the implementer or reviewers judge this a product bug, file it — do not build the
+   missing feature inside a journey test.)
+3. **Pricing-copy drift detection:** the plan copy shown to the signing-up owner must
+   agree with what the platform actually charges
+   (`Registry::DAO::Payment::REVENUE_SHARE_PERCENT` = 2.5). **This is expected to FAIL
+   today**: the seeded platform plan is "Registry Revenue Share - 2%" with `amount 0.02`
+   (`sql/deploy/unified-pricing-infrastructure.sql:107-113`), while destination charges
+   collect 2.5% — a real, pre-existing drift between displayed price and collected fee.
+   Per the failure philosophy this is a finding: fix the seeded data (and any
+   `pricing_configuration` template copy) to 2.5% in-branch if the requester confirms
+   2.5% is the decided rate, or file an issue and mark the assertion TODO with the issue
+   reference.
 
 **Explicit non-goal (stated in the file):** recurring usage-based billing — the
 `_get_usage_data` branch is deliberately non-functional pending redesign (issue #263).

--- a/docs/superpowers/specs/2026-06-11-alex-user-journeys-design.md
+++ b/docs/superpowers/specs/2026-06-11-alex-user-journeys-design.md
@@ -31,6 +31,17 @@ regression in any of these breaks Alex's business, not a feature.
   `t/job/*`). Runtime cost accepted.
 - **Structure:** four numbered legs, one per outcome, each self-contained with its own test
   DB (option A; matches the existing per-leg convention).
+- **Implementation sequencing (pushback resolution):** build the cheap legs first —
+  4 (health) → 2 (activate+collect) → 3 (billing) → 1 (acquire) — so the suite delivers
+  value even if Leg 1 stalls on funnel findings. Leg 1 may land in two stages: a
+  walk-the-funnel commit (drive every step, assert HTTP-level success/redirects only),
+  then an outcome-assertions commit, with funnel bugs fixed or filed between them.
+- **Funnel friction inventory (pushback resolution):** while walking the funnel with
+  minimal data, Legs 1 and 3 record which fields each signup step marks required vs.
+  accepts empty, and which of those downstream steps actually consume. The inventory is
+  filed as a funnel-friction issue (per-field evidence); removing fields is a separate
+  product change decided field-by-field — NOT part of this suite. The legs keep asserting
+  the minimal-data path works, permanently guarding against required-field creep.
 
 ## Design
 
@@ -81,16 +92,25 @@ readiness-gate test's fixture approach), Stripe intercepted at the
    PaymentIntent params carry `transfer_data[destination]`, `on_behalf_of`, and
    `application_fee_amount == Registry::DAO::Payment::application_fee_cents(_to_cents($plan_amount))`;
    the payment row lands in the tenant schema.
+4. **Complete (pushback resolution):** deliver a signed `payment_intent.succeeded` over
+   HTTP (synthesized from the captured intent params — the same proof shape as the
+   integration test; reuse the signing helper from step 2) → the payment is `completed`
+   and the enrollment exists, both in the tenant schema. The leg now walks Alex's outcome
+   end to end: gated → activated → charged → enrolled.
 
 Distinct from `t/integration/tenant-paid-enrollment.t` by driving the enrollment workflow
-through the HTTP surface rather than calling step classes directly.
+and both webhooks through the HTTP surface rather than calling step classes/handler
+methods directly.
 
 ### Leg 3 — `t/user-journeys/alex/03-platform-billing.t`
 *Outcome: Registry bills the tenant for the platform subscription.*
 
-Walk the pricing-plan-selection + `TenantPayment` portion of signup (HTTP, as in Leg 1, or
-the narrowest HTTP path that reaches it) and assert the platform-side artifacts **that
-actually exist post-signup** (verified against the code: signup does NOT create a
+Start a `tenant-signup` run over HTTP and drive it from the start with **minimal form
+data** at each pre-pricing step (the data-flow test proves those steps accept minimal
+input) — no mid-workflow entry tricks; journey tests walk the path real users take. The
+walk shape intentionally mirrors Leg 1 with different assertions; if the two legs'
+fixture setup converges, share a `t/lib/` helper per the YAGNI rule. Then assert the
+platform-side artifacts **that actually exist post-signup** (verified against the code: signup does NOT create a
 tenant↔plan `PricingRelationship` — `PricingPlanSelection` only finds the pre-seeded
 platform plans and stashes the choice in run data; `TenantPayment::_provision_tenant`
 writes billing fields onto the tenant row):
@@ -129,7 +149,11 @@ Thin aggregation leg, deliberately:
    and assert per-tenant processing reached the tenant with state and did not abort on the
    other.
 2. A `registry.tenants` row whose schema does not exist (the #265 shape) does not abort
-   either sweep — failure is isolated and logged.
+   either sweep — failure is isolated and logged. **Framing (pushback resolution):** this
+   is a defense-in-depth assertion, not an endorsement of that state. The sweep must never
+   let one bad row break other tenants regardless of whether such rows turn out to be
+   legal; the test comment links #265, and the assertion survives any resolution of it
+   (including deleting the row and forbidding the state).
 3. GET `/health` returns 200 with `db: ok`.
 
 ### Shared conventions (all legs)

--- a/lib/Registry/DAO/Tenant.pm
+++ b/lib/Registry/DAO/Tenant.pm
@@ -196,6 +196,30 @@ class Registry::DAO::Tenant :isa(Registry::DAO::Object) {
                 $tenant->slug, $user_id);
         }
 
+        # Copy OutcomeDefinitions into the tenant schema BEFORE copying workflows.
+        # copy_workflow inserts workflow_steps with outcome_definition_id FK values;
+        # the tenant schema's workflow_steps FK references the tenant's own
+        # outcome_definitions table (clone_schema strips the schema qualifier).
+        # Copying outcome definitions here ensures the FK is satisfiable when
+        # copy_workflow runs below.  We temporarily switch the search_path on $db
+        # so unqualified 'outcome_definitions' resolves to the tenant schema.
+        # After the inserts we reset to registry so later queries remain correct.
+        my @outcome_defs = Registry::DAO::OutcomeDefinition->find($db);
+        if (@outcome_defs) {
+            $db->query("SET search_path = ${schema}, public");
+            for my $def (@outcome_defs) {
+                Registry::DAO::OutcomeDefinition->create(
+                    $db,
+                    {
+                        id     => $def->id,
+                        name   => $def->name,
+                        schema => $def->schema,
+                    }
+                );
+            }
+            $db->query('SET search_path = registry, public');
+        }
+
         # Copy every workflow in registry except tenant-signup
         my @workflows = $db->select('registry.workflows', ['id', 'slug'])->hashes->each;
         for my $wf (@workflows) {
@@ -227,26 +251,6 @@ class Registry::DAO::Tenant :isa(Registry::DAO::Object) {
             DELETE FROM ${schema}.templates
              WHERE name = 'tenant-storefront/program-listing'
         });
-
-        # Copy OutcomeDefinitions into the tenant schema.  We temporarily switch
-        # the search_path on $db (the in-transaction handle) so that the unqualified
-        # 'outcome_definitions' table resolves to the tenant schema.  After the
-        # inserts, we reset back to registry so later queries remain correct.
-        my @outcome_defs = Registry::DAO::OutcomeDefinition->find($db);
-        if (@outcome_defs) {
-            $db->query("SET search_path = ${schema}, public");
-            for my $def (@outcome_defs) {
-                Registry::DAO::OutcomeDefinition->create(
-                    $db,
-                    {
-                        id     => $def->id,
-                        name   => $def->name,
-                        schema => $def->schema,
-                    }
-                );
-            }
-            $db->query('SET search_path = registry, public');
-        }
 
         $tx->commit;
 

--- a/lib/Registry/DAO/WorkflowSteps/MultiChildSessionSelection.pm
+++ b/lib/Registry/DAO/WorkflowSteps/MultiChildSessionSelection.pm
@@ -119,18 +119,31 @@ class Registry::DAO::WorkflowSteps::MultiChildSessionSelection :isa(Registry::DA
                 };
             }
             
-            # Store selections in run data
+            # Store selections in run data. Also snapshot the children array
+            # so calculate_enrollment_total (called from the Payment step) can
+            # iterate children and look up pricing without re-querying the family.
             my @enrollment_items;
             for my $child_id (keys %selections) {
                 push @enrollment_items, {
-                    child_id => $child_id,
+                    child_id   => $child_id,
                     session_id => $selections{$child_id},
                 };
             }
-            
+
+            my @children_data = map {
+                {
+                    id         => $_->id,
+                    first_name => $_->child_name,
+                    last_name  => '',
+                    birth_date => $_->birth_date,
+                    grade      => $_->grade,
+                }
+            } @children;
+
             $run->update_data($db, {
-                enrollment_items => \@enrollment_items,
+                enrollment_items   => \@enrollment_items,
                 session_selections => \%selections,
+                children           => \@children_data,
             });
             
             # Move to payment step

--- a/lib/Registry/DAO/WorkflowSteps/ProgramListing.pm
+++ b/lib/Registry/DAO/WorkflowSteps/ProgramListing.pm
@@ -214,12 +214,27 @@ class Registry::DAO::WorkflowSteps::ProgramListing :isa(Registry::DAO::WorkflowS
             ORDER BY pt.name
         })->hashes;
 
+        # Resolve the tenant's human-readable name for the storefront title.
+        # The search_path on $db is set to the tenant schema, so current_schema()
+        # returns the slug.  A registry.tenants lookup then yields the name.
+        # This populates stash('page_title') which the template uses as the nav logo.
+        my $current_slug = $db->query('SELECT current_schema()')->array->[0];
+        my $tenant_name;
+        if ($current_slug && $current_slug ne 'registry') {
+            my $row = $db->query(
+                q{SELECT name FROM registry.tenants WHERE slug = ?},
+                $current_slug
+            )->hash;
+            $tenant_name = $row->{name} if $row;
+        }
+
         return {
             programs             => \@sorted,
             grouped_programs     => \%grouped,
             filter_locations     => $filter_locations->to_array,
             filter_program_types => $filter_program_types->to_array,
             run                  => $run,
+            page_title           => $tenant_name,
         };
     }
 }

--- a/t/dao/multi-child-session-selection-workflow-step.t
+++ b/t/dao/multi-child-session-selection-workflow-step.t
@@ -270,7 +270,9 @@ subtest 'Submit with valid session selections' => sub {
     ok $child_ids{$child1->id} && $child_ids{$child2->id},
         'snapshot carries both child ids';
     ok defined $data->{children}[0]{first_name},
-        'snapshot carries the fields the payment description uses';
+        'snapshot carries the first_name field the payment description uses';
+    ok exists $data->{children}[0]{last_name},
+        'snapshot carries a last_name key (empty string; family members have no surname)';
 };
 
 subtest 'Program type sibling rule validation' => sub {

--- a/t/dao/multi-child-session-selection-workflow-step.t
+++ b/t/dao/multi-child-session-selection-workflow-step.t
@@ -260,6 +260,17 @@ subtest 'Submit with valid session selections' => sub {
     # Check session selections
     is $data->{session_selections}->{$child1->id}, $session1->id, 'Child1 session stored';
     is $data->{session_selections}->{$child2->id}, $session1->id, 'Child2 session stored';
+
+    # The children snapshot feeds Payment::calculate_enrollment_total; without
+    # it the total degenerates to $0 and paid enrollment silently goes free,
+    # bypassing the Connect readiness gate.
+    ok $data->{children}, 'children snapshot stored in run data';
+    is scalar(@{$data->{children}}), 2, 'both selected children snapshotted';
+    my %child_ids = map { $_->{id} => 1 } @{$data->{children}};
+    ok $child_ids{$child1->id} && $child_ids{$child2->id},
+        'snapshot carries both child ids';
+    ok defined $data->{children}[0]{first_name},
+        'snapshot carries the fields the payment description uses';
 };
 
 subtest 'Program type sibling rule validation' => sub {

--- a/t/dao/tenant-provision.t
+++ b/t/dao/tenant-provision.t
@@ -54,13 +54,12 @@ ok $copied, 'admin user copied into tenant schema';
 #
 # The app's before_server_start hook (lib/Registry.pm) calls import_schemas
 # first, then import_workflows, so the registry schema always has outcome
-# definitions in place when provision is called in production.  But the
-# old test helper import_all_workflows never imported outcome definitions,
-# meaning every helper-based provisioning test exercised only the NULL-FK
-# path and would pass even with the broken ordering.
+# definitions in place when provision is called in production.  A test that
+# imports workflows without outcome definitions exercises only the NULL-FK
+# path and cannot detect a broken copy ordering.
 #
-# This subtest mirrors the production boot order: load schemas/*.json before
-# importing workflows, then provisions a tenant and verifies that:
+# This subtest mirrors the production boot order (schemas before workflows,
+# via the shared helper), provisions a tenant, and verifies that:
 #   1. summer-camp-registration (the canonical workflow with a linked outcome
 #      definition on its camper-info step) was copied into the tenant schema.
 #   2. No step in the tenant schema has a dangling outcome_definition_id FK
@@ -73,21 +72,11 @@ subtest 'provision copies outcome definitions before workflows (FK ordering pin)
     $ENV{DB_URL}   = $pin_db_obj->uri;
     my $pin_db     = $pin_dao->db;
 
-    # Step 1: import outcome definitions into the registry schema, mirroring
-    # the production import_schemas call (Registry.pm before_server_start).
-    my @schema_files =
-      Mojo::Home->new->child('schemas')->list->grep(qr/\.json$/)->each;
-    Registry::DAO::OutcomeDefinition->import_from_file($pin_dao, $_)
-      for @schema_files;
-
-    # Step 2: import workflows after outcome definitions are in place.
-    my @wf_files =
-      Mojo::Home->new->child('workflows')->list_tree->grep(qr/\.ya?ml$/)->each;
-    for my $file (@wf_files) {
-        require YAML::XS;
-        next if YAML::XS::Load($file->slurp)->{draft};
-        Registry::DAO::Workflow->from_yaml($pin_dao, $file->slurp);
-    }
+    # Import outcome definitions then workflows via the shared helper, which
+    # mirrors the production import_schemas-then-import_workflows boot order.
+    # Sharing the helper keeps this pin on the exact code path every other
+    # provisioning test uses.
+    import_all_workflows($pin_dao);
 
     my $pin_admin = Registry::DAO::User->create($pin_db, {
         username => 'pin_admin', user_type => 'admin',

--- a/t/dao/tenant-provision.t
+++ b/t/dao/tenant-provision.t
@@ -3,10 +3,12 @@
 use 5.42.0;
 use lib qw(lib t/lib);
 use experimental qw(defer keyword_any);
-use Test::More import => [qw(done_testing is ok)];
+use Test::More import => [qw(done_testing is ok subtest)];
 defer { done_testing };
 
+use Mojo::Home;
 use Registry::DAO;
+use Registry::DAO::OutcomeDefinition;
 use Registry::DAO::Tenant;
 use Registry::DAO::User;
 use Test::Registry::DB;
@@ -41,3 +43,96 @@ ok( !(any { $_ eq 'tenant-signup' } @slugs), 'tenant does NOT have tenant-signup
 
 my $copied = $tenant_dao->find(User => { username => 'prov_admin' });
 ok $copied, 'admin user copied into tenant schema';
+
+# Regression pin for the outcome-definition FK ordering bug fixed in 3652f34.
+#
+# Background: copy_workflow inserts workflow_steps rows that carry an
+# outcome_definition_id FK.  That FK references the TENANT schema's own
+# outcome_definitions table (clone_schema strips the registry. qualifier).
+# If outcome definitions are not copied into the tenant schema BEFORE
+# copy_workflow runs, the FK insert fails with a constraint violation.
+#
+# The app's before_server_start hook (lib/Registry.pm) calls import_schemas
+# first, then import_workflows, so the registry schema always has outcome
+# definitions in place when provision is called in production.  But the
+# old test helper import_all_workflows never imported outcome definitions,
+# meaning every helper-based provisioning test exercised only the NULL-FK
+# path and would pass even with the broken ordering.
+#
+# This subtest mirrors the production boot order: load schemas/*.json before
+# importing workflows, then provisions a tenant and verifies that:
+#   1. summer-camp-registration (the canonical workflow with a linked outcome
+#      definition on its camper-info step) was copied into the tenant schema.
+#   2. No step in the tenant schema has a dangling outcome_definition_id FK
+#      (join count of unresolvable IDs == 0).
+#   3. At least one step has a non-NULL outcome_definition_id so the pin
+#      cannot pass vacuously on a database where the FK column is always NULL.
+subtest 'provision copies outcome definitions before workflows (FK ordering pin)' => sub {
+    my $pin_db_obj = Test::Registry::DB->new;
+    my $pin_dao    = $pin_db_obj->db;
+    $ENV{DB_URL}   = $pin_db_obj->uri;
+    my $pin_db     = $pin_dao->db;
+
+    # Step 1: import outcome definitions into the registry schema, mirroring
+    # the production import_schemas call (Registry.pm before_server_start).
+    my @schema_files =
+      Mojo::Home->new->child('schemas')->list->grep(qr/\.json$/)->each;
+    Registry::DAO::OutcomeDefinition->import_from_file($pin_dao, $_)
+      for @schema_files;
+
+    # Step 2: import workflows after outcome definitions are in place.
+    my @wf_files =
+      Mojo::Home->new->child('workflows')->list_tree->grep(qr/\.ya?ml$/)->each;
+    for my $file (@wf_files) {
+        require YAML::XS;
+        next if YAML::XS::Load($file->slurp)->{draft};
+        Registry::DAO::Workflow->from_yaml($pin_dao, $file->slurp);
+    }
+
+    my $pin_admin = Registry::DAO::User->create($pin_db, {
+        username => 'pin_admin', user_type => 'admin',
+        email => 'pin_admin@test.com', name => 'Pin Admin',
+    });
+
+    my $pin_tenant = Registry::DAO::Tenant->provision($pin_db, {
+        name  => 'FK Pin Test',
+        slug  => 'fkpin1',
+        users => [ $pin_admin ],
+    });
+    ok $pin_tenant, 'provision succeeded with outcome definitions pre-loaded';
+
+    my $pin_tdao = Registry::DAO->new(url => $ENV{DB_URL}, schema => $pin_tenant->slug);
+    my $pin_tdb  = $pin_tdao->db;
+
+    # Assert summer-camp-registration was copied into the tenant schema.
+    my @tenant_wf_slugs =
+      map { $_->{slug} } $pin_tdb->select('workflows', ['slug'])->hashes->each;
+    ok( (any { $_ eq 'summer-camp-registration' } @tenant_wf_slugs),
+        'tenant schema contains summer-camp-registration workflow' );
+
+    # Assert no dangling outcome_definition_id FK in the tenant schema.
+    # A dangling FK would mean copy_workflow ran before outcome defs existed
+    # (the pre-fix bug: workflow_steps rows with outcome_definition_id values
+    # that do not resolve to any row in the tenant's outcome_definitions table).
+    my $dangling = $pin_tdb->query(qq{
+        SELECT COUNT(*) AS n
+          FROM workflow_steps ws
+         WHERE ws.outcome_definition_id IS NOT NULL
+           AND NOT EXISTS (
+               SELECT 1 FROM outcome_definitions od
+                WHERE od.id = ws.outcome_definition_id
+           )
+    })->hash->{n};
+    is $dangling + 0, 0,
+      'no workflow_steps rows have a dangling outcome_definition_id FK';
+
+    # Assert at least one step has a non-NULL outcome_definition_id so the
+    # above check cannot pass vacuously on a fully-NULL dataset.
+    my $linked = $pin_tdb->query(q{
+        SELECT COUNT(*) AS n
+          FROM workflow_steps
+         WHERE outcome_definition_id IS NOT NULL
+    })->hash->{n};
+    ok $linked > 0,
+      'at least one workflow_step has a non-NULL outcome_definition_id (pin is non-vacuous)';
+};

--- a/t/lib/Test/Registry/Helpers.pm
+++ b/t/lib/Test/Registry/Helpers.pm
@@ -9,9 +9,11 @@ package Test::Registry::Helpers {
     sub import(@) {
         no warnings;
         export_lexically(
-            authenticate_as           => __PACKAGE__->can('authenticate_as'),
-            import_all_workflows      => __PACKAGE__->can('import_all_workflows'),
-            process_workflow          => __PACKAGE__->can('process_workflow'),
+            authenticate_as                  => __PACKAGE__->can('authenticate_as'),
+            import_all_workflows             => __PACKAGE__->can('import_all_workflows'),
+            process_workflow                 => __PACKAGE__->can('process_workflow'),
+            seed_platform_pricing_relationship =>
+              __PACKAGE__->can('seed_platform_pricing_relationship'),
             workflow_process_step_url =>
               __PACKAGE__->can('workflow_process_step_url'),
             workflow_run_step_url => __PACKAGE__->can('workflow_run_step_url'),
@@ -62,6 +64,64 @@ package Test::Registry::Helpers {
         else {
             die "Unexpected response code: " . $req->tx->res->code;
         }
+    }
+
+    # seed_platform_pricing_relationship($dao) -- issue #268
+    #
+    # Fresh test databases have ZERO pricing relationships: the migration
+    # sql/deploy/create-default-pricing-relationships.sql is orphaned from
+    # sqitch.plan, so PricingPlanSelection::prepare_pricing_data finds no plans,
+    # renders no radio buttons, and silently skips the pricing step without any
+    # visible error.  Without seeding here, any leg that walks the pricing step
+    # would skip it silently, leaving downstream billing assertions vacuous.
+    #
+    # The INSERT mirrors the orphaned migration (sql/deploy/create-default-
+    # pricing-relationships.sql:63-80) with one difference: consumer_id uses the
+    # 'system' user that ships in the test dump instead of a dynamically-created
+    # platform_admin.  The listing query in PricingPlanSelection never filters on
+    # consumer_id, so any valid user id satisfies the NOT NULL FK constraint.
+    #
+    # Returns the plan UUID so the caller can POST it as selected_plan_id.
+    # Dies with a loud message if any prerequisite is missing (equivalent to
+    # BAIL_OUT in the context of a test script).
+    sub seed_platform_pricing_relationship ($dao) {
+        my $db = $dao->db;
+
+        my $plan_row = $db->query(q{
+            SELECT id FROM registry.pricing_plans
+            WHERE pricing_model_type = 'percentage' AND plan_scope = 'tenant' LIMIT 1
+        })->hash;
+        die 'No tenant-scoped percentage plan in DB -- cannot walk pricing step'
+            unless $plan_row;
+        Test::More::ok($plan_row, 'seeded 2% revenue-share plan found in registry.pricing_plans');
+
+        my $plan_id = $plan_row->{id};
+
+        my $system_user_row = $db->query(
+            q{SELECT id FROM registry.users WHERE username = 'system' LIMIT 1}
+        )->hash;
+        die 'system user missing -- cannot satisfy consumer_id FK'
+            unless $system_user_row;
+        Test::More::ok($system_user_row, 'system user exists in test dump');
+
+        my $system_user_id = $system_user_row->{id};
+
+        $db->query(q{
+            INSERT INTO registry.pricing_relationships
+                (provider_id, consumer_id, pricing_plan_id, status, metadata)
+            VALUES ('00000000-0000-0000-0000-000000000000', ?, ?, 'active',
+                    '{"plan_type":"tenant_subscription","created_by":"test_fixture"}'::jsonb)
+        }, $system_user_id, $plan_id);
+
+        # Verify the seed landed so a misconfigured DB fails loudly here, not later.
+        my $rel_count = $db->query(q{
+            SELECT count(*) AS n FROM registry.pricing_relationships
+            WHERE provider_id = '00000000-0000-0000-0000-000000000000'
+              AND pricing_plan_id = ?
+        }, $plan_id)->hash->{n};
+        Test::More::is($rel_count, 1, 'exactly one platform pricing relationship seeded');
+
+        return $plan_id;
     }
 
     sub import_all_workflows ($dao) {

--- a/t/lib/Test/Registry/Helpers.pm
+++ b/t/lib/Test/Registry/Helpers.pm
@@ -68,6 +68,19 @@ package Test::Registry::Helpers {
         require Mojo::Home;
         require YAML::XS;
         require Registry::DAO;
+        require Registry::DAO::OutcomeDefinition;
+
+        # Import outcome definitions BEFORE workflows.  copy_workflow inserts
+        # workflow_steps rows with outcome_definition_id FK values that reference
+        # the registry schema's outcome_definitions table.  If no definitions
+        # exist when from_yaml runs the FK insert fails.  This mirrors the
+        # production boot order in Registry.pm before_server_start:
+        # import_schemas, then import_workflows.
+        my @schema_files =
+          Mojo::Home->new->child('schemas')->list->grep(qr/\.json$/)->each;
+        Registry::DAO::OutcomeDefinition->import_from_file($dao, $_)
+          for @schema_files;
+
         my @files = Mojo::Home->new->child('workflows')->list_tree->grep(qr/\.ya?ml$/)->each;
         for my $file (@files) {
             next if YAML::XS::Load($file->slurp)->{draft};

--- a/t/user-journeys/alex/01-acquire-tenant.t
+++ b/t/user-journeys/alex/01-acquire-tenant.t
@@ -14,6 +14,7 @@ defer { done_testing };
 
 use Test::Registry::Mojo;
 use Test::Registry::DB;
+use Test::Registry::Helpers qw(import_all_workflows);
 
 use Registry::DAO;
 use Registry::DAO::Workflow;
@@ -28,12 +29,18 @@ my $db      = $dao->db;
 $ENV{DB_URL} = $test_db->uri;
 
 # ---------------------------------------------------------------------------
-# Import the tenant-signup workflow into the registry schema.
+# Import all non-draft workflows into the registry schema.
+# Tenant->provision copies every registry workflow (except tenant-signup) into
+# the tenant schema via copy_workflow.  If only tenant-signup is imported here,
+# the tenant schema ends up with zero workflows — making the Stage 2 workflow
+# count assertion vacuous.  import_all_workflows also seeds outcome definitions
+# before the workflow rows, satisfying the outcome_definition_id FK.
 # ---------------------------------------------------------------------------
-$dao->import_workflows(['workflows/tenant-signup.yml']);
+import_all_workflows($dao);
 
 my ($signup_wf) = $dao->find(Workflow => { slug => 'tenant-signup' });
-ok $signup_wf, 'tenant-signup workflow present in registry schema';
+ok $signup_wf, 'tenant-signup workflow present in registry schema'
+    or BAIL_OUT('tenant-signup workflow missing -- cannot walk funnel');
 
 # ---------------------------------------------------------------------------
 # Fixture: seed the platform pricing relationship.
@@ -102,7 +109,7 @@ $t->app->helper(dao => sub { $dao });
 # Stage 1 asserts HTTP-level health only: each POST 302s to the expected next
 # step, each GET 200s, and the complete page renders.
 #
-# Friction inventory (inputs to per-field discussion in Task 5 issue):
+# Friction inventory (inputs to per-field discussion in issue #270):
 #   landing     — no fields; POST with empty body advances.  Required: none.
 #   profile     — 'name' consumed downstream by _provision_tenant (falls back
 #                 to 'Organization' without it); 'description' is accepted
@@ -256,7 +263,120 @@ my $complete_url = $t->tx->res->headers->location;
 $t->get_ok($complete_url)->status_is(200);
 
 # ---------------------------------------------------------------------------
-# Stage 2 (working-tenant assertions) follows in a later commit.
+# Stage 2: working-tenant assertions.
+#
+# The funnel has completed.  Retrieve the run's accumulated data to find the
+# provisioned slug and then assert that the tenant is fully functional from
+# Alex's perspective: row exists, schema exists, workflows were cloned, the
+# admin user is dual-resident, the storefront serves, and the billing fields
+# are set correctly.
 # ---------------------------------------------------------------------------
+
+my $run      = $signup_wf->latest_run($db);
+my $run_data = $run->data;
+
+# The slug is written into run data as 'subdomain' by _provision_tenant.
+# It is derived from the org name: lc(name =~ s/\s+/_/gr) with hyphens also
+# replaced by underscores (see Tenant::provision, TenantPayment::_provision_tenant).
+my $slug = $run_data->{subdomain};
+ok $slug, "provisioned tenant slug present in run data (${\($slug // 'undef')})";
+
+# ---------------------------------------------------------------------------
+# Assertion 1: tenant row + schema exist; clone artifacts present.
+# ---------------------------------------------------------------------------
+subtest 'tenant row, schema, and workflows exist' => sub {
+    # 1a. Tenant row in registry.tenants
+    my $tenant_row = $db->query(
+        q{SELECT id, slug, name FROM registry.tenants WHERE slug = ?},
+        $slug
+    )->hash;
+    ok $tenant_row, "tenant row found in registry.tenants for slug '$slug'";
+
+    # 1b. Postgres schema exists.
+    # information_schema.schemata is available on any PostgreSQL connection and
+    # does not require special privileges.
+    my $schema_row = $db->query(
+        q{SELECT 1 FROM information_schema.schemata WHERE schema_name = ?},
+        $slug
+    )->hash;
+    ok $schema_row, "postgres schema '$slug' exists (clone_schema ran)";
+
+    # 1c. Workflows were copied into the tenant schema.
+    # provision copies every registry workflow except tenant-signup; at least
+    # one workflow (e.g. tenant-storefront) should always be present.
+    # Use a format-safe qualified identifier: the slug was already normalised
+    # to a safe postgres identifier (lc + spaces/hyphens -> underscores) by
+    # Tenant::provision, so direct interpolation is safe here.
+    my $wf_count = $db->query(
+        "SELECT count(*) AS n FROM ${\ $db->dbh->quote_identifier($slug) }.workflows"
+    )->hash->{n};
+    ok $wf_count > 0,
+        "tenant schema '$slug' has $wf_count workflow(s) (copy_workflow ran)";
+};
+
+# ---------------------------------------------------------------------------
+# Assertion 2: signup user is dual-resident (same id in registry.users and
+# <slug>.users).
+# ---------------------------------------------------------------------------
+subtest 'admin user is dual-resident in registry and tenant schemas' => sub {
+    # The admin user was created/looked up by _provision_tenant using the
+    # admin_username field from the funnel.
+    my $registry_user = $db->query(
+        q{SELECT id FROM registry.users WHERE username = ?},
+        $admin_user
+    )->hash;
+    ok $registry_user, "admin user '$admin_user' exists in registry.users";
+
+    my $user_id = $registry_user ? $registry_user->{id} : undef;
+
+    my $tenant_user = $db->query(
+        "SELECT id FROM ${\ $db->dbh->quote_identifier($slug) }.users WHERE id = ?",
+        $user_id
+    )->hash;
+    ok $tenant_user, "admin user id ${\($user_id // 'undef')} also exists in ${slug}.users (dual-resident)";
+    is $tenant_user->{id}, $user_id,
+        'registry.users.id matches tenant.users.id (same identity, no copy)';
+};
+
+# ---------------------------------------------------------------------------
+# Assertion 3: tenant's storefront serves.
+# GET / with Host: <slug>.localhost must return 200 and contain the org name.
+#
+# A fresh Test::Mojo->new('Registry') boots a new app instance whose dao helper
+# is NOT overridden, so host-based tenant resolution takes effect.  $ENV{DB_URL}
+# is already set to the test DB, so the new app resolves to the correct DB.
+# The existing $t pins its dao to the registry schema (needed for the signup
+# workflow walk) and is NOT reused here.
+# ---------------------------------------------------------------------------
+subtest 'tenant storefront serves at <slug>.localhost' => sub {
+    use Test::Mojo;
+    my $t2 = Test::Mojo->new('Registry');
+
+    $t2->get_ok('/' => { Host => "$slug.localhost" })
+      ->status_is(200, 'storefront GET / returns 200')
+      ->content_like(qr/\Q$org_name\E/i,
+          'storefront page contains the organization name');
+};
+
+# ---------------------------------------------------------------------------
+# Assertion 4: billing fields are set correctly for the seti_test path.
+# _provision_tenant writes billing_status='trial' and stripe_subscription_id
+# = 'sub_test_...' when subscription data carries a stripe_subscription_id
+# (set by handle_setup_completion on the seti_test branch).
+# ---------------------------------------------------------------------------
+subtest 'tenant row carries billing fields from seti_test path' => sub {
+    my $tenant_row = $db->query(
+        q{SELECT billing_status, stripe_subscription_id
+          FROM registry.tenants WHERE slug = ?},
+        $slug
+    )->hash;
+    ok $tenant_row, 'tenant row accessible for billing assertions';
+
+    is $tenant_row->{billing_status}, 'trial',
+        'billing_status is "trial" on the seti_test provision path';
+
+    like $tenant_row->{stripe_subscription_id}, qr/^sub_test_/,
+        'stripe_subscription_id starts with sub_test_ (seti_test seam)';
+};
 
 $test_db->cleanup_test_database;

--- a/t/user-journeys/alex/01-acquire-tenant.t
+++ b/t/user-journeys/alex/01-acquire-tenant.t
@@ -14,7 +14,7 @@ defer { done_testing };
 
 use Test::Registry::Mojo;
 use Test::Registry::DB;
-use Test::Registry::Helpers qw(import_all_workflows);
+use Test::Registry::Helpers qw(import_all_workflows seed_platform_pricing_relationship);
 
 use Registry::DAO;
 use Registry::DAO::Workflow;
@@ -42,56 +42,9 @@ my ($signup_wf) = $dao->find(Workflow => { slug => 'tenant-signup' });
 ok $signup_wf, 'tenant-signup workflow present in registry schema'
     or BAIL_OUT('tenant-signup workflow missing -- cannot walk funnel');
 
-# ---------------------------------------------------------------------------
-# Fixture: seed the platform pricing relationship.
-#
-# Fresh test databases have ZERO pricing relationships (issue #268):
-# sql/deploy/create-default-pricing-relationships.sql is orphaned from
-# sqitch.plan, so PricingPlanSelection::prepare_pricing_data finds no plans,
-# renders no radio buttons, and silently skips the pricing step without any
-# visible error.  Without seeding here, the leg would walk right past pricing
-# without ever selecting a plan, leaving the assertions in this file vacuous.
-#
-# The INSERT mirrors the orphaned migration (sql/deploy/create-default-
-# pricing-relationships.sql:63-80) with one difference: consumer_id uses the
-# 'system' user that ships in the test dump instead of a dynamically-created
-# platform_admin.  The listing query in PricingPlanSelection never filters on
-# consumer_id, so any valid user id satisfies the NOT NULL FK constraint.
-# ---------------------------------------------------------------------------
-my $plan_row = $db->query(q{
-    SELECT id FROM registry.pricing_plans
-    WHERE pricing_model_type = 'percentage' AND plan_scope = 'tenant' LIMIT 1
-})->hash;
-ok $plan_row, 'seeded 2% revenue-share plan found in registry.pricing_plans'
-    or BAIL_OUT('No tenant-scoped percentage plan in DB -- cannot walk pricing step');
-
-my $plan_id = $plan_row->{id};
-
-# consumer_id is a NOT NULL FK to registry.users(id); the test dump ships a
-# 'system' user whose id satisfies the constraint.  The pricing query never
-# filters on consumer_id, so no behavioural difference.
-my $system_user_row = $db->query(
-    q{SELECT id FROM registry.users WHERE username = 'system' LIMIT 1}
-)->hash;
-ok $system_user_row, 'system user exists in test dump'
-    or BAIL_OUT('system user missing -- cannot satisfy consumer_id FK');
-
-my $system_user_id = $system_user_row->{id};
-
-$db->query(q{
-    INSERT INTO registry.pricing_relationships
-        (provider_id, consumer_id, pricing_plan_id, status, metadata)
-    VALUES ('00000000-0000-0000-0000-000000000000', ?, ?, 'active',
-            '{"plan_type":"tenant_subscription","created_by":"test_fixture"}'::jsonb)
-}, $system_user_id, $plan_id);
-
-# Verify the seed landed so a misconfigured DB fails loudly here, not later.
-my $rel_count = $db->query(q{
-    SELECT count(*) AS n FROM registry.pricing_relationships
-    WHERE provider_id = '00000000-0000-0000-0000-000000000000'
-      AND pricing_plan_id = ?
-}, $plan_id)->hash->{n};
-is $rel_count, 1, 'exactly one platform pricing relationship seeded';
+# Fixture: seed the platform pricing relationship -- see #268 for full rationale.
+my $plan_id = seed_platform_pricing_relationship($dao)
+    or BAIL_OUT('seed_platform_pricing_relationship failed -- cannot walk pricing step');
 
 # ---------------------------------------------------------------------------
 # App setup: pin the app dao to the registry-context DAO so the workflow
@@ -325,15 +278,16 @@ subtest 'admin user is dual-resident in registry and tenant schemas' => sub {
         q{SELECT id FROM registry.users WHERE username = ?},
         $admin_user
     )->hash;
-    ok $registry_user, "admin user '$admin_user' exists in registry.users";
+    ok $registry_user, "admin user '$admin_user' exists in registry.users"
+        or return;    # guard: later assertions would warn on undef $user_id
 
-    my $user_id = $registry_user ? $registry_user->{id} : undef;
+    my $user_id = $registry_user->{id};
 
     my $tenant_user = $db->query(
         "SELECT id FROM ${\ $db->dbh->quote_identifier($slug) }.users WHERE id = ?",
         $user_id
     )->hash;
-    ok $tenant_user, "admin user id ${\($user_id // 'undef')} also exists in ${slug}.users (dual-resident)";
+    ok $tenant_user, "admin user id ${user_id} also exists in ${slug}.users (dual-resident)";
     is $tenant_user->{id}, $user_id,
         'registry.users.id matches tenant.users.id (same identity, no copy)';
 };
@@ -352,10 +306,25 @@ subtest 'tenant storefront serves at <slug>.localhost' => sub {
     use Test::Mojo;
     my $t2 = Test::Mojo->new('Registry');
 
-    $t2->get_ok('/' => { Host => "$slug.localhost" })
+    my $res = $t2->get_ok('/' => { Host => "$slug.localhost" })
       ->status_is(200, 'storefront GET / returns 200')
-      ->content_like(qr/\Q$org_name\E/i,
-          'storefront page contains the organization name');
+      ->tx->res;
+
+    # Pin to the elements ProgramListing populates (page_title -> stash).
+    # The <title> tag and the landing-logo nav div both render stash('page_title'),
+    # which ProgramListing sets to the tenant name.  Asserting here (rather than
+    # page-wide) confirms the fix to that step is what surfaces the org name.
+    my $dom = $res->dom;
+
+    my $title_text = $dom->at('title') ? $dom->at('title')->text : '';
+    like $title_text, qr/\Q$org_name\E/i,
+        'storefront <title> contains the organization name';
+
+    my $logo_el = $dom->at('.landing-logo');
+    ok $logo_el, 'storefront page has a .landing-logo element';
+    like( ($logo_el ? $logo_el->text : ''), qr/\Q$org_name\E/i,
+        'landing-logo element contains the organization name' )
+        if $logo_el;
 };
 
 # ---------------------------------------------------------------------------

--- a/t/user-journeys/alex/01-acquire-tenant.t
+++ b/t/user-journeys/alex/01-acquire-tenant.t
@@ -1,0 +1,262 @@
+#!/usr/bin/env perl
+# ABOUTME: Alex (platform owner) journey: the signup funnel produces a working,
+# ABOUTME: billable tenant.  Stage 1 walks the full funnel over HTTP with realistic data.
+
+BEGIN { $ENV{EMAIL_SENDER_TRANSPORT} = 'Test' }
+
+use 5.42.0;
+use utf8;
+use warnings;
+use lib qw(lib t/lib);
+use experimental qw(defer);
+use Test::More import => [qw( done_testing diag is like ok subtest BAIL_OUT )];
+defer { done_testing };
+
+use Test::Registry::Mojo;
+use Test::Registry::DB;
+
+use Registry::DAO;
+use Registry::DAO::Workflow;
+use Registry::DAO::WorkflowRun;
+
+# ---------------------------------------------------------------------------
+# Database setup
+# ---------------------------------------------------------------------------
+my $test_db = Test::Registry::DB->new;
+my $dao     = $test_db->db;    # registry-schema DAO
+my $db      = $dao->db;
+$ENV{DB_URL} = $test_db->uri;
+
+# ---------------------------------------------------------------------------
+# Import the tenant-signup workflow into the registry schema.
+# ---------------------------------------------------------------------------
+$dao->import_workflows(['workflows/tenant-signup.yml']);
+
+my ($signup_wf) = $dao->find(Workflow => { slug => 'tenant-signup' });
+ok $signup_wf, 'tenant-signup workflow present in registry schema';
+
+# ---------------------------------------------------------------------------
+# Fixture: seed the platform pricing relationship.
+#
+# Fresh test databases have ZERO pricing relationships (issue #268):
+# sql/deploy/create-default-pricing-relationships.sql is orphaned from
+# sqitch.plan, so PricingPlanSelection::prepare_pricing_data finds no plans,
+# renders no radio buttons, and silently skips the pricing step without any
+# visible error.  Without seeding here, the leg would walk right past pricing
+# without ever selecting a plan, leaving the assertions in this file vacuous.
+#
+# The INSERT mirrors the orphaned migration (sql/deploy/create-default-
+# pricing-relationships.sql:63-80) with one difference: consumer_id uses the
+# 'system' user that ships in the test dump instead of a dynamically-created
+# platform_admin.  The listing query in PricingPlanSelection never filters on
+# consumer_id, so any valid user id satisfies the NOT NULL FK constraint.
+# ---------------------------------------------------------------------------
+my $plan_row = $db->query(q{
+    SELECT id FROM registry.pricing_plans
+    WHERE pricing_model_type = 'percentage' AND plan_scope = 'tenant' LIMIT 1
+})->hash;
+ok $plan_row, 'seeded 2% revenue-share plan found in registry.pricing_plans'
+    or BAIL_OUT('No tenant-scoped percentage plan in DB -- cannot walk pricing step');
+
+my $plan_id = $plan_row->{id};
+
+# consumer_id is a NOT NULL FK to registry.users(id); the test dump ships a
+# 'system' user whose id satisfies the constraint.  The pricing query never
+# filters on consumer_id, so no behavioural difference.
+my $system_user_row = $db->query(
+    q{SELECT id FROM registry.users WHERE username = 'system' LIMIT 1}
+)->hash;
+ok $system_user_row, 'system user exists in test dump'
+    or BAIL_OUT('system user missing -- cannot satisfy consumer_id FK');
+
+my $system_user_id = $system_user_row->{id};
+
+$db->query(q{
+    INSERT INTO registry.pricing_relationships
+        (provider_id, consumer_id, pricing_plan_id, status, metadata)
+    VALUES ('00000000-0000-0000-0000-000000000000', ?, ?, 'active',
+            '{"plan_type":"tenant_subscription","created_by":"test_fixture"}'::jsonb)
+}, $system_user_id, $plan_id);
+
+# Verify the seed landed so a misconfigured DB fails loudly here, not later.
+my $rel_count = $db->query(q{
+    SELECT count(*) AS n FROM registry.pricing_relationships
+    WHERE provider_id = '00000000-0000-0000-0000-000000000000'
+      AND pricing_plan_id = ?
+}, $plan_id)->hash->{n};
+is $rel_count, 1, 'exactly one platform pricing relationship seeded';
+
+# ---------------------------------------------------------------------------
+# App setup: pin the app dao to the registry-context DAO so the workflow
+# controller resolves the tenant-signup workflow correctly.  (Matches the
+# data-flow test's $t->app->helper(dao => sub { $db }) pattern.)
+# ---------------------------------------------------------------------------
+my $t = Test::Registry::Mojo->new('Registry');
+$t->app->helper(dao => sub { $dao });
+
+# ---------------------------------------------------------------------------
+# Walk the tenant-signup funnel with REALISTIC data (Portland-Art-Collective-
+# style from t/controller/tenant-signup-data-flow.t), through the full path:
+#   landing -> profile -> users -> pricing -> review -> payment -> complete
+#
+# Stage 1 asserts HTTP-level health only: each POST 302s to the expected next
+# step, each GET 200s, and the complete page renders.
+#
+# Friction inventory (inputs to per-field discussion in Task 5 issue):
+#   landing     — no fields; POST with empty body advances.  Required: none.
+#   profile     — 'name' consumed downstream by _provision_tenant (falls back
+#                 to 'Organization' without it); 'description' is accepted
+#                 empty but displayed on review; 'billing_email' displayed on
+#                 review if non-empty.  Realistic data tests all three.
+#   users       — 'admin_name', 'admin_email', 'admin_username' accumulated in
+#                 run data and rendered on review; 'admin_user_type' must be
+#                 'admin' to avoid the invite-pending warn() path in
+#                 _provision_tenant (pristine-output hazard noted in spec).
+#                 Team kept admin-only here to preserve pristine output.
+#   pricing     — 'selected_plan_id' required (must be a valid UUID for an
+#                 active platform relationship; absent silently skips).  The
+#                 seeded plan renders and is selected explicitly.
+#   review      — 'terms_accepted' required by the controller (Workflows.pm)
+#                 BEFORE calling step->process; the step itself accepts empty
+#                 body but the controller gate refuses without it.
+#   payment     — 'collect_payment_method' + 'setup_intent_id' (seti_test...)
+#                 trigger the test-mode provision path in TenantPayment.pm:43-46.
+#                 The seti_test branch wins on dispatch order before the no-keys
+#                 branch, so Stripe env keys are irrelevant to this POST.
+# ---------------------------------------------------------------------------
+
+# Realistic identity: Portland-Art-Collective-style, $$-suffixed for uniqueness.
+my $org_name     = "Cascadia Maker Camp $$";
+my $admin_name   = "Jordan Cascadia $$";
+my $admin_email  = "jordan_$$\@cascadiamakers.example";
+my $admin_user   = "jordan_$$";
+my $billing_email = "billing_$$\@cascadiamakers.example";
+my $description  = 'Maker education for youth and adults in the Pacific Northwest';
+
+# -- Step: landing (starts the run) ----------------------------------------
+# POST to the tenant-signup start URL.  No form fields required.
+# Expected: 302 -> /tenant-signup/<run-id>/profile
+$t->post_ok('/tenant-signup')
+  ->status_is(302)
+  ->header_like(Location => qr{/tenant-signup/[^/]+/profile$},
+                'landing POST redirects to profile step');
+
+my $profile_url = $t->tx->res->headers->location;
+
+# GET before POST (establishes session / populates CSRF token if any).
+$t->get_ok($profile_url)->status_is(200);
+
+# -- Step: profile ----------------------------------------------------------
+# Realistic org profile data.  'name' is the only field _provision_tenant
+# reads from this step; 'description' and 'billing_email' are captured in run
+# data and displayed on the review page (content_like assertions below).
+# Expected: 302 -> /tenant-signup/<run-id>/users
+$t->post_ok($profile_url => form => {
+    name          => $org_name,
+    description   => $description,
+    billing_email => $billing_email,
+})->status_is(302)
+  ->header_like(Location => qr{/tenant-signup/[^/]+/users$},
+                'profile POST redirects to users step');
+
+my $users_url = $t->tx->res->headers->location;
+
+# GET before POST.
+$t->get_ok($users_url)->status_is(200);
+
+# -- Step: users ------------------------------------------------------------
+# Realistic admin-only team.  'admin_user_type => admin' avoids the
+# invite-pending warn() path in _provision_tenant (pristine output).
+# Full fields (admin_name/email/username) are rendered on the review page.
+# Expected: 302 -> /tenant-signup/<run-id>/pricing
+$t->post_ok($users_url => form => {
+    admin_name      => $admin_name,
+    admin_email     => $admin_email,
+    admin_username  => $admin_user,
+    admin_user_type => 'admin',
+})->status_is(302)
+  ->header_like(Location => qr{/tenant-signup/[^/]+/pricing$},
+                'users POST redirects to pricing step');
+
+my $pricing_url = $t->tx->res->headers->location;
+
+# -- Step: pricing (GET) -- assert seeded plan renders ---------------------
+# This GET doubles as the #268 guard: if the seeded relationship is absent,
+# prepare_pricing_data returns an empty list, the template renders no radio
+# buttons, and the assertion below catches that silently-broken path.
+my $pricing_page = $t->get_ok($pricing_url)->status_is(200)->tx->res->body;
+
+like $pricing_page, qr/selected_plan_id/,
+    'pricing page renders at least one plan radio (seeded relationship visible, #268 guard)';
+like $pricing_page, qr/Registry Revenue Share/,
+    'pricing page shows the seeded revenue-share plan name';
+
+# -- Step: pricing (POST) -- select the seeded plan -----------------------
+# 'selected_plan_id' is consumed via exists $form_data->{selected_plan_id}
+# in PricingPlanSelection::process.
+# Expected: 302 -> /tenant-signup/<run-id>/review
+$t->post_ok($pricing_url => form => {
+    selected_plan_id => $plan_id,
+})->status_is(302)
+  ->header_like(Location => qr{/tenant-signup/[^/]+/review$},
+                'pricing POST redirects to review step');
+
+my $review_url = $t->tx->res->headers->location;
+
+# -- Step: review (GET) -- verify accumulated data renders ----------------
+# The TenantSignupReview step spreads profile/team into the stash.
+# The template reads stash('profile') and stash('team') directly.
+# Assert that all four realistic-data fields from the profile and users steps
+# are displayed on the review page (cribbed from tenant-signup-data-flow.t).
+$t->get_ok($review_url)
+  ->status_is(200)
+  ->content_like(qr/\Q$org_name\E/,
+      'review page shows organization name from profile step')
+  ->content_like(qr/\Q$billing_email\E/,
+      'review page shows billing email from profile step')
+  ->content_like(qr/\Q$admin_name\E/,
+      'review page shows admin name from users step')
+  ->content_like(qr/\Q$admin_email\E/,
+      'review page shows admin email from users step')
+  ->content_like(qr/\Q$admin_user\E/,
+      'review page shows admin username from users step');
+
+# -- Step: review (POST) -- accept terms ----------------------------------
+# The controller validates terms_accepted before calling step->process.
+# No other field is required at this step; all accumulation happened earlier.
+# Expected: 302 -> /tenant-signup/<run-id>/payment
+$t->post_ok($review_url => form => {
+    terms_accepted => 1,
+})->status_is(302)
+  ->header_like(Location => qr{/tenant-signup/[^/]+/payment$},
+                'review POST redirects to payment step');
+
+my $payment_url = $t->tx->res->headers->location;
+
+# -- Step: payment (GET) --------------------------------------------------
+$t->get_ok($payment_url)->status_is(200);
+
+# -- Step: payment (POST via seti_test seam) ------------------------------
+# POST collect_payment_method=1 + setup_intent_id=seti_test_... dispatches
+# to handle_setup_completion -> _provision_tenant (TenantPayment.pm:43-46,
+# 283-294).  The seti_test branch wins on dispatch order before the no-keys
+# branch, so Stripe env keys are irrelevant to this POST.
+# Expected: 302 -> /tenant-signup/<run-id>/complete
+$t->post_ok($payment_url => form => {
+    collect_payment_method => 1,
+    setup_intent_id        => 'seti_test_acquire_' . $$,
+})->status_is(302)
+  ->header_like(Location => qr{/tenant-signup/[^/]+/complete$},
+                'payment POST redirects to complete step');
+
+my $complete_url = $t->tx->res->headers->location;
+
+# -- Step: complete -------------------------------------------------------
+# The complete step (RegisterTenant) renders the success page.
+$t->get_ok($complete_url)->status_is(200);
+
+# ---------------------------------------------------------------------------
+# Stage 2 (working-tenant assertions) follows in a later commit.
+# ---------------------------------------------------------------------------
+
+$test_db->cleanup_test_database;

--- a/t/user-journeys/alex/02-activate-and-collect.t
+++ b/t/user-journeys/alex/02-activate-and-collect.t
@@ -1,0 +1,512 @@
+#!/usr/bin/env perl
+# ABOUTME: Alex (platform owner) journey: activating a tenant's Connect account
+# ABOUTME: unlocks paid enrollment and the platform fee is collected at charge time.
+
+BEGIN { $ENV{EMAIL_SENDER_TRANSPORT} = 'Test' }
+
+use 5.42.0;
+use warnings;
+use lib qw(lib t/lib);
+use experimental qw(defer);
+use Test::More import => [qw( done_testing is like ok subtest )];
+defer { done_testing };
+
+use Mojo::JSON     qw(encode_json);
+use Digest::SHA    qw(hmac_sha256_hex);
+use Mojo::Home;
+use YAML::XS qw(Load);
+use DateTime;
+
+use Test::Mojo;
+use Test::Registry::Mojo;
+use Test::Registry::DB;
+use Test::Registry::Helpers qw(
+    workflow_url
+    workflow_process_step_url
+    authenticate_as
+);
+
+use Registry::DAO;
+use Registry::DAO::Tenant;
+use Registry::DAO::User;
+use Registry::DAO::Family;
+use Registry::DAO::Payment;
+use Registry::DAO::Enrollment;
+use Registry::DAO::Workflow;
+use Registry::DAO::WorkflowRun;
+use Registry::DAO::Session;
+use Registry::DAO::PricingPlan;
+use Registry::DAO::Project;
+use Registry::DAO::Event;
+use Registry::DAO::Location;
+
+# ---------------------------------------------------------------------------
+# Stripe env: intercept at the service seam; never hit the network.
+# STRIPE_WEBHOOK_SECRET is mandatory for the signature-verification path.
+# ---------------------------------------------------------------------------
+local $ENV{STRIPE_SECRET_KEY}       = 'sk_test_dummy';
+local $ENV{STRIPE_PUBLISHABLE_KEY}  = 'pk_test_dummy';
+local $ENV{STRIPE_WEBHOOK_SECRET}   = 'whsec_test_journey';
+
+# ---------------------------------------------------------------------------
+# Database setup
+# ---------------------------------------------------------------------------
+my $test_db = Test::Registry::DB->new;
+my $dao     = $test_db->db;    # registry-schema DAO
+my $db      = $dao->db;
+$ENV{DB_URL} = $test_db->uri;
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+my $PLAN_AMOUNT = 150.00;
+
+# Import all non-draft workflows into the registry schema first.  Tenant
+# provisioning copies registry workflows via copy_workflow, so the registry
+# schema must have them before provision is called.
+{
+    my @files = Mojo::Home->new->child('workflows')->list_tree->grep(qr/\.ya?ml$/)->each;
+    for my $file (@files) {
+        my $yaml = $file->slurp;
+        next if Load($yaml)->{draft};
+        Registry::DAO::Workflow->from_yaml($dao, $yaml);
+    }
+}
+
+# Provision tenant -- NOT Stripe Connect ready yet.
+my $slug = 'ac_tenant_' . $$;
+
+my $admin = Registry::DAO::User->create($db, {
+    username  => "ac_admin_$$",
+    email     => "ac_admin_$$\@test.example",
+    name      => 'AC Admin',
+    user_type => 'admin',
+});
+
+my $tenant = Registry::DAO::Tenant->provision($db, {
+    name  => "AC Tenant $$",
+    slug  => $slug,
+    users => [ $admin ],
+});
+ok $tenant, 'tenant provisioned (not yet Stripe Connect ready)';
+ok !$tenant->stripe_connect_ready, 'precondition: tenant not Stripe Connect ready';
+
+# Tenant-schema DAO
+my $tenant_dao = Registry::DAO->new(url => $test_db->uri, schema => $slug);
+my $tenant_db  = $tenant_dao->db;
+
+# Verify that provision copied summer-camp-registration into the tenant schema.
+my ($reg_wf) = $tenant_dao->find(Workflow => { slug => 'summer-camp-registration' });
+ok $reg_wf, 'summer-camp-registration workflow present in tenant schema';
+
+# Build location / program / event / session / pricing fixtures.
+my $location = Registry::DAO::Location->create($tenant_db, {
+    name         => 'AC Studio',
+    address_info => { street_address => '1 AC Blvd', city => 'T', state => 'TX', postal_code => '78701' },
+    metadata     => {},
+});
+
+my $teacher = Registry::DAO::User->create($tenant_db, {
+    name      => 'AC Teacher',
+    username  => "ac_teacher_$$",
+    email     => "ac_teacher_$$\@test.com",
+    user_type => 'staff',
+});
+
+my $future_start = DateTime->now->add(days => 30)->ymd;
+my $future_end   = DateTime->now->add(days => 37)->ymd;
+
+my $project = Registry::DAO::Project->create($tenant_db, {
+    name              => 'AC Summer Camp',
+    slug              => "ac_camp_$$",
+    status            => 'published',
+    program_type_slug => 'summer-camp',
+    metadata          => {},
+});
+
+my $event = Registry::DAO::Event->create($tenant_db, {
+    time        => "$future_start 09:00:00",
+    duration    => 420,
+    location_id => $location->id,
+    project_id  => $project->id,
+    teacher_id  => $teacher->id,
+    capacity    => 20,
+    metadata    => {},
+});
+
+my $session = Registry::DAO::Session->create($tenant_db, {
+    name       => 'AC Week 1',
+    start_date => $future_start,
+    end_date   => $future_end,
+    status     => 'published',
+    capacity   => 20,
+    metadata   => {},
+});
+$session->add_events($tenant_db, $event->id);
+
+Registry::DAO::PricingPlan->create($tenant_db, {
+    session_id => $session->id,
+    plan_name  => 'Standard',
+    plan_type  => 'standard',
+    amount     => $PLAN_AMOUNT,
+});
+
+# ---------------------------------------------------------------------------
+# App setup: pin the app to the TENANT dao so all workflow HTTP requests are
+# resolved against the tenant schema.  The tenant helper still reads the Host
+# header to determine the slug; we send <slug>.localhost for workflow GETs/POSTs
+# so the controller sets __tenant_slug in the run data.
+# ---------------------------------------------------------------------------
+my $t = Test::Registry::Mojo->new('Registry');
+$t->app->helper(dao => sub { $tenant_dao });
+
+# Webhook calls use a raw Test::Mojo client that shares the same app instance
+# but bypasses Test::Registry::Mojo's CSRF-injection logic.
+# CSRF validation is already bypassed for /webhooks/ paths in the app
+# (before_dispatch hook: `return if $c->req->url->path =~ m{^/webhooks/}`),
+# but Test::Registry::Mojo appends `form => { csrf_token => ... }` to bare
+# POST calls that have no form body.  With a raw JSON body this would result
+# in 3+ args to build_tx with the JSON string as the generator key, crashing
+# Mojo::UserAgent::Transactor line 172.  Using the parent Test::Mojo directly
+# avoids that injection while sharing the same Mojolicious app/session.
+my $t_webhook = Test::Mojo->new($t->app);
+
+# ---------------------------------------------------------------------------
+# Helper: post a signed Stripe webhook event.
+# Signature format: "t=<epoch>,v1=<hmac_sha256_hex(epoch.payload, secret)>"
+# Timestamp must be within 300 s of now (verified in _verify_stripe_signature).
+# Each event id must be unique (registry.webhook_events dedup).
+# ---------------------------------------------------------------------------
+my sub post_signed_webhook ($tw, $event) {
+    my $payload = encode_json($event);
+    my $ts      = time();
+    my $sig     = hmac_sha256_hex("$ts.$payload", $ENV{STRIPE_WEBHOOK_SECRET});
+    return $tw->post_ok('/webhooks/stripe',
+        { 'stripe-signature' => "t=$ts,v1=$sig", 'Content-Type' => 'application/json' },
+        $payload);
+}
+
+# Host header for the tenant subdomain (drives __tenant_slug in new_run).
+my %tenant_host = ( Host => "$slug.localhost" );
+
+# ---------------------------------------------------------------------------
+# Walk helpers and cross-subtest state
+# ---------------------------------------------------------------------------
+
+# Reload the run fresh from the DB.
+my sub reload_run ($run) {
+    my ($fresh) = $tenant_dao->find(WorkflowRun => { id => $run->id });
+    return $fresh;
+}
+
+# File-scope state threaded through the four subtests.
+my ($journey_parent_id, $journey_child_id, $journey_run_id);
+
+# ---------------------------------------------------------------------------
+# Phase 1: Walk the registration workflow to the payment step, confirm gate.
+# ---------------------------------------------------------------------------
+subtest 'gated: unready tenant blocks paid enrollment' => sub {
+
+    # Start the workflow run: POST to /<slug> with the tenant host header.
+    $t->post_ok(workflow_url($reg_wf), \%tenant_host, form => {})->status_is(302);
+    my $run = $reg_wf->latest_run($tenant_db);
+    ok $run, 'workflow run created';
+
+    # account-check: create_account
+    my $step = $run->next_step($tenant_db);
+    is $step->slug, 'account-check', 'at account-check step';
+
+    $t->post_ok(
+        workflow_process_step_url($reg_wf, $run, $step),
+        \%tenant_host,
+        form => {
+            action   => 'create_account',
+            username => "ac_parent_$$",
+            email    => "ac_parent_$$\@example.com",
+            name     => 'AC Parent',
+        }
+    )->status_is(302);
+
+    my $parent = Registry::DAO::User->find($tenant_db, { username => "ac_parent_$$" });
+    ok $parent, 'parent account created in tenant schema';
+
+    # Simulate magic-link auth and continue
+    authenticate_as($t, $parent);
+    $run  = reload_run($run);
+    $step = $run->next_step($tenant_db);
+    is $step->slug, 'account-check', 'still at account-check (continue_logged_in)';
+
+    $t->post_ok(
+        workflow_process_step_url($reg_wf, $run, $step),
+        \%tenant_host,
+        form => { action => 'continue_logged_in' }
+    )->status_is(302);
+
+    # Add child via DAO (same pattern as tenant-onboarding e2e)
+    my $child = Registry::DAO::Family->add_child($tenant_db, $parent->id, {
+        child_name        => 'AC Child',
+        birth_date        => '2018-06-01',
+        grade             => '3',
+        medical_info      => {},
+        emergency_contact => { name => 'AC Emergency', phone => '512-555-0100' },
+    });
+    ok $child, 'child created';
+
+    # select-children
+    $run  = reload_run($run);
+    $step = $run->next_step($tenant_db);
+    is $step->slug, 'select-children', 'at select-children step';
+
+    $t->post_ok(
+        workflow_process_step_url($reg_wf, $run, $step),
+        \%tenant_host,
+        form => {
+            action               => 'continue',
+            "child_${\$child->id}" => 1,
+        }
+    )->status_is(302);
+
+    # camper-info
+    $run  = reload_run($run);
+    $step = $run->next_step($tenant_db);
+    is $step->slug, 'camper-info', 'at camper-info step';
+
+    $t->post_ok(
+        workflow_process_step_url($reg_wf, $run, $step),
+        \%tenant_host,
+        form => { childName => 'AC Child' }
+    )->status_is(302);
+
+    # session-selection
+    $run  = reload_run($run);
+    $step = $run->next_step($tenant_db);
+    is $step->slug, 'session-selection', 'at session-selection step';
+
+    $t->post_ok(
+        workflow_process_step_url($reg_wf, $run, $step),
+        \%tenant_host,
+        form => {
+            action                      => 'select_sessions',
+            "session_for_${\$child->id}" => $session->id,
+        }
+    )->status_is(302);
+
+    # payment step -- gate should fire
+    $run  = reload_run($run);
+    $step = $run->next_step($tenant_db);
+    is $step->slug, 'payment', 'at payment step';
+
+    # The gate fires: stays on the payment step (redirect back to same URL)
+    # or returns a 200 with errors rendered inline.  Either way, check that
+    # the run stays on the payment step and no payment row was created.
+    $t->post_ok(
+        workflow_process_step_url($reg_wf, $run, $step),
+        \%tenant_host,
+        form => { agreeTerms => 1 }
+    );
+
+    my $response_code = $t->tx->res->code;
+    ok $response_code == 302 || $response_code == 200,
+        "gate response is redirect or inline error ($response_code)";
+
+    # If 302, follow to confirm it stays on the payment step
+    if ($response_code == 302) {
+        my $loc = $t->tx->res->headers->location;
+        like $loc, qr/payment/, 'redirect stays on payment step URL';
+
+        $t->get_ok($loc, \%tenant_host)->status_is(200)
+          ->content_like(qr/not yet available/i, 'gate error visible in payment page');
+    } else {
+        $t->content_like(qr/not yet available/i, 'gate error visible in inline response');
+    }
+
+    # Reload run: must still be on payment step
+    $run = reload_run($run);
+    $step = $run->next_step($tenant_db);
+    is $step->slug, 'payment', 'run stays on payment step after gate fires';
+
+    # Zero payment rows in tenant schema
+    my $tenant_pay_count = $tenant_db->select(
+        'payments', ['id'], { user_id => $parent->id })->hashes->size;
+    is $tenant_pay_count, 0, 'no payment row created in tenant schema when gate fires';
+
+    # Zero payment rows in registry schema (qualified table)
+    my $registry_pay_count = $db->select(
+        'registry.payments', ['id'], { user_id => $parent->id })->hashes->size;
+    is $registry_pay_count, 0, 'no payment row in registry schema when gate fires';
+
+    # Thread state to later phases via file-scope variables.
+    $journey_parent_id = $parent->id;
+    $journey_child_id  = $child->id;
+    $journey_run_id    = $run->id;
+};
+
+# ---------------------------------------------------------------------------
+# Phase 2: Activate -- record the account then fire the signed webhook.
+# ---------------------------------------------------------------------------
+subtest 'activate: account row + signed account.updated webhook' => sub {
+    # (a) Record the Stripe connected account id; booleans stay false.
+    # The runbook step: platform owner pastes the account id into the tenant row.
+    # Readiness is supplied by Stripe's account.updated webhook, not by us.
+    $db->query(
+        q{UPDATE registry.tenants
+          SET stripe_connect_account_id = 'acct_journey'
+          WHERE slug = ?},
+        $slug,
+    );
+
+    # Reload and confirm not yet ready (booleans still false)
+    my $row = $db->query('SELECT * FROM registry.tenants WHERE slug = ?', $slug)->hash;
+    my $pre = Registry::DAO::Tenant->new(%$row);
+    ok !$pre->stripe_connect_ready,
+        'tenant not ready after account id recorded (booleans still false)';
+
+    # (b) Deliver signed account.updated over HTTP.
+    # The webhook controller uses $self->app->dao (pinned to $tenant_dao).
+    # _process_account_updated does: $dao->db->query('UPDATE registry.tenants ...')
+    # $tenant_dao->db has search_path = $slug, public -- but registry.tenants is
+    # qualified, so the update reaches the right table.  We verify empirically below.
+    my $acct_event_id = 'evt_journey_acct_' . $$;
+    post_signed_webhook($t_webhook, {
+        id   => $acct_event_id,
+        type => 'account.updated',
+        data => { object => {
+            id                => 'acct_journey',
+            charges_enabled   => \1,
+            details_submitted => \1,
+        } },
+    })->status_is(200, 'account.updated webhook accepted');
+
+    # Verify webhook-DAO context note (spec, step 3):
+    # The webhook controller calls $self->app->dao (pinned to $tenant_dao).
+    # _process_account_updated executes:
+    #   $dao->db->query('UPDATE registry.tenants ... WHERE stripe_connect_account_id = ?', ...)
+    # $dao->db is a Mojo::Pg::Database whose search_path = [$slug, 'public'].
+    # The table is schema-qualified (registry.tenants), so the search_path is irrelevant;
+    # the UPDATE reaches the correct platform table regardless of the pinned dao.
+    # Confirmed: the assertion below shows the flags were set.
+
+    # Assert flags were set
+    my $row_after = $db->query('SELECT * FROM registry.tenants WHERE slug = ?', $slug)->hash;
+    my $after_tenant = Registry::DAO::Tenant->new(%$row_after);
+    ok $after_tenant->stripe_connect_ready,
+        'tenant is stripe_connect_ready after account.updated webhook';
+};
+
+# ---------------------------------------------------------------------------
+# Phase 3: Collect -- intercept Stripe, retry payment step, verify params.
+# ---------------------------------------------------------------------------
+my $captured_params;
+
+subtest 'collect: payment step passes, correct Stripe Connect params captured' => sub {
+    my ($run)  = $tenant_dao->find(WorkflowRun => { id => $journey_run_id });
+    my $step   = $run->next_step($tenant_db);
+    is $step->slug, 'payment', 'run is still on payment step (gate refusal did not advance it)';
+
+    # Intercept create_payment_intent; capture params and return a fixture intent.
+    {
+        no warnings 'redefine';
+        local *Registry::Service::Stripe::create_payment_intent = sub {
+            my ($self_stripe, $params) = @_;
+            $captured_params = $params;
+            return { id => 'pi_journey', client_secret => 'cs_journey' };
+        };
+
+        # When payment intent is created, the step stays on the payment page
+        # (status 200) to render the Stripe card-entry form with the
+        # client_secret.  A redirect (302) only comes from handle_payment_callback
+        # after the card is submitted with payment_intent_id.  We assert 200 here
+        # and verify the intent was created via the captured params below.
+        $t->post_ok(
+            workflow_process_step_url($reg_wf, $run, $step),
+            \%tenant_host,
+            form => { agreeTerms => 1 }
+        )->status_is(200, 'payment step renders Stripe form after passing gate');
+    }
+
+    ok $captured_params, 'Stripe create_payment_intent was called and params captured';
+
+    # Connect routing params
+    is $captured_params->{'transfer_data[destination]'}, 'acct_journey',
+        'transfer_data[destination] is the connected account id';
+    is $captured_params->{'on_behalf_of'}, 'acct_journey',
+        'on_behalf_of is the connected account id';
+
+    # Application fee: 2.5% of $150 = $3.75 = 375 cents
+    my $expected_fee = Registry::DAO::Payment::application_fee_cents(
+        Registry::DAO::Payment::_to_cents($PLAN_AMOUNT));
+    is $expected_fee, 375, 'sanity: expected fee is 375 cents (2.5% of $150)';
+    is $captured_params->{'application_fee_amount'}, $expected_fee,
+        'application_fee_amount matches platform 2.5% fee';
+
+    # Bracket-notation metadata keys for webhook routing
+    ok exists $captured_params->{'metadata[payment_id]'},
+        'metadata[payment_id] bracket key present';
+    ok exists $captured_params->{'metadata[tenant_slug]'},
+        'metadata[tenant_slug] bracket key present';
+    is $captured_params->{'metadata[tenant_slug]'}, $slug,
+        'metadata[tenant_slug] value matches tenant slug';
+
+    # Payment row must exist in tenant schema only
+    my $tenant_pays = $tenant_db->select(
+        'payments', ['id'], { user_id => $journey_parent_id })->hashes;
+    is scalar @$tenant_pays, 1, 'exactly one payment row in the tenant schema';
+
+    my $reg_pays = $db->select(
+        'registry.payments', ['id'], { user_id => $journey_parent_id })->hashes;
+    is scalar @$reg_pays, 0, 'no payment row in registry schema';
+};
+
+# ---------------------------------------------------------------------------
+# Phase 4: Complete -- deliver signed payment_intent.succeeded, assert enrollment.
+# ---------------------------------------------------------------------------
+subtest 'complete: payment_intent.succeeded webhook finalizes payment and enrollment' => sub {
+    ok $captured_params, 'captured Stripe params available for phase 4';
+
+    # Synthesize the webhook from captured bracket-notation params.
+    # This mirrors what Stripe echoes back: our bracket keys become nested
+    # metadata on the intent object.
+    my $payment_id  = $captured_params->{'metadata[payment_id]'};
+    my $tenant_slug = $captured_params->{'metadata[tenant_slug]'};
+    my $pi_id       = 'pi_journey';
+
+    ok $payment_id,  'payment_id extracted from captured Stripe bracket params';
+    ok $tenant_slug, 'tenant_slug extracted from captured Stripe bracket params';
+
+    # Unique event id (dedup guard)
+    my $pi_event_id = 'evt_journey_pi_' . $$ . '_1';
+    post_signed_webhook($t_webhook, {
+        id   => $pi_event_id,
+        type => 'payment_intent.succeeded',
+        data => { object => {
+            id       => $pi_id,
+            metadata => {
+                payment_id  => $payment_id,
+                tenant_slug => $tenant_slug,
+            },
+        } },
+    })->status_is(200, 'payment_intent.succeeded webhook accepted');
+
+    # Payment must be completed in tenant schema
+    my $payment = Registry::DAO::Payment->find($tenant_db, { id => $payment_id });
+    ok $payment, 'payment found in tenant schema';
+    is $payment->status, 'completed', 'payment status is completed';
+
+    # Enrollment must exist in tenant schema
+    my $enrollments = $tenant_db->select(
+        'enrollments', '*', { payment_id => $payment_id })->hashes;
+    is scalar @$enrollments, 1, 'exactly one enrollment created in tenant schema';
+    is $enrollments->[0]{status}, 'active', 'enrollment status is active';
+
+    # Neither completed payment nor enrollment in registry schema
+    my $reg_enr = $db->select(
+        'registry.enrollments', ['id'], { payment_id => $payment_id })->hash;
+    ok !$reg_enr, 'enrollment NOT created in registry schema';
+
+    my $reg_pay = $db->select(
+        'registry.payments', ['id'], { id => $payment_id })->hash;
+    ok !$reg_pay, 'payment NOT present in registry schema';
+};
+
+$test_db->cleanup_test_database;

--- a/t/user-journeys/alex/02-activate-and-collect.t
+++ b/t/user-journeys/alex/02-activate-and-collect.t
@@ -298,8 +298,10 @@ subtest 'gated: unready tenant blocks paid enrollment' => sub {
     is $step->slug, 'payment', 'at payment step';
 
     # The gate fires: stays on the payment step (redirect back to same URL)
-    # or returns a 200 with errors rendered inline.  Either way, check that
-    # the run stays on the payment step and no payment row was created.
+    # or returns a 200 with errors rendered inline.  Both modes are accepted
+    # deliberately -- the controller's error rendering varies with request
+    # type, and the load-bearing invariants are the ones asserted below:
+    # the run stays on the payment step and no payment row exists anywhere.
     $t->post_ok(
         workflow_process_step_url($reg_wf, $run, $step),
         \%tenant_host,
@@ -377,15 +379,6 @@ subtest 'activate: account row + signed account.updated webhook' => sub {
             details_submitted => \1,
         } },
     })->status_is(200, 'account.updated webhook accepted');
-
-    # Verify webhook-DAO context note (spec, step 3):
-    # The webhook controller calls $self->app->dao (pinned to $tenant_dao).
-    # _process_account_updated executes:
-    #   $dao->db->query('UPDATE registry.tenants ... WHERE stripe_connect_account_id = ?', ...)
-    # $dao->db is a Mojo::Pg::Database whose search_path = [$slug, 'public'].
-    # The table is schema-qualified (registry.tenants), so the search_path is irrelevant;
-    # the UPDATE reaches the correct platform table regardless of the pinned dao.
-    # Confirmed: the assertion below shows the flags were set.
 
     # Assert flags were set
     my $row_after = $db->query('SELECT * FROM registry.tenants WHERE slug = ?', $slug)->hash;

--- a/t/user-journeys/alex/03-platform-billing.t
+++ b/t/user-journeys/alex/03-platform-billing.t
@@ -107,7 +107,7 @@ $t->app->helper(dao => sub { $dao });
 # ---------------------------------------------------------------------------
 # Walk the tenant-signup funnel with minimal data.
 #
-# Friction inventory (inputs to the per-field discussion in issue TBD):
+# Friction inventory (inputs to the per-field discussion in issue #270):
 #   landing     — no fields required; POST with empty body advances.
 #   profile     — 'name' consumed downstream by _provision_tenant (falls back
 #                 to 'Organization' without it); 'description' and

--- a/t/user-journeys/alex/03-platform-billing.t
+++ b/t/user-journeys/alex/03-platform-billing.t
@@ -15,6 +15,7 @@ defer { done_testing };
 
 use Test::Registry::Mojo;
 use Test::Registry::DB;
+use Test::Registry::Helpers qw(seed_platform_pricing_relationship);
 
 use Registry::DAO;
 use Registry::DAO::Workflow;
@@ -45,56 +46,9 @@ $dao->import_workflows(['workflows/tenant-signup.yml']);
 my ($signup_wf) = $dao->find(Workflow => { slug => 'tenant-signup' });
 ok $signup_wf, 'tenant-signup workflow present in registry schema';
 
-# ---------------------------------------------------------------------------
-# Fixture: seed the platform pricing relationship.
-#
-# Fresh test databases have ZERO pricing relationships (issue #268):
-# sql/deploy/create-default-pricing-relationships.sql is orphaned from
-# sqitch.plan, so PricingPlanSelection::prepare_pricing_data finds no plans,
-# renders no radio buttons, and silently skips the pricing step without any
-# visible error.  Without seeding here, the leg would walk right past pricing
-# without ever selecting a plan, leaving the assertions in this file vacuous.
-#
-# The INSERT mirrors the orphaned migration (sql/deploy/create-default-
-# pricing-relationships.sql:63-80) with one difference: consumer_id uses the
-# 'system' user that ships in the test dump instead of a dynamically-created
-# platform_admin.  The listing query in PricingPlanSelection never filters on
-# consumer_id, so any valid user id satisfies the NOT NULL FK constraint.
-# ---------------------------------------------------------------------------
-my $plan_row = $db->query(q{
-    SELECT id FROM registry.pricing_plans
-    WHERE pricing_model_type = 'percentage' AND plan_scope = 'tenant' LIMIT 1
-})->hash;
-ok $plan_row, 'seeded 2% revenue-share plan found in registry.pricing_plans'
-    or BAIL_OUT('No tenant-scoped percentage plan in DB -- cannot walk pricing step');
-
-my $plan_id = $plan_row->{id};
-
-# consumer_id is a NOT NULL FK to registry.users(id); the test dump ships a
-# 'system' user whose id satisfies the constraint.  The pricing query never
-# filters on consumer_id, so no behavioural difference.
-my $system_user_row = $db->query(
-    q{SELECT id FROM registry.users WHERE username = 'system' LIMIT 1}
-)->hash;
-ok $system_user_row, 'system user exists in test dump'
-    or BAIL_OUT('system user missing -- cannot satisfy consumer_id FK');
-
-my $system_user_id = $system_user_row->{id};
-
-$db->query(q{
-    INSERT INTO registry.pricing_relationships
-        (provider_id, consumer_id, pricing_plan_id, status, metadata)
-    VALUES ('00000000-0000-0000-0000-000000000000', ?, ?, 'active',
-            '{"plan_type":"tenant_subscription","created_by":"test_fixture"}'::jsonb)
-}, $system_user_id, $plan_id);
-
-# Verify the seed landed so a misconfigured DB fails loudly here, not later.
-my $rel_count = $db->query(q{
-    SELECT count(*) AS n FROM registry.pricing_relationships
-    WHERE provider_id = '00000000-0000-0000-0000-000000000000'
-      AND pricing_plan_id = ?
-}, $plan_id)->hash->{n};
-is $rel_count, 1, 'exactly one platform pricing relationship seeded';
+# Fixture: seed the platform pricing relationship -- see #268 for full rationale.
+my $plan_id = seed_platform_pricing_relationship($dao)
+    or BAIL_OUT('seed_platform_pricing_relationship failed -- cannot walk pricing step');
 
 # ---------------------------------------------------------------------------
 # App setup: pin the app dao to the registry-context DAO so the workflow

--- a/t/user-journeys/alex/03-platform-billing.t
+++ b/t/user-journeys/alex/03-platform-billing.t
@@ -9,7 +9,7 @@ use utf8;
 use warnings;
 use lib qw(lib t/lib);
 use experimental qw(defer);
-use Test::More import => [qw( done_testing diag is like ok subtest )];
+use Test::More import => [qw( done_testing diag is like ok subtest BAIL_OUT )];
 our $TODO;
 defer { done_testing };
 

--- a/t/user-journeys/alex/03-platform-billing.t
+++ b/t/user-journeys/alex/03-platform-billing.t
@@ -1,0 +1,349 @@
+#!/usr/bin/env perl
+# ABOUTME: Alex (platform owner) journey: Registry bills the tenant for the
+# ABOUTME: platform subscription established during signup.
+
+BEGIN { $ENV{EMAIL_SENDER_TRANSPORT} = 'Test' }
+
+use 5.42.0;
+use utf8;
+use warnings;
+use lib qw(lib t/lib);
+use experimental qw(defer);
+use Test::More import => [qw( done_testing diag is like ok subtest )];
+our $TODO;
+defer { done_testing };
+
+use Test::Registry::Mojo;
+use Test::Registry::DB;
+
+use Registry::DAO;
+use Registry::DAO::Workflow;
+use Registry::DAO::WorkflowRun;
+use Registry::DAO::Payment ();
+
+# ---------------------------------------------------------------------------
+# Non-goal: recurring usage-based billing.
+# The _get_usage_data branch is deliberately non-functional pending redesign
+# (issue #263).  This leg asserts that the subscription is *established* at
+# signup time, not that monthly invoices flow afterwards.
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Database setup
+# ---------------------------------------------------------------------------
+my $test_db = Test::Registry::DB->new;
+my $dao     = $test_db->db;    # registry-schema DAO
+my $db      = $dao->db;
+$ENV{DB_URL} = $test_db->uri;
+
+# ---------------------------------------------------------------------------
+# Import the tenant-signup workflow into the registry schema.
+# The app's dao helper is pinned below to use this same schema connection.
+# ---------------------------------------------------------------------------
+$dao->import_workflows(['workflows/tenant-signup.yml']);
+
+my ($signup_wf) = $dao->find(Workflow => { slug => 'tenant-signup' });
+ok $signup_wf, 'tenant-signup workflow present in registry schema';
+
+# ---------------------------------------------------------------------------
+# Fixture: seed the platform pricing relationship.
+#
+# Fresh test databases have ZERO pricing relationships (issue #268):
+# sql/deploy/create-default-pricing-relationships.sql is orphaned from
+# sqitch.plan, so PricingPlanSelection::prepare_pricing_data finds no plans,
+# renders no radio buttons, and silently skips the pricing step without any
+# visible error.  Without seeding here, the leg would walk right past pricing
+# without ever selecting a plan, leaving the assertions in this file vacuous.
+#
+# The INSERT mirrors the orphaned migration (sql/deploy/create-default-
+# pricing-relationships.sql:63-80) with one difference: consumer_id uses the
+# 'system' user that ships in the test dump instead of a dynamically-created
+# platform_admin.  The listing query in PricingPlanSelection never filters on
+# consumer_id, so any valid user id satisfies the NOT NULL FK constraint.
+# ---------------------------------------------------------------------------
+my $plan_row = $db->query(q{
+    SELECT id FROM registry.pricing_plans
+    WHERE pricing_model_type = 'percentage' AND plan_scope = 'tenant' LIMIT 1
+})->hash;
+ok $plan_row, 'seeded 2% revenue-share plan found in registry.pricing_plans'
+    or BAIL_OUT('No tenant-scoped percentage plan in DB -- cannot walk pricing step');
+
+my $plan_id = $plan_row->{id};
+
+# consumer_id is a NOT NULL FK to registry.users(id); the test dump ships a
+# 'system' user whose id satisfies the constraint.  The pricing query never
+# filters on consumer_id, so no behavioural difference.
+my $system_user_row = $db->query(
+    q{SELECT id FROM registry.users WHERE username = 'system' LIMIT 1}
+)->hash;
+ok $system_user_row, 'system user exists in test dump'
+    or BAIL_OUT('system user missing -- cannot satisfy consumer_id FK');
+
+my $system_user_id = $system_user_row->{id};
+
+$db->query(q{
+    INSERT INTO registry.pricing_relationships
+        (provider_id, consumer_id, pricing_plan_id, status, metadata)
+    VALUES ('00000000-0000-0000-0000-000000000000', ?, ?, 'active',
+            '{"plan_type":"tenant_subscription","created_by":"test_fixture"}'::jsonb)
+}, $system_user_id, $plan_id);
+
+# Verify the seed landed so a misconfigured DB fails loudly here, not later.
+my $rel_count = $db->query(q{
+    SELECT count(*) AS n FROM registry.pricing_relationships
+    WHERE provider_id = '00000000-0000-0000-0000-000000000000'
+      AND pricing_plan_id = ?
+}, $plan_id)->hash->{n};
+is $rel_count, 1, 'exactly one platform pricing relationship seeded';
+
+# ---------------------------------------------------------------------------
+# App setup: pin the app dao to the registry-context DAO so the workflow
+# controller resolves the tenant-signup workflow correctly.  (Matches the
+# data-flow test's $t->app->helper(dao => sub { $db }) pattern.)
+# ---------------------------------------------------------------------------
+my $t = Test::Registry::Mojo->new('Registry');
+$t->app->helper(dao => sub { $dao });
+
+# ---------------------------------------------------------------------------
+# Walk the tenant-signup funnel with minimal data.
+#
+# Friction inventory (inputs to the per-field discussion in issue TBD):
+#   landing     — no fields required; POST with empty body advances.
+#   profile     — 'name' consumed downstream by _provision_tenant (falls back
+#                 to 'Organization' without it); 'description' and
+#                 'billing_email' are accepted empty without error.
+#   users       — 'admin_name', 'admin_email', 'admin_username' accepted empty
+#                 by the step's process() (WorkflowStep base class stores
+#                 whatever it receives); 'admin_user_type' must be 'admin' to
+#                 avoid the invite-pending warning path in _provision_tenant.
+#   pricing     — 'selected_plan_id' required (must be a valid UUID for an
+#                 active platform relationship; empty or absent silently skips).
+#   review      — 'terms_accepted' required by the controller (Workflows.pm:337-
+#                 358) BEFORE calling step->process; the step itself accepts
+#                 empty body but the controller gate refuses without it.
+#   payment     — 'collect_payment_method' + 'setup_intent_id' (seti_test…)
+#                 trigger the test-mode provision path.
+# ---------------------------------------------------------------------------
+
+# -- Step: land (starts the run) -------------------------------------------
+$t->post_ok('/tenant-signup')->status_is(302);
+my $profile_url = $t->tx->res->headers->location;
+like $profile_url, qr{/tenant-signup/[^/]+/profile}, 'redirected to profile step';
+
+# GET before POST (session/CSRF).
+$t->get_ok($profile_url)->status_is(200);
+
+# -- Step: profile ---------------------------------------------------------
+# 'name' is the only field _provision_tenant reads from this step (via
+# $data->{name}).  'description' and 'billing_email' are accepted but not
+# consumed by any downstream step.
+$t->post_ok($profile_url => form => {
+    name          => 'Billing Journey Org ' . $$,
+    description   => '',          # accepted empty
+    billing_email => '',          # accepted empty
+})->status_is(302);
+
+my $users_url = $t->tx->res->headers->location;
+like $users_url, qr{/tenant-signup/[^/]+/users}, 'redirected to users step';
+
+# GET before POST.
+$t->get_ok($users_url)->status_is(200);
+
+# -- Step: users -----------------------------------------------------------
+# admin_user_type => 'admin' avoids the invite-pending warn() in
+# _provision_tenant; admin_name/email/username accepted empty by the step.
+$t->post_ok($users_url => form => {
+    admin_name      => 'BJ Admin ' . $$,
+    admin_email     => "bj_admin_$$\@test.example",
+    admin_username  => "bj_admin_$$",
+    admin_user_type => 'admin',
+})->status_is(302);
+
+my $pricing_url = $t->tx->res->headers->location;
+like $pricing_url, qr{/tenant-signup/[^/]+/pricing}, 'redirected to pricing step';
+
+# -- Step: pricing (GET) -- assert the seeded plan renders ----------------
+# This GET doubles as the #268 guard: if the seeded relationship is absent,
+# prepare_pricing_data returns an empty list and the template renders no
+# radio buttons, and this assertion catches that silently-broken path.
+my $pricing_page = $t->get_ok($pricing_url)->status_is(200)->tx->res->body;
+
+like $pricing_page, qr/selected_plan_id/,
+    'pricing page renders at least one plan radio (seeded relationship visible, #268 guard)';
+like $pricing_page, qr/Registry Revenue Share/,
+    'pricing page shows the seeded 2% revenue-share plan name';
+
+# -- Capture the displayed rate for the TODO drift assertion below ---------
+# The plan description contains "2% of all customer payments"; the plan name
+# contains "2%".  Extract the rate as a number for numeric comparison.
+# (If the field ever gains a revenue_share_percent key, this pattern still
+# works because the surrounding text will still mention the rate.)
+my ($displayed_rate_str) = $pricing_page =~ /(\d+(?:\.\d+)?)\s*%\s*of\s+(?:all\s+)?customer\s+payments/i;
+$displayed_rate_str //= do {
+    # Fallback: extract the rate from the plan name "Revenue Share - N%"
+    ($pricing_page =~ /Revenue Share[^%]*?(\d+(?:\.\d+)?)\s*%/i)[0];
+};
+
+# -- Step: pricing (POST) -- select the seeded plan ----------------------
+$t->post_ok($pricing_url => form => {
+    selected_plan_id => $plan_id,
+})->status_is(302);
+
+my $review_url = $t->tx->res->headers->location;
+like $review_url, qr{/tenant-signup/[^/]+/review}, 'redirected to review step';
+
+# -- Step: review ---------------------------------------------------------
+# The controller (Workflows.pm:337-358) validates terms_accepted and checks
+# for accumulated admin_name/admin_email/name in run data before advancing.
+# terms_accepted is the only field the user must explicitly submit here;
+# all other required data must have been collected in earlier steps.
+$t->get_ok($review_url)->status_is(200);
+$t->post_ok($review_url => form => {
+    terms_accepted => 1,    # required by controller review-step validation
+})->status_is(302);
+
+my $payment_url = $t->tx->res->headers->location;
+like $payment_url, qr{/tenant-signup/[^/]+/payment}, 'redirected to payment step';
+
+# -- Step: payment (GET) --------------------------------------------------
+$t->get_ok($payment_url)->status_is(200);
+
+# -- Step: payment (POST via seti_test seam) ------------------------------
+# POST collect_payment_method=1 + setup_intent_id=seti_test_… dispatches to
+# handle_setup_completion -> _provision_tenant (TenantPayment.pm:43-46, 283-
+# 294).  The seti_test branch wins on dispatch order before the no-keys
+# branch, so Stripe env keys are irrelevant to this POST.
+$t->post_ok($payment_url => form => {
+    collect_payment_method => 1,
+    setup_intent_id        => 'seti_test_billing_' . $$,
+})->status_is(302);
+
+my $complete_url = $t->tx->res->headers->location;
+like $complete_url, qr{/tenant-signup/[^/]+/complete}, 'redirected to complete step';
+
+# -- Step: complete -------------------------------------------------------
+$t->get_ok($complete_url)->status_is(200);
+
+# ---------------------------------------------------------------------------
+# Retrieve the workflow run and its accumulated data for assertion.
+# ---------------------------------------------------------------------------
+my $run = $signup_wf->latest_run($db);
+ok $run, 'workflow run exists after funnel walk';
+
+my $run_data = $run->data;
+
+# ---------------------------------------------------------------------------
+# Assertion 1a: the run carries selected_pricing_plan
+# ---------------------------------------------------------------------------
+subtest 'run data carries selected_pricing_plan' => sub {
+    my $sel = $run_data->{selected_pricing_plan};
+    ok $sel, 'selected_pricing_plan key present in workflow run data';
+    is $sel->{id}, $plan_id,
+        'selected_pricing_plan.id matches the plan we posted';
+};
+
+# ---------------------------------------------------------------------------
+# Assertion 1b: the provisioned tenant row carries billing fields
+# ---------------------------------------------------------------------------
+subtest 'provisioned tenant row carries billing fields' => sub {
+    # _provision_tenant writes the tenant slug into run_data as 'subdomain'.
+    my $slug = $run_data->{subdomain};
+    ok $slug, "provisioned tenant slug present in run data ($slug)";
+
+    my $tenant_row = $db->query(
+        q{SELECT stripe_subscription_id, billing_status, trial_ends_at
+          FROM registry.tenants WHERE slug = ?},
+        $slug
+    )->hash;
+    ok $tenant_row, 'provisioned tenant row found in registry.tenants';
+
+    like $tenant_row->{stripe_subscription_id}, qr/^sub_test_/,
+        'stripe_subscription_id starts with sub_test_ (seti_test provision path)';
+    is $tenant_row->{billing_status}, 'trial',
+        'billing_status is "trial" on the seti_test path';
+    ok defined($tenant_row->{trial_ends_at}),
+        'trial_ends_at is set (not NULL)';
+};
+
+# ---------------------------------------------------------------------------
+# Assertion 2: no tenant<->plan pricing_relationship exists post-signup.
+#
+# PricingPlanSelection only stashes the selected plan in run data; it does not
+# INSERT a registry.pricing_relationships row linking the new tenant as
+# provider or consumer.  _provision_tenant writes billing fields onto the
+# tenant row but also does not create a pricing_relationship.
+#
+# This absence is a tracked dependency of issue #267 (plan-driven revenue
+# share): when #267 lands, the revenue-share rate will be read from the
+# tenant's pricing plan rather than the REVENUE_SHARE_PERCENT constant, which
+# requires persisting the tenant<->plan link.  At that point this assertion
+# should be strengthened to assert the persisted link exists.  Until then,
+# the assertion documents current reality so any accidental addition of such
+# a row will cause a visible test failure and prompt a deliberate review.
+# ---------------------------------------------------------------------------
+subtest '#267 dependency: no tenant<->plan pricing_relationship post-signup' => sub {
+    my $slug = $run_data->{subdomain};
+    ok $slug, "tenant slug available ($slug)";
+
+    # Look up the provisioned tenant's id.
+    my $tenant_row = $db->query(
+        q{SELECT id FROM registry.tenants WHERE slug = ?}, $slug
+    )->hash;
+    ok $tenant_row, 'provisioned tenant row found';
+
+    my $tenant_id = $tenant_row->{id};
+
+    # Assert zero pricing_relationships rows where the new tenant is either
+    # provider or consumer -- those are the two roles a tenant could occupy in
+    # a platform-billing relationship.  The only relationship in the table
+    # should be the fixture we inserted above (provider = platform UUID).
+    my $as_provider = $db->query(q{
+        SELECT count(*) AS n FROM registry.pricing_relationships
+        WHERE provider_id = ?
+    }, $tenant_id)->hash->{n};
+
+    my $as_consumer = $db->query(q{
+        SELECT count(*) AS n FROM registry.pricing_relationships
+        WHERE consumer_id = ?
+    }, $tenant_id)->hash->{n};
+
+    is $as_provider + 0, 0,
+        'no pricing_relationships row with the new tenant as provider (#267 dependency)';
+    is $as_consumer + 0, 0,
+        'no pricing_relationships row with the new tenant as consumer (#267 dependency)';
+};
+
+# ---------------------------------------------------------------------------
+# Assertion 3 (TODO #267): rate-consistency drift detection.
+#
+# The plan displayed on the pricing page advertises 2% (from the plan name
+# "Registry Revenue Share - 2%" and description "2% of all customer payments"),
+# but Registry::DAO::Payment::REVENUE_SHARE_PERCENT is 2.5 -- the constant
+# used to compute application_fee_amount at charge time.  This is a real,
+# pre-existing drift between what the tenant is shown and what the platform
+# actually collects, captured in issue #267.
+#
+# This TODO comes off when #267 ships: the revenue-share rate will be read from
+# the tenant's selected pricing plan, making the displayed rate and the charged
+# rate identical.
+# ---------------------------------------------------------------------------
+subtest 'rate-consistency: displayed rate equals platform constant' => sub {
+    my $constant_rate = Registry::DAO::Payment::REVENUE_SHARE_PERCENT;
+
+    ok defined($displayed_rate_str),
+        'extracted a numeric rate from the pricing page HTML';
+
+    my $displayed_rate = defined($displayed_rate_str) ? ($displayed_rate_str + 0) : undef;
+
+    # Both values printed as diagnostics so the drift is visible in prove -v output.
+    diag "displayed_rate (from pricing page HTML): ${\( $displayed_rate // 'undef' )}%";
+    diag "platform REVENUE_SHARE_PERCENT (constant): ${constant_rate}%";
+
+    TODO: {
+        local $TODO = 'rate is constant-driven until #267 ships; seeded plan advertises 2% but constant is 2.5%';
+        is $displayed_rate, $constant_rate,
+            'displayed plan rate matches REVENUE_SHARE_PERCENT (will pass once #267 makes rate plan-driven)';
+    }
+};
+
+$test_db->cleanup_test_database;

--- a/t/user-journeys/alex/04-platform-health.t
+++ b/t/user-journeys/alex/04-platform-health.t
@@ -1,0 +1,320 @@
+#!/usr/bin/env perl
+# ABOUTME: Alex (platform owner) journey: the automation runs without him.
+# ABOUTME: Tenant-aware sweeps process every tenant, isolate bad rows, and /health probes the DB.
+use 5.42.0;
+
+BEGIN { $ENV{EMAIL_SENDER_TRANSPORT} = 'Test' }
+
+use lib qw(lib t/lib);
+use experimental qw(defer);
+use Test::More import => [qw( done_testing is like ok subtest )];
+defer { done_testing };
+
+use Test::Registry::Mojo;
+use Test::Registry::DB;
+use Test::Registry::Fixtures;
+use Registry::DAO;
+use Registry::DAO::Tenant;
+use Registry::DAO::Waitlist;
+use Registry::DAO::Location;
+use Registry::DAO::Session;
+use Registry::DAO::Enrollment;
+use Registry::Job::ProcessWaitlist;
+use Registry::Job::WaitlistExpiration;
+
+# ---- database setup --------------------------------------------------------
+
+my $test_db = Test::Registry::DB->new;
+my $dao     = $test_db->db;    # registry-schema DAO
+$ENV{DB_URL} = $test_db->uri;
+
+# ---- fixture: Tenant A - has sweepable state for both sweeps ---------------
+#
+# WaitlistExpiration material: an 'offered' entry with expires_at in the past.
+# ProcessWaitlist material: a recently-cancelled enrollment + a 'waiting' entry.
+
+my $parent_a = Test::Registry::Fixtures::create_user( $dao, {
+    username  => 'ph_parent_a_' . $$,
+    password  => 'pw',
+    user_type => 'parent',
+});
+
+my $student_a = Test::Registry::Fixtures::create_user( $dao, {
+    username  => 'ph_student_a_' . $$,
+    password  => 'pw',
+    user_type => 'student',
+});
+
+# Second student for the 'waiting' waitlist entry (session/student unique constraint).
+my $student_a2 = Test::Registry::Fixtures::create_user( $dao, {
+    username  => 'ph_student_a2_' . $$,
+    password  => 'pw',
+    user_type => 'student',
+});
+
+my $tenant_a = Registry::DAO::Tenant->provision( $dao->db, {
+    name  => 'PlatformHealthTenantA_' . $$,
+    slug  => 'ph_tenant_a_' . $$,
+    users => [ $parent_a ],
+});
+
+my $slug_a  = $tenant_a->slug;
+my $dao_a   = $dao->connect_schema($slug_a);
+my $db_a    = $dao_a->db;
+
+# Copy students into the tenant schema so FK constraints are satisfied.
+$dao->db->query('SELECT copy_user(dest_schema => ?, user_id => ?)', $slug_a, $student_a->id);
+$dao->db->query('SELECT copy_user(dest_schema => ?, user_id => ?)', $slug_a, $student_a2->id);
+
+my $location_a = Registry::DAO::Location->create( $db_a, {
+    name         => 'PH Test Location A',
+    slug         => 'ph-loc-a-' . $$,
+    address_info => { street => '1 Test St' },
+});
+
+my $session_a = Registry::DAO::Session->create( $db_a, {
+    name => 'PH Test Session A',
+    slug => 'ph-session-a-' . $$,
+});
+
+# WaitlistExpiration material: offered entry with expires_at in the past.
+$db_a->query(q{
+    INSERT INTO waitlist
+        (session_id, location_id, student_id, parent_id, position, status,
+         offered_at, expires_at)
+    VALUES (?, ?, ?, ?, 1, 'offered', NOW() - INTERVAL '49 hours', NOW() - INTERVAL '1 hour')
+}, $session_a->id, $location_a->id, $student_a->id, $parent_a->id);
+
+# ProcessWaitlist material: a recently-cancelled enrollment + a waiting entry.
+Registry::DAO::Enrollment->create( $db_a, {
+    session_id => $session_a->id,
+    student_id => $student_a->id,
+    parent_id  => $parent_a->id,
+    status     => 'cancelled',
+});
+
+# student_a2 is distinct from student_a to satisfy the (session_id, student_id)
+# unique constraint on the waitlist table -- each student can appear at most
+# once per session on the waitlist.
+Registry::DAO::Waitlist->create( $db_a, {
+    session_id  => $session_a->id,
+    location_id => $location_a->id,
+    student_id  => $student_a2->id,
+    parent_id   => $parent_a->id,
+    position    => 2,
+    status      => 'waiting',
+});
+
+# ---- fixture: Tenant B - provisioned with NO waitlist state ----------------
+
+my $parent_b = Test::Registry::Fixtures::create_user( $dao, {
+    username  => 'ph_parent_b_' . $$,
+    password  => 'pw',
+    user_type => 'parent',
+});
+
+my $tenant_b = Registry::DAO::Tenant->provision( $dao->db, {
+    name  => 'PlatformHealthTenantB_' . $$,
+    slug  => 'ph_tenant_b_' . $$,
+    users => [ $parent_b ],
+});
+
+my $slug_b = $tenant_b->slug;
+
+# ---- fixture: bad row - slug with no Postgres schema (#265 shape) ----------
+#
+# Defense-in-depth: the sweep must never let one bad row break other tenants
+# regardless of whether such rows turn out to be legal (issue #265).
+# This assertion survives any #265 resolution, including deleting the row
+# and forbidding the state.
+
+my $bad_slug = 'ph_no_schema_' . $$;
+$dao->db->query(
+    'INSERT INTO registry.tenants (name, slug) VALUES (?, ?)',
+    'PH Bad Row ' . $$,
+    $bad_slug,
+);
+
+# ---- mock infrastructure (extended shims) -----------------------------------
+#
+# MockLogger captures error() calls to an array for assertion; other levels
+# are silenced so test output stays pristine.
+# MockJob records whether finish() or fail() was called so we can assert
+# the bad row did not abort the sweep.
+
+{
+    package MockLogger;
+    sub new   { bless { errors => [] }, shift }
+    sub info  { }
+    sub debug { }
+    sub warn  { }
+    sub error {
+        my ($self, $msg) = @_;
+        push @{ $self->{errors} }, $msg;
+    }
+    sub errors { @{ $_[0]->{errors} } }
+}
+
+{
+    package MockJob;
+    sub new    { bless { app => $_[1], finished => 0, failed => 0 }, $_[0] }
+    sub app    { $_[0]->{app} }
+    sub finish { $_[0]->{finished}++ }
+    sub fail   { $_[0]->{failed}++  }
+}
+
+{
+    package MockApp;
+    sub new { bless { dao => $_[1], log => $_[2] }, $_[0] }
+    sub dao { $_[0]->{dao} }
+    sub log { $_[0]->{log} }
+}
+
+# ---- subtest 1: ProcessWaitlist dispatch reaches every tenant, skips registry ----
+
+subtest 'ProcessWaitlist: sweep reaches tenant A and B, skips registry' => sub {
+    my $log = MockLogger->new;
+    my $app = MockApp->new( $dao, $log );
+    my $job = MockJob->new( $app );
+
+    my @called_schemas;
+    {
+        no warnings 'redefine';
+        local *Registry::Job::ProcessWaitlist::process_recent_cancellations = sub {
+            my ($class, $tenant_dao, $log) = @_;
+            push @called_schemas, $tenant_dao->current_tenant;
+        };
+
+        Registry::Job::ProcessWaitlist->perform( $job );
+    }
+
+    ok scalar(@called_schemas) > 0,
+        'perform called process_recent_cancellations at least once';
+
+    my @a_calls = grep { $_ eq $slug_a } @called_schemas;
+    is scalar(@a_calls), 1,
+        "process_recent_cancellations dispatched for tenant A ($slug_a)";
+
+    my @b_calls = grep { $_ eq $slug_b } @called_schemas;
+    is scalar(@b_calls), 1,
+        "process_recent_cancellations dispatched for tenant B ($slug_b)";
+
+    my @reg_calls = grep { $_ eq 'registry' } @called_schemas;
+    is scalar(@reg_calls), 0,
+        'registry schema is not included in the ProcessWaitlist sweep';
+
+    is $job->{finished}, 1, 'MockJob->finish was called (not fail)';
+    is $job->{failed},   0, 'MockJob->fail was NOT called';
+};
+
+# ---- subtest 2: WaitlistExpiration dispatch reaches every tenant, skips registry ----
+
+subtest 'WaitlistExpiration: sweep reaches tenant A and B, skips registry' => sub {
+    my $log = MockLogger->new;
+    my $app = MockApp->new( $dao, $log );
+    my $job = MockJob->new( $app );
+
+    my @called_schemas;
+    {
+        no warnings 'redefine';
+        local *Registry::Job::WaitlistExpiration::expire_all_old_offers = sub {
+            my ($class, $tenant_dao, $log) = @_;
+            push @called_schemas, $tenant_dao->current_tenant;
+        };
+
+        Registry::Job::WaitlistExpiration->perform( $job );
+    }
+
+    ok scalar(@called_schemas) > 0,
+        'perform called expire_all_old_offers at least once';
+
+    my @a_calls = grep { $_ eq $slug_a } @called_schemas;
+    is scalar(@a_calls), 1,
+        "expire_all_old_offers dispatched for tenant A ($slug_a)";
+
+    my @b_calls = grep { $_ eq $slug_b } @called_schemas;
+    is scalar(@b_calls), 1,
+        "expire_all_old_offers dispatched for tenant B ($slug_b)";
+
+    my @reg_calls = grep { $_ eq 'registry' } @called_schemas;
+    is scalar(@reg_calls), 0,
+        'registry schema is not included in the WaitlistExpiration sweep';
+
+    is $job->{finished}, 1, 'MockJob->finish was called (not fail)';
+    is $job->{failed},   0, 'MockJob->fail was NOT called';
+};
+
+# ---- subtest 3: bad-row isolation (defense-in-depth, links issue #265) ------
+#
+# Run both performs WITHOUT dispatch interception so the real per-tenant
+# try/catch exercises against the bad row whose schema does not exist.
+# The sweep must: call finish (not fail), and the error must be logged
+# (captured in MockLogger, never to raw STDERR) mentioning the bad slug.
+# This assertion is intentionally schema-resolution-neutral - it survives
+# any resolution of #265, including making such rows illegal and deleting them.
+
+subtest 'ProcessWaitlist: bad row (no schema, #265) is isolated, sweep finishes' => sub {
+    my $log = MockLogger->new;
+    my $app = MockApp->new( $dao, $log );
+    my $job = MockJob->new( $app );
+
+    Registry::Job::ProcessWaitlist->perform( $job );
+
+    is $job->{finished}, 1, 'ProcessWaitlist->finish called despite bad row';
+    is $job->{failed},   0, 'ProcessWaitlist->fail NOT called';
+
+    my @errors = $log->errors;
+    my @bad_slug_errors = grep { /\Q$bad_slug\E/ } @errors;
+    ok scalar(@bad_slug_errors) > 0,
+        'bad-slug error was captured in the logger (not lost to STDERR)';
+    like $bad_slug_errors[0], qr/\Q$bad_slug\E/,
+        'captured error message mentions the bad slug';
+};
+
+subtest 'WaitlistExpiration: bad row (no schema, #265) is isolated, sweep finishes' => sub {
+    my $log = MockLogger->new;
+    my $app = MockApp->new( $dao, $log );
+    my $job = MockJob->new( $app );
+
+    Registry::Job::WaitlistExpiration->perform( $job );
+
+    is $job->{finished}, 1, 'WaitlistExpiration->finish called despite bad row';
+    is $job->{failed},   0, 'WaitlistExpiration->fail NOT called';
+
+    my @errors = $log->errors;
+    my @bad_slug_errors = grep { /\Q$bad_slug\E/ } @errors;
+    ok scalar(@bad_slug_errors) > 0,
+        'bad-slug error was captured in the logger (not lost to STDERR)';
+    like $bad_slug_errors[0], qr/\Q$bad_slug\E/,
+        'captured error message mentions the bad slug';
+};
+
+# ---- subtest 4: real effect in tenant A - WaitlistExpiration flips offer ----
+#
+# After the real WaitlistExpiration run above (subtest 3), the offered entry
+# in tenant A should have flipped to 'expired'.  Assert on the tenant connection.
+
+subtest 'WaitlistExpiration: offered entry in tenant A flipped to expired' => sub {
+    # expire_old_offers sets position = 0 for expired entries, so we must NOT
+    # filter on position here -- the row moved from position=1 to position=0.
+    my $wl = $db_a->query(q{
+        SELECT status FROM waitlist
+        WHERE session_id = ? AND student_id = ?
+    }, $session_a->id, $student_a->id)->hash;
+
+    ok $wl, 'waitlist row still exists in tenant A';
+    is $wl->{status}, 'expired',
+        'the offered entry with past expires_at was flipped to expired by the sweep';
+};
+
+# ---- subtest 5: /health returns 200 with db:ok ------------------------------
+
+subtest '/health: probes DB and returns ok' => sub {
+    my $t = Test::Registry::Mojo->new('Registry');
+    $t->get_ok('/health')
+      ->status_is(200)
+      ->json_is('/status', 'ok')
+      ->json_is('/db',     'ok');
+};
+
+$test_db->cleanup_test_database;

--- a/t/user-journeys/alex/04-platform-health.t
+++ b/t/user-journeys/alex/04-platform-health.t
@@ -290,11 +290,18 @@ subtest 'WaitlistExpiration: bad row (no schema, #265) is isolated, sweep finish
 };
 
 # ---- subtest 4: real effect in tenant A - WaitlistExpiration flips offer ----
-#
-# After the real WaitlistExpiration run above (subtest 3), the offered entry
-# in tenant A should have flipped to 'expired'.  Assert on the tenant connection.
 
 subtest 'WaitlistExpiration: offered entry in tenant A flipped to expired' => sub {
+    # Run the sweep here rather than relying on the bad-row subtest's run
+    # above, so this subtest is order-independent.  expire_old_offers only
+    # touches rows still in 'offered' status, so a repeat run is a no-op for
+    # an already-expired entry.
+    my $log = MockLogger->new;
+    my $app = MockApp->new( $dao, $log );
+    my $job = MockJob->new( $app );
+    Registry::Job::WaitlistExpiration->perform( $job );
+    is $job->{finished}, 1, 'expiration sweep completed';
+
     # expire_old_offers sets position = 0 for expired entries, so we must NOT
     # filter on position here -- the row moved from position=1 to position=0.
     my $wl = $db_a->query(q{


### PR DESCRIPTION
Adds the missing persona journey suite for **Alex** — the platform owner whose journeys are business outcomes rather than in-app clicks. Spec: `docs/superpowers/specs/2026-06-11-alex-user-journeys-design.md` · Plan: `docs/superpowers/plans/2026-06-11-alex-user-journeys.md` (both on this branch; brainstormed, PAAD-pushback'd, and review-looped before implementation).

## The four legs (`t/user-journeys/alex/`)

1. **`01-acquire-tenant.t`** — the signup funnel produces a working, billable tenant: full realistic-data HTTP walk landing→…→payment(`seti_test`)→complete (the payment→complete segment's first-ever HTTP crossing), then outcome assertions: schema + 26 cloned workflows, dual-resident signup users, storefront serves at `<slug>.localhost` with the tenant's name, `billing_status`/`stripe_subscription_id` set.
2. **`02-activate-and-collect.t`** — activating Connect unlocks paid revenue: gate refuses an unready tenant (zero payment rows anywhere) → activation via tenant-row update + **real signed `account.updated` over HTTP** → retry succeeds as a destination charge carrying the 2.5% application fee → **signed `payment_intent.succeeded`** completes the payment and creates the enrollment, all tenant-schema-resident.
3. **`03-platform-billing.t`** — Registry bills the tenant: minimal-data funnel walk, plan selection, trial subscription established; asserts the *absence* of a tenant↔plan record as a tracked #267 dependency; carries the suite's only TODO — the **rate-drift assertion** (seeded plan advertises 2%, the platform charges 2.5%) gated on #267.
4. **`04-platform-health.t`** — the automation runs without Alex: both tenant-aware sweeps reach every tenant, isolate a schema-less tenant row (#265 shape, defense-in-depth), real expiry effect asserted, `/health` probes the DB.

## Three production bugs found and fixed (each with a revert-proven pin)

- **`MultiChildSessionSelection` never snapshotted `children` into run data** → `calculate_enrollment_total` returned $0 over the real HTTP workflow, so **every paid enrollment silently went free, bypassing the Connect readiness gate**. Unit-pinned in the step's test.
- **`Tenant::provision` copied workflows before outcome definitions** → tenant-local `workflow_steps.outcome_definition_id` FK violation under the production boot order (schemas imported before workflows). Invisible to the old test helper, which never imported schemas; the helper now mirrors production order, converting the whole provisioning suite into a standing pin, plus a dedicated FK-ordering subtest.
- **`ProgramListing` never resolved the tenant's name** → storefronts rendered the generic title instead of the org name. Pinned by Leg 1's title/logo assertion.

## Issues filed en route

- **#268** — four `sql/deploy` files orphaned from `sqitch.plan`; fresh deploys (production included) offer **zero selectable pricing plans at signup** (the legs seed the relationship as a fixture; the assertions guard the real fix).
- **#270** — tenant-signup funnel friction inventory: per-field required-vs-optional with downstream-consumer mapping, for field-by-field removal decisions.
- **#269** — pre-existing non-pristine output in `payment-free-by-total.t`.

## Verification

Full suite: **247 files / 2,216 tests, 100% PASS**. All 14 persona-journey files green (298 tests). Every task two-stage-reviewed (spec + quality) with adversarial reproduction of each production bug; final whole-branch integration review passed.