### PR TITLE
Read Stripe responses through the current Mojolicious API

### DIFF
--- a/lib/Registry/DAO/Subscription.pm
+++ b/lib/Registry/DAO/Subscription.pm
@@ -86,8 +86,16 @@ class Registry::DAO::Subscription :isa(Registry::DAO::Object) {
             $tx = $ua->delete($url, $headers, form => $data);
         }
         
-        unless ($tx->success) {
-            warn "Stripe API error: " . $tx->error->{message} if $tx->error;
+        unless ($tx->res->is_success) {
+            # $tx->error carries Mojolicious' view of the failure -- the bare
+            # status reason, or a transport error -- so it says "Payment
+            # Required" where Stripe says which card control declined.  Read
+            # the body first and keep $tx->error as the transport fallback.
+            my $message = $tx->res->json('/error/message')
+                || ( $tx->error // {} )->{message}
+                || $tx->res->message
+                || 'unknown error';
+            warn "Stripe API error: $message";
             return;
         }
         

--- a/t/dao/stripe-subscription.t
+++ b/t/dao/stripe-subscription.t
@@ -10,6 +10,7 @@ use Test::Registry::Fixtures;
 use Registry::DAO::Subscription;
 use JSON;
 use DateTime;
+use Mojo::Transaction::HTTP;
 
 # Setup test database
 my $t = Test::Registry::DB->new;
@@ -210,6 +211,61 @@ subtest 'Configurable subscription creation' => sub {
     
     # Just verify the config is properly structured
     ok($config->{monthly_amount} == 15000, 'Configuration structure is correct');
+};
+
+subtest 'Stripe HTTP transport against a real transaction' => sub {
+    local $ENV{STRIPE_SECRET_KEY} = 'sk_test_dummy';
+
+    my $subscription_dao = Registry::DAO::Subscription->new(db => $db->db);
+
+    my $transport_tenant = Test::Registry::Fixtures::create_tenant($db, {
+        name => 'Transport Test Org',
+        slug => 'transport_test'
+    });
+
+    # Hand back a real Mojo::Transaction::HTTP rather than a stand-in.  The
+    # response API this code calls is the thing under test, so a fake
+    # transaction would pass here while tenant signup dies in production.
+    my $canned;
+    no warnings 'redefine';
+    local *Mojo::UserAgent::post = sub { $canned };
+
+    $canned = Mojo::Transaction::HTTP->new;
+    $canned->res->code(200)->headers->content_type('application/json');
+    $canned->res->body(encode_json({ id => 'cus_transport', object => 'customer' }));
+
+    my $customer = $subscription_dao->create_customer(
+        { id => $transport_tenant->id, name => 'Transport Test Org' },
+        { billing_email => 'billing@transport.test' },
+    );
+
+    is($customer->{id}, 'cus_transport', 'successful response is parsed and returned');
+
+    my $stored = $db->db->query(
+        'SELECT stripe_customer_id FROM registry.tenants WHERE id = ?',
+        $transport_tenant->id
+    )->hash;
+    is($stored->{stripe_customer_id}, 'cus_transport', 'customer id written back to the tenant');
+
+    # Stripe reports failures as a 4xx with a JSON body.  $tx->error would only
+    # give the status reason ("Payment Required"), so the useful message has to
+    # come off the response body.
+    $canned = Mojo::Transaction::HTTP->new;
+    $canned->res->code(402)->headers->content_type('application/json');
+    $canned->res->body(encode_json({ error => { message => 'Your card was declined.' } }));
+
+    my @warnings;
+    my $declined = do {
+        local $SIG{__WARN__} = sub { push @warnings, @_ };
+        $subscription_dao->create_customer(
+            { id => $transport_tenant->id, name => 'Transport Test Org' },
+            { billing_email => 'billing@transport.test' },
+        );
+    };
+
+    ok(!defined $declined, 'failed request returns undef');
+    like(join('', @warnings), qr/Your card was declined/,
+        'Stripe error message is surfaced in the warning');
 };
 
 done_testing();


### PR DESCRIPTION
`Registry::DAO::Subscription::_stripe_request` checked `$tx->success`. Mojolicious removed that method in 8.0; we run 9.40. Every Stripe call through this class died with `Can't locate object method "success" via package "Mojo::Transaction::HTTP"`.

`workflows/tenant-signup.yml:26` wires `TenantPayment`, which routes here, and the die is swallowed into a generic error message. Tenant self-serve signup has been dead in every context -- daemon, worker, CLI and `prove` alike.

This is not the `Mojo::Promise::wait` bug from #284. This class never touches `Mojo::Promise` and is immune to the async fix in #283; it is a separate, older Stripe client.

## The second half

An HTTP status never populates `$tx->error` -- `Mojo/Transaction.pm:27` is just `req->error || res->error`, and `Mojo::Message::error` is a plain setter written to on transport and parse failures only. So the failure branch was warning nothing at all on a Stripe 402. The message now comes off the response body, where Stripe puts it, falling back to `$tx->error` for genuine transport failures.

## Testing

The existing tests never exercised `_stripe_request` -- `t/dao/stripe-subscription.t:202` said so out loud: "We won't mock the full Stripe API here to keep tests simple." That is why this survived.

The new subtest drives `create_customer` against a real `Mojo::Transaction::HTTP` with a canned response. That shape matters: the response API is the thing under test, so anything that faked the transaction would have passed while production died. It covers both the 200 path (parsed, and the customer id written back to the tenant) and the 402 path (returns undef, and Stripe's message reaches the warning).

`grep -rn -- '->success\b' lib/ t/` now returns nothing, so this was the only site.

## Verification

```
t/dao/stripe-subscription.t ................. ok
t/controller/stripe-webhooks.t .............. ok
t/integration/stripe-webhook-integration.t .. ok
Result: PASS
```

Full suite green on the branch this was developed on: `Files=257, Tests=2278, Result: PASS`.

Split out of #283 deliberately -- that PR is scoped to the enrollment path and this should not wait behind its review.