### PR TITLE
Harden workflow run data: refuse operator hashrefs, re-derive server-owned keys, bound child selections, scope subscription config

### DIFF
--- a/lib/Registry/Controller/Workflows.pm
+++ b/lib/Registry/Controller/Workflows.pm
@@ -49,16 +49,37 @@ class Registry::Controller::Workflows :isa(Registry::Controller) {
         }
         
         my $run = $workflow->new_run( $dao->db, $config );
-        my $data = $self->req->params->to_hash;
-        
-        # Add tenant context to workflow run data if present
-        my $tenant_slug = $self->tenant;
-        if ($tenant_slug && $tenant_slug ne 'registry') {
-            $data->{__tenant_slug} = $tenant_slug;
-        }
-        
+        my $data = $self->_apply_server_owned_data( $self->req->params->to_hash );
+
         $run->process( $dao->db, $first_step, $data );
         return $run;
+    }
+
+    # Request params are merged into a run's data verbatim, on every step, so
+    # any key the server owns has to be re-derived from the request rather than
+    # trusted. __tenant_slug alone selects the Stripe destination account,
+    # on_behalf_of, and the revenue-share rate; user_id decides whose enrollment
+    # and whose charge this is. Both are dropped when there is nothing to derive
+    # -- an absent session is not a licence to invent a user.
+    method _apply_server_owned_data ($data) {
+        my $tenant_slug = $self->tenant;
+        if ( $tenant_slug && $tenant_slug ne 'registry' ) {
+            $data->{__tenant_slug} = $tenant_slug;
+        }
+        else {
+            delete $data->{__tenant_slug};
+        }
+
+        my $current_user = $self->stash('current_user');
+        my $user_id = ref $current_user ? $current_user->{id} : undef;
+        if ($user_id) {
+            $data->{user_id} = $user_id;
+        }
+        else {
+            delete $data->{user_id};
+        }
+
+        return $data;
     }
 
     method index() {
@@ -381,6 +402,8 @@ class Registry::Controller::Workflows :isa(Registry::Controller) {
     # Run a step and render whatever it hands back. Shared by the POST path and
     # by the Stripe return leg, which arrives as a GET.
     method _process_step ( $run, $step, $data ) {
+        $self->_apply_server_owned_data($data);
+
         my $result = $run->process( $self->dao->db, $step, $data );
 
         # Steps that talk to Stripe hand back a promise rather than a hashref;

--- a/lib/Registry/DAO/WorkflowSteps/MultiChildSessionSelection.pm
+++ b/lib/Registry/DAO/WorkflowSteps/MultiChildSessionSelection.pm
@@ -53,13 +53,22 @@ class Registry::DAO::WorkflowSteps::MultiChildSessionSelection :isa(Registry::DA
             my %selections;  # child_id => session_id
             my @errors;
 
-            # Collect selections from form; template emits session_for_<child_id>
+            # Collect selections from form; template emits session_for_<child_id>.
+            # The capacity and age checks below iterate the selected children, so
+            # a selection for anyone else would be enrolled unchecked -- and
+            # unpriced, since Payment totals the children snapshot. Selections
+            # must be a subset of the children this run actually chose.
+            my %is_selected = map { $_ => 1 } @$selected_child_ids;
             for my $key (keys %$form_data) {
                 if ($key =~ /^session_for_(.+)$/) {
                     my $child_id = $1;
                     my $session_id = $form_data->{$key};
-                    
+
                     if ($session_id && $session_id ne 'none') {
+                        unless ($is_selected{$child_id}) {
+                            push @errors, "Session selected for a child that is not part of this registration";
+                            next;
+                        }
                         $selections{$child_id} = $session_id;
                     }
                 }

--- a/lib/Registry/DAO/WorkflowSteps/Payment.pm
+++ b/lib/Registry/DAO/WorkflowSteps/Payment.pm
@@ -98,6 +98,18 @@ method _render_data ($db, $run, %extra) {
     return { step_data => { %{ $self->prepare_payment_data($db, $run) }, %extra } };
 }
 
+# The run's payment_id is bound straight into a WHERE clause, so it must be a
+# plain scalar. Run data is merged from request params, and a bracketed name
+# (payment_id[!=]=<uuid>) expands to { '!=' => <uuid> } -- which SQL::Abstract
+# renders as an operator, turning `WHERE id = ?` into `WHERE id != ?` and
+# pointing the reuse UPDATE/DELETE at every other payment in the tenant. There
+# is no sanitised reading of a client-chosen operator, so refuse it outright.
+method _run_payment_id ($run) {
+    my $payment_id = $run->data->{payment_id};
+    die "Invalid payment_id in workflow data" if ref $payment_id;
+    return $payment_id;
+}
+
 method create_payment ($db, $run, $form_data) {
     my $user_id = $run->data->{user_id} or die "No user_id in workflow data";
     
@@ -143,7 +155,7 @@ method create_payment ($db, $run, $form_data) {
     # a second payment row or a second Stripe charge -- the stable
     # idempotency_token on the existing row ensures Stripe deduplicates too.
     # ponytail: reuse check; completed payments start a new row (second purchase)
-    my $existing_payment_id = $run->data->{payment_id};
+    my $existing_payment_id = $self->_run_payment_id($run);
     my $payment;
     # Cancelling the superseded intent has to finish before the replacement is
     # minted, so it is threaded through the chain rather than fired and
@@ -242,7 +254,7 @@ method create_payment ($db, $run, $form_data) {
 }
 
 method handle_payment_callback ($db, $run, $form_data) {
-    my $payment_id = $run->data->{payment_id} or die "No payment_id in workflow data";
+    my $payment_id = $self->_run_payment_id($run) or die "No payment_id in workflow data";
 
     my $payment = Registry::DAO::Payment->find($db, { id => $payment_id });
     die "Payment $payment_id not found" unless $payment;

--- a/lib/Registry/DAO/WorkflowSteps/TenantPayment.pm
+++ b/lib/Registry/DAO/WorkflowSteps/TenantPayment.pm
@@ -74,7 +74,7 @@ class Registry::DAO::WorkflowSteps::TenantPayment :isa(Registry::DAO::WorkflowSt
 
     method prepare_payment_data($db, $run) {
         # Get tenant subscription pricing configuration
-        my $subscription_config = $self->get_subscription_config($db);
+        my $subscription_config = $self->get_subscription_config($db, $run);
         
         # Get organization info from workflow data
         my $org_data = $run->data->{profile} || {};
@@ -93,10 +93,10 @@ class Registry::DAO::WorkflowSteps::TenantPayment :isa(Registry::DAO::WorkflowSt
         };
     }
 
-    method get_subscription_config($db) {
-        # Get selected pricing plan from workflow data
-        my $workflow = $self->workflow($db);
-        my $run = $workflow->latest_run($db);
+    # The run is passed in, never looked up: latest_run is scoped to the
+    # workflow alone, so re-resolving it here would price this visitor's signup
+    # from whichever run on the platform happens to be newest.
+    method get_subscription_config($db, $run) {
         my $selected_plan;
 
         # Check if we have a run and it has pricing plan data
@@ -314,7 +314,7 @@ class Registry::DAO::WorkflowSteps::TenantPayment :isa(Registry::DAO::WorkflowSt
         # Create subscription with trial
         my $subscription;
         eval {
-            my $config = $self->get_subscription_config($db);
+            my $config = $self->get_subscription_config($db, $run);
             $subscription = $subscription_dao->create_subscription_with_config(
                 $setup_data->{stripe_customer_id},
                 $setup_intent->{payment_method},

--- a/t/dao/multi-child-session-selection-workflow-step.t
+++ b/t/dao/multi-child-session-selection-workflow-step.t
@@ -407,4 +407,34 @@ subtest 'Session capacity constraints' => sub {
     is $available1->[0]->{session}->id, $session1->id, 'Available session is session1';
 };
 
+subtest 'session_for_<id> for a child that was never selected' => sub {
+    my $run = $workflow->new_run($db);
+    $run->update_data($db, {
+        user_id => $parent->id,
+        selected_child_ids => [$child1->id],   # only child1 was chosen
+        location_id => $location->id,
+        program_id => $project->id,
+    });
+
+    my $step = $workflow->get_step($db, { slug => 'session-selection' });
+
+    # session2 is at capacity from the subtest above. Because child2 is absent
+    # from selected_child_ids, neither the capacity nor the age loop -- both of
+    # which iterate the selected children -- ever looks at him, and Payment
+    # prices the children array rather than enrollment_items, so he would
+    # enroll unchecked and unpriced.
+    my $result = $step->process($db, {
+        action => 'select_sessions',
+        "session_for_" . $child1->id => $session1->id,
+        "session_for_" . $child2->id => $session2->id,
+    }, $run);
+
+    ok $result->{errors}, 'submission with an unselected child is rejected';
+    ok $result->{stay}, 'run stays on the session-selection step';
+    ok !$run->data->{enrollment_items},
+        'no enrollment items are stored';
+    ok !$run->data->{session_selections},
+        'no session selections are stored';
+};
+
 done_testing;

--- a/t/dao/tenant-payment-plan-link.t
+++ b/t/dao/tenant-payment-plan-link.t
@@ -50,7 +50,7 @@ subtest 'no-plan get_subscription_config is plan-driven (Free 0%)' => sub {
         data        => { profile => { organization_name => 'NoPlan Org' } },
     });
 
-    my $config = $step->get_subscription_config($db);
+    my $config = $step->get_subscription_config($db, $run);
     is $config->{revenue_share_percent}, 0,
         'revenue_share_percent is 0 (from the platform Free plan)';
     like $config->{description}, qr/\b0%/,

--- a/t/dao/tenant-payment-workflow.t
+++ b/t/dao/tenant-payment-workflow.t
@@ -36,6 +36,13 @@ my $payment_step = Registry::DAO::WorkflowSteps::TenantPayment->create($db, {
     description => 'Payment step'
 });
 
+# A run with no selected_pricing_plan: the Solo/Free fallback the two
+# configuration subtests below exercise.
+my $no_plan_run = Registry::DAO::WorkflowRun->create($db, {
+    workflow_id => $workflow->id,
+    data => encode_json({})
+});
+
 subtest 'TenantPayment workflow step creation' => sub {
     plan tests => 3;
     
@@ -47,7 +54,7 @@ subtest 'TenantPayment workflow step creation' => sub {
 subtest 'Subscription configuration' => sub {
     plan tests => 6;
 
-    my $config = $payment_step->get_subscription_config($db);
+    my $config = $payment_step->get_subscription_config($db, $no_plan_run);
 
     ok($config, 'Configuration returned');
     is($config->{plan_name}, 'Solo', 'Plan name correct');
@@ -66,7 +73,7 @@ subtest 'Solo tier revenue share percent is plan-driven (Free 0%)' => sub {
         'REVENUE_SHARE_PERCENT constant removed from TenantPayment'
     );
 
-    my $config = $payment_step->get_subscription_config($db);
+    my $config = $payment_step->get_subscription_config($db, $no_plan_run);
 
     # The no-plan fallback rate comes from the platform Free plan (0%), not 2.5.
     is( $config->{revenue_share_percent}, 0,
@@ -161,6 +168,61 @@ subtest 'Validation error handling' => sub {
     ok($result, 'Result returned even with missing data');
     # Should have default values for missing organization name
     is($result->{billing_summary}->{organization_name}, 'Your Organization', 'Default organization name used');
+};
+
+subtest 'Subscription config follows the run in hand, not the newest run' => sub {
+    plan tests => 4;
+
+    my $mine = Registry::DAO::WorkflowRun->create($db, {
+        workflow_id => $workflow->id,
+        data => encode_json({
+            profile => {
+                organization_name => 'My Organization',
+                billing_email     => 'me@example.org',
+            },
+            selected_pricing_plan => {
+                plan_name    => 'Studio',
+                amount_cents => 4900,
+                currency     => 'USD',
+                pricing_configuration => {
+                    trial_days  => 14,
+                    description => 'Studio plan',
+                },
+            },
+        })
+    });
+
+    # Another visitor starts a signup after mine and picks a different plan.
+    my $theirs = Registry::DAO::WorkflowRun->create($db, {
+        workflow_id => $workflow->id,
+        data => encode_json({
+            selected_pricing_plan => {
+                plan_name    => 'Empire',
+                amount_cents => 19900,
+                currency     => 'USD',
+                pricing_configuration => {},
+            },
+        })
+    });
+
+    # latest_run orders by created_at, and two rows written in the same instant
+    # would tie; make theirs unambiguously the newest.
+    $db->query(
+        q{UPDATE workflow_runs SET created_at = created_at + interval '1 minute' WHERE id = ?},
+        $theirs->id
+    );
+
+    my $data = $payment_step->prepare_payment_data($db, $mine);
+    is($data->{subscription_config}{plan_name}, 'Studio',
+        'payment page prices my run with my plan');
+    is($data->{subscription_config}{monthly_amount}, 4900,
+        'and with my amount');
+    is($data->{billing_summary}{plan_details}{plan_name}, 'Studio',
+        'billing summary agrees');
+
+    my $config = eval { $payment_step->get_subscription_config($db, $mine) };
+    is(($config ? $config->{plan_name} : undef), 'Studio',
+        'get_subscription_config prices the run it is handed');
 };
 
 done_testing();

--- a/t/dao/tenant-signup-pricing-integration.t
+++ b/t/dao/tenant-signup-pricing-integration.t
@@ -151,7 +151,7 @@ subtest 'Full tenant signup integration test' => sub {
     my $payment_step_obj = $workflow->get_step($dao->db, { slug => 'payment' });
 
     # Get payment configuration
-    my $payment_config = $payment_step_obj->get_subscription_config($dao->db);
+    my $payment_config = $payment_step_obj->get_subscription_config($dao->db, $run);
 
     is $payment_config->{plan_name}, 'Registry Enterprise', 'Payment uses selected plan name';
     is $payment_config->{monthly_amount}, 50000, 'Payment uses selected plan amount';
@@ -194,7 +194,7 @@ subtest 'Backwards compatibility test' => sub {
 
     # Test that payment step falls back to default configuration
     my $legacy_payment_obj = $legacy_workflow->get_step($dao->db, { slug => 'payment' });
-    my $legacy_config = $legacy_payment_obj->get_subscription_config($dao->db);
+    my $legacy_config = $legacy_payment_obj->get_subscription_config($dao->db, $legacy_run);
 
     is $legacy_config->{plan_name}, 'Solo', 'Falls back to default plan name';
     is $legacy_config->{monthly_amount}, 0, 'Falls back to default amount (free)';

--- a/t/security/payment-id-operator-injection.t
+++ b/t/security/payment-id-operator-injection.t
@@ -1,0 +1,133 @@
+#!/usr/bin/env perl
+# ABOUTME: Proves a client-planted operator hashref in run data's payment_id cannot reach a WHERE clause.
+# ABOUTME: A bracketed form param expands to { '!=' => ... }, which SQL::Abstract renders as an operator.
+use 5.42.0;
+use warnings;
+use lib qw(lib t/lib);
+use Test::More;
+use Test::Registry::DB;
+use Test::Registry::Fixtures;
+use Registry::DAO;
+use Registry::DAO::Workflow;
+use Registry::DAO::WorkflowStep;
+use Registry::DAO::User;
+use Registry::DAO::Payment;
+use Registry::DAO::WorkflowSteps::Payment;
+
+my $test_db = Test::Registry::DB->new;
+my $dao     = $test_db->db;
+
+Test::Registry::Fixtures::create_tenant($dao->db, {
+    name => 'Injection Test Tenant',
+    slug => 'test_injection',
+});
+$dao->db->query('SELECT clone_schema(?)', 'test_injection');
+
+$dao = Registry::DAO->new(url => $test_db->uri, schema => 'test_injection');
+my $db = $dao->db;
+
+my $parent = Registry::DAO::User->create($db, {
+    name      => 'Test Parent',
+    username  => 'testparent',
+    email     => 'parent@example.com',
+    user_type => 'parent',
+});
+
+my $workflow = Registry::DAO::Workflow->create($db, {
+    name        => 'Injection Test Workflow',
+    slug        => 'injection-test-workflow',
+    description => 'Landing passthrough followed by the payment step',
+});
+
+# The landing step is a bare WorkflowStep with no outcome definition, so
+# validate() is a no-op and process() persists whatever the client posted.
+my $landing = Registry::DAO::WorkflowStep->create($db, {
+    workflow_id => $workflow->id,
+    slug        => 'landing',
+    class       => 'Registry::DAO::WorkflowStep',
+    description => 'Landing',
+});
+my $payment_step_row = Registry::DAO::WorkflowStep->create($db, {
+    workflow_id => $workflow->id,
+    slug        => 'payment',
+    class       => 'Registry::DAO::WorkflowSteps::Payment',
+    description => 'Payment',
+    depends_on  => $landing->id,
+});
+Registry::DAO::WorkflowStep->create($db, {
+    workflow_id => $workflow->id,
+    slug        => 'complete',
+    class       => 'Registry::DAO::WorkflowStep',
+    description => 'Complete',
+    depends_on  => $payment_step_row->id,
+});
+$workflow->update($db, { first_step => 'landing' }, { id => $workflow->id });
+
+my $payment_step = $workflow->get_step($db, { slug => 'payment' });
+
+# An unrelated payment belonging to this tenant, with one line item.
+sub make_victim {
+    my $victim = Registry::DAO::Payment->create($db, {
+        user_id      => $parent->id,
+        amount_cents => 5000,
+        metadata     => {},
+    });
+    $victim->add_line_item($db, {
+        description  => 'Someone else tuition',
+        amount_cents => 5000,
+    });
+    return $victim;
+}
+
+# Plant the operator hashref exactly the way an unauthenticated GET/POST would:
+# payment_id[!=]=<uuid> expands to payment_id => { '!=' => <uuid> }.
+sub planted_run {
+    my $run = $workflow->new_run($db);
+    $run->process($db, $landing, {
+        'payment_id[!=]' => '00000000-0000-0000-0000-000000000000',
+    });
+    $run->update_data($db, { user_id => $parent->id });
+    return $run;
+}
+
+subtest 'the operator hashref really does land in run data' => sub {
+    my $run = planted_run();
+    is ref $run->data->{payment_id}, 'HASH',
+        'bracketed param expands to a hashref in run data';
+    is $run->data->{payment_id}{'!='}, '00000000-0000-0000-0000-000000000000',
+        'and carries the operator the client chose';
+};
+
+subtest 'create_payment refuses a non-scalar payment_id' => sub {
+    my $victim = make_victim();
+    my $run    = planted_run();
+
+    my $ok = eval { $payment_step->create_payment($db, $run, {}); 1 };
+    my $err = $@;
+
+    ok !$ok, 'create_payment dies instead of binding a hashref into WHERE';
+    like $err, qr/payment_id/, 'error names the offending key';
+
+    my $row = $db->select('payments', '*', { id => $victim->id })->hash;
+    is $row->{amount_cents}, 5000, 'unrelated payment amount untouched';
+    is $db->select('payment_items', '*', { payment_id => $victim->id })->rows, 1,
+        'unrelated payment line items untouched';
+};
+
+subtest 'handle_payment_callback refuses a non-scalar payment_id' => sub {
+    my $victim = make_victim();
+    my $run    = planted_run();
+
+    my $ok = eval {
+        $payment_step->handle_payment_callback($db, $run, {
+            payment_intent_id => 'pi_never_sent',
+        });
+        1;
+    };
+    my $err = $@;
+
+    ok !$ok, 'handle_payment_callback dies before looking up a payment';
+    like $err, qr/payment_id/, 'error names the offending key';
+};
+
+done_testing;

--- a/t/security/workflow-run-data-server-owned-keys.t
+++ b/t/security/workflow-run-data-server-owned-keys.t
@@ -1,0 +1,142 @@
+#!/usr/bin/env perl
+# ABOUTME: Proves a client cannot write the server-owned workflow run-data keys __tenant_slug and user_id.
+# ABOUTME: __tenant_slug alone selects the Stripe destination account, on_behalf_of, and the fee rate.
+BEGIN { $ENV{EMAIL_SENDER_TRANSPORT} = 'Test' }
+
+use 5.42.0;
+use warnings;
+use utf8;
+
+use lib qw(lib t/lib);
+use Test::More;
+use Test::Registry::DB;
+use Test::Registry::Fixtures;
+use Test::Registry::Mojo;
+use Test::Registry::Helpers qw( authenticate_as );
+
+use Registry::DAO qw(Workflow);
+use Registry::DAO::Workflow;
+use Registry::DAO::WorkflowStep;
+use Registry::DAO::WorkflowRun;
+use Registry::DAO::User;
+
+my $test_db = Test::Registry::DB->new;
+my $dao     = $test_db->db;
+$ENV{DB_URL} = $test_db->uri;
+
+# A real tenant schema so the tenant helper resolves <slug>.localhost instead of
+# degrading to the platform.
+Test::Registry::Fixtures::create_tenant($dao->db, {
+    name => 'Host Tenant',
+    slug => 'hosttenant',
+});
+$dao->db->query('SELECT clone_schema(?)', 'hosttenant');
+
+# Two passthrough steps: no outcome definition, so validate() is a no-op and
+# whatever the client posts is merged into the run's data.
+my $workflow = Registry::DAO::Workflow->create($dao->db, {
+    name        => 'Run Data Test Workflow',
+    slug        => 'run-data-test',
+    description => 'Landing passthrough followed by a completion step',
+});
+my $landing = Registry::DAO::WorkflowStep->create($dao->db, {
+    workflow_id => $workflow->id,
+    slug        => 'landing',
+    class       => 'Registry::DAO::WorkflowStep',
+    description => 'Landing',
+});
+Registry::DAO::WorkflowStep->create($dao->db, {
+    workflow_id => $workflow->id,
+    slug        => 'complete',
+    class       => 'Registry::DAO::WorkflowStep',
+    description => 'Complete',
+    depends_on  => $landing->id,
+});
+$workflow->update($dao->db, { first_step => 'landing' }, { id => $workflow->id });
+
+my $session_user = Registry::DAO::User->create($dao->db, {
+    name      => 'Logged In Parent',
+    username  => 'loggedin',
+    email     => 'loggedin@example.com',
+    user_type => 'parent',
+});
+my $other_user = Registry::DAO::User->create($dao->db, {
+    name      => 'Someone Else',
+    username  => 'someoneelse',
+    email     => 'someoneelse@example.com',
+    user_type => 'parent',
+});
+
+my $t = Test::Registry::Mojo->new('Registry');
+$t->app->helper(dao => sub { $dao });
+
+# A run parked on the landing step, ready for a POST to the next one.
+sub run_on_second_step {
+    my $run = $workflow->new_run($dao->db);
+    $run->process($dao->db, $landing, {});
+    return $run;
+}
+
+sub data_for {
+    my ($run_id) = @_;
+    my ($fresh) = $dao->find(WorkflowRun => { id => $run_id });
+    return $fresh->data;
+}
+
+subtest 'run creation ignores posted server-owned keys' => sub {
+    $t->post_ok('/run-data-test' => form => {
+        __tenant_slug => 'victim_tenant',
+        user_id       => $other_user->id,
+    })->status_is(302);
+
+    my ($run_id) = $t->tx->res->headers->location =~ m{/run-data-test/([^/]+)/};
+    my $data = data_for($run_id);
+
+    ok !exists $data->{__tenant_slug},
+        'posted __tenant_slug is not stored at run creation';
+    ok !exists $data->{user_id},
+        'posted user_id is not stored at run creation';
+};
+
+subtest 'a later step cannot plant them either' => sub {
+    my $run = run_on_second_step();
+
+    $t->post_ok("/run-data-test/${\ $run->id}/complete" => form => {
+        __tenant_slug => 'victim_tenant',
+        user_id       => $other_user->id,
+    })->status_is(201);
+
+    my $data = data_for($run->id);
+    ok !exists $data->{__tenant_slug},
+        'posted __tenant_slug is not stored on a subsequent step';
+    ok !exists $data->{user_id},
+        'posted user_id is not stored on a subsequent step';
+};
+
+subtest 'on a tenant host a later step gets the host tenant, not the posted one' => sub {
+    my $run = run_on_second_step();
+
+    $t->post_ok("/run-data-test/${\ $run->id}/complete"
+        => { Host => 'hosttenant.localhost' }
+        => form => { __tenant_slug => 'victim_tenant' }
+    )->status_is(201);
+
+    is data_for($run->id)->{__tenant_slug}, 'hosttenant',
+        'run data carries the tenant the request actually arrived at';
+};
+
+# authenticate_as installs a permanent before_dispatch hook, so every request
+# from here on is authenticated. Keep this subtest last.
+subtest 'user_id comes from the session, not the request' => sub {
+    authenticate_as($t, $session_user);
+    my $run = run_on_second_step();
+
+    $t->post_ok("/run-data-test/${\ $run->id}/complete" => form => {
+        user_id => $other_user->id,
+    })->status_is(201);
+
+    is data_for($run->id)->{user_id}, $session_user->id,
+        'the authenticated user wins over the posted user_id';
+};
+
+done_testing;


### PR DESCRIPTION
Four unauthenticated defects in the workflow run-data path, carved out of PriceOps Leg 0 so they don't wait 10-12 sessions. Each is independent of Leg 0's transaction rewrite.

Found while mapping Leg 0 against the code. The spec schedules all four inside that leg; they are small, they are live, and three of them touch money.

## Why unauthenticated

The workflow routes at `Registry.pm:761-767` hang off a bare router. None of the five `under` blocks in that file covers `/:workflow`. The first step of `summer-camp-registration` is a `Registry::DAO::WorkflowStep` passthrough with no outcome definition, so `validate` is a no-op and a **GET with query parameters** writes straight into run data.

## The four

**1 — an operator hashref reaches a `WHERE` clause** (`24d2cb9`)

`expand_form_params` (`WorkflowStep.pm:122-144`) turns `payment_id[!=]=…` into `{ '!=' => … }`, and `SQL::Abstract::Pg` renders that as an operator:

```
UPDATE payments SET amount_cents = ? WHERE id != ?
DELETE FROM payment_items          WHERE payment_id != ?
```

Sinks are `WorkflowSteps/Payment.pm:153,162-165,167,169`. One query parameter rewrites **every payment row in the tenant** — `completed` and `refunded` included — deletes **every line item**, then binds the attacker's run to a victim's payment row and mints a Stripe intent against it.

The regression test's red output is the damage, not an abstraction:
```
not ok 3 - unrelated payment amount untouched     got: '0'  expected: '5000'
not ok 4 - unrelated payment line items untouched got: '0'  expected: '1'
```

Fix: `_run_payment_id` refuses a ref. Both readers route through it — the reuse branch and the Stripe callback; guarding one would have left the other open.

**2 — server-owned run-data keys are client-writable** (`91cdeeb`)

`Workflows.pm:52-58` derives `__tenant_slug` only at run creation, and only when the slug is not `registry` — so on the platform host a posted value is never overwritten. `:351` re-reads request params on every later step with no override. `__tenant_slug` alone selects the Stripe destination account, `on_behalf_of` and the fee rate (`DAO/Payment.pm:74-97`).

Fix: one helper re-derives tenant-from-host and user-from-session on both paths that turn request params into run data.

**3 — `session_for_<id>` is not checked against the selected children** (`9527c85`)

`MultiChildSessionSelection.pm:56-66` accepts any `session_for_*` parameter, while capacity and age checks at `:93-112` iterate the *other* array. An id in one and not the other is enrolled with no capacity check and no age check, and is never priced — pricing reads `children`, enrollment reads `enrollment_items`.

**4 — a tenant signup is priced from a stranger's run** (`c64a5cb`)

`TenantPayment.pm:96-99` called `$workflow->latest_run($db)`, scoped by `workflow_id` only and ordered `created_at DESC` — the newest signup run on the platform, not this visitor's. Both callers already held the right `$run`. Red output:
```
not ok 1 - payment page prices my run with my plan   got: 'Empire'  expected: 'Studio'
not ok 2 - and with my amount                        got: '19900'   expected: '4900'
```

## Verification

Every test was written first and confirmed to fail for the right reason. For the injection test I additionally reverted **only the source file**, left the test in place, and re-ran:

```
pre-fix:  Tests: 3 Failed: 2   Result: FAIL
post-fix: Tests: 3             Result: PASS
```

Full suite: **`Files=254, Tests=2258, PASS`** (from 252/2249 on main). Neither `t/stripe-live/` nor `t/playwright/` ran.

## Scope note

Registry is pre-alpha: production has two seeded tenants, no customer tenants, no tenant schemas and no real payments, so there is nothing to destroy today. These are fixed now because the fixes are small and the alternative was shipping them after the leg that rewrites the money path.

`Workflows.pm:270`'s `!$run->data->{user_id}` guard is deliberately untouched — with planting closed at both entry points there is no forged value left for it to preserve. Making it *correct* a stale legitimate value is a separate change.

https://claude.ai/code/session_01UMLwCP8cMNQ2kc4LnfeVc2
