### PR TITLE
PriceOps 2.4: one owner for the seat-holding vocabulary

### DIFF
--- a/docs/superpowers/specs/2026-08-18-payment-settlement-state-machine.md
+++ b/docs/superpowers/specs/2026-08-18-payment-settlement-state-machine.md
@@ -198,6 +198,12 @@ What this subsumes, without any lock at all:
 
 One sub answers "what does this cart hold in this session", returning counts by category, and the three consumers read from it. The short-circuit, the demotion predicate and the capacity arithmetic then cannot diverge, because there is one source.
 
+**Implemented, with a deviation.** The shared thing is `Enrollment::seat_holding_statuses` — the *list*, not a counts object. The three consumers ask genuinely different questions (one child's state, everyone else's occupancy, and demotability), so a shared counts structure would have to be reshaped at each call site; the duplication was never the counting, it was the `('active','pending')` literal appearing three times. Sharing the list gets the whole benefit for a fraction of the diff.
+
+Graded by `t/dao/enrollment-seat-vocabulary.t`, which walks every status `enrollments_status_check` permits and asserts all three consumers agree on each. Narrowing any one consumer fails it, and so does narrowing the owner — verified by mutation. The test also reads the CHECK constraint at runtime and fails if the vocabulary grows without a decision here, because a new status would otherwise fall into `cart_seat_state`'s `closed` default silently.
+
+Deliberately out of scope: `get_dashboard_stats_for_parent` and the family-enrollment query both count `('active','pending')` too, but they answer "what is this family signed up for" rather than "who holds a seat" — the same answer today for a different reason. Folding them in would couple a display concern to the settlement predicate.
+
 ---
 
 ## 3. What this fixes

--- a/lib/Registry/DAO/Enrollment.pm
+++ b/lib/Registry/DAO/Enrollment.pm
@@ -5,6 +5,7 @@ class Registry::DAO::Enrollment :isa(Registry::DAO::Object) {
     use Mojo::JSON qw(decode_json);
     use Carp qw(croak);
     use Scalar::Util qw(blessed);
+    use experimental 'keyword_any';
     use DateTime;
 
     
@@ -228,6 +229,28 @@ class Registry::DAO::Enrollment :isa(Registry::DAO::Object) {
     #                 whole category: a terminal drop another system owns, and
     #                 not ours to re-adjudicate.
     #   none       -- nothing here; adjudicate normally.
+    # The one place that answers "does this enrollment status hold a seat".
+    #
+    # Three consumers used to carry their own copy of this list: this class's
+    # cart_seat_state classification, payment_fits_session's COUNT predicate,
+    # and demote_to_waitlisted's UPDATE predicate. They agreed, which is the
+    # most fragile state a duplicated rule can be in -- nothing failed if one
+    # drifted, and every way of drifting is a money defect. Round 3 of the Leg 0
+    # review found three separate disagreements between them about 'cancelled'.
+    #
+    # Deviation from the settlement spec's section 2.4, which proposes a sub
+    # returning counts by category. The three consumers ask different questions
+    # -- one child's state, everyone else's occupancy, and demotability -- so a
+    # shared counts object would have to be reshaped at each call site. The
+    # duplication was never the counting; it was this list. Sharing the list
+    # gets the whole benefit for a fraction of the diff.
+    #
+    # Out of scope, sharing the vocabulary but not this owner:
+    # get_dashboard_stats_for_parent and the family-enrollment query both count
+    # ('active','pending') to answer "what is this family signed up for", which
+    # is a different question that happens to have the same answer today.
+    sub seat_holding_statuses ($class) { return [qw( active pending )] }
+
     sub cart_seat_state ($class, $db, $payment_id, $session_id, $child_id) {
         $db = $db->db if $db isa Registry::DAO;
 
@@ -242,7 +265,8 @@ class Registry::DAO::Enrollment :isa(Registry::DAO::Object) {
         return 'none' unless $row;
 
         my $status = $row->{status} // '';
-        return 'seated'     if $status eq 'active' || $status eq 'pending';
+        return 'seated'
+            if any { $_ eq $status } @{ $class->seat_holding_statuses };
         return 'waitlisted' if $status eq 'waitlisted';
         return 'closed';
     }
@@ -272,7 +296,7 @@ class Registry::DAO::Enrollment :isa(Registry::DAO::Object) {
                 # Only a seat in hand is demotable. A predicate of
                 # "not already waitlisted" also matches a cancelled row, which
                 # un-cancels an admin's drop and re-owes its share.
-                status     => { -in => [ 'active', 'pending' ] },
+                status     => { -in => $class->seat_holding_statuses },
             },
         )->rows;
 
@@ -325,9 +349,9 @@ class Registry::DAO::Enrollment :isa(Registry::DAO::Object) {
         my $taken = $db->query(
             q{SELECT COUNT(*) FROM enrollments
                WHERE session_id = ?
-                 AND status IN ('active', 'pending')
+                 AND status = ANY(?)
                  AND (payment_id IS NULL OR payment_id != ?)},
-            $session_id, $payment->id
+            $session_id, $class->seat_holding_statuses, $payment->id
         )->array->[0] // 0;
 
         return $taken + $already_granted + 1 <= $capacity ? 1 : 0;

--- a/t/dao/enrollment-seat-vocabulary.t
+++ b/t/dao/enrollment-seat-vocabulary.t
@@ -1,0 +1,126 @@
+#!/usr/bin/env perl
+# ABOUTME: One rule decides which enrollment statuses hold a seat, for all three consumers.
+# ABOUTME: cart_seat_state, payment_fits_session and demote_to_waitlisted must never diverge.
+BEGIN { $ENV{EMAIL_SENDER_TRANSPORT} = 'Test' }
+
+use 5.42.0;
+use warnings;
+use lib qw(lib t/lib);
+use Test::More;
+use Test::Registry::DB;
+use Registry::DAO::Enrollment;
+use Registry::DAO::Payment;
+
+local $ENV{STRIPE_SECRET_KEY} = 'sk_test_seat_vocabulary';
+
+my $test_db = Test::Registry::DB->new;
+my $dao     = $test_db->db;
+my $db      = $dao->db;
+
+my $parent = $dao->create(User => {
+    username => 'sv_parent', name => 'SV Parent', user_type => 'parent',
+    email => 'sv@test.local' });
+
+my $n = 0;
+sub a_child () {
+    $n++;
+    Registry::DAO::Family->add_child($db, $parent->id, {
+        child_name => "SV Kid $n", birth_date => '2015-01-01', grade => '4',
+        medical_info => {}, emergency_contact => { name => 'x', phone => '5' } });
+}
+
+sub a_session ($capacity) {
+    my $loc = Registry::DAO::Location->create($db, {
+        name => "SV Loc $n$$", slug => "sv_loc_$n$$", address_info => {}, metadata => {} });
+    my $proj = Registry::DAO::Project->create($db, {
+        name => "SV Proj $n$$", status => 'published',
+        program_type_slug => 'summer-camp', metadata => {} });
+    my $teacher = $dao->create(User => {
+        username => "sv_t_$n$$", name => 'SV T', user_type => 'staff',
+        email => "sv_t_$n$$\@test.local" });
+    my $event = Registry::DAO::Event->create($db, {
+        location_id => $loc->id, project_id => $proj->id, teacher_id => $teacher->id,
+        time => \'NOW()', duration => 60, capacity => $capacity, metadata => {} });
+    my $s = Registry::DAO::Session->create($db, {
+        name => "SV Session $n$$", status => 'published', capacity => $capacity, metadata => {} });
+    $s->add_events($db, $event->id);
+    return $s;
+}
+
+sub a_payment () {
+    Registry::DAO::Payment->create($db, {
+        user_id => $parent->id, amount_cents => 10000, status => 'pending',
+        metadata => { enrollment_items => [], tenant_slug => undef } });
+}
+
+# The whole point of section 2.4: one owner, and the consumers read from it rather
+# than each carrying a copy of the list.
+subtest 'the seat-holding vocabulary has exactly one owner' => sub {
+    my $held = Registry::DAO::Enrollment->seat_holding_statuses;
+    is ref $held, 'ARRAY', 'it is a list';
+    is_deeply [ sort @$held ], [qw( active pending )],
+        'active and pending hold a seat; nothing else does';
+};
+
+# The property that matters. For every status the column can carry, the three
+# consumers must agree on whether it occupies a seat:
+#   - cart_seat_state must call it 'seated'
+#   - payment_fits_session must count it against capacity
+#   - demote_to_waitlisted must be willing to demote it
+# A divergence in any one is a money defect: the capacity arithmetic
+# over- or under-counts, or an admin's cancellation gets un-done.
+subtest 'all three consumers agree, status by status' => sub {
+    my %expect_seated = ( active => 1, pending => 1,
+                          waitlisted => 0, cancelled => 0 );
+
+    # Cover the whole vocabulary, and notice if it grows. enrollments_status_check
+    # is the authority; a status added there without a decision here would
+    # silently default to "does not hold a seat" in cart_seat_state's `closed`
+    # fallback, which is the safe direction only by luck.
+    my $allowed = $db->query(q{
+        SELECT pg_get_constraintdef(oid) FROM pg_constraint
+         WHERE conname = 'enrollments_status_check'
+    })->array->[0];
+    my @in_db = sort( $allowed =~ /'([a-z_]+)'::text/g );
+    is_deeply [ sort keys %expect_seated ], [ @in_db ],
+        'this test covers every status the column permits';
+
+    for my $status ( sort keys %expect_seated ) {
+        my $seated  = $expect_seated{$status};
+        my $session = a_session(1);
+        my $child   = a_child();
+        my $payment = a_payment();
+
+        Registry::DAO::Enrollment->create_for_payment($db, {
+            session_id => $session->id, family_member_id => $child->id,
+            parent_id => $parent->id, status => $status, payment_id => $payment->id });
+
+        # Consumer 1: the cart's own view of this child.
+        my $state = Registry::DAO::Enrollment->cart_seat_state(
+            $db, $payment->id, $session->id, $child->id );
+        is $state eq 'seated' ? 1 : 0, $seated,
+            "cart_seat_state: '$status' " . ( $seated ? 'holds' : 'does not hold' ) . ' a seat';
+
+        # Consumer 2: capacity, seen by a DIFFERENT payment, so this row counts
+        # as somebody else's occupancy rather than being self-excluded.
+        my $other = a_payment();
+        my $fits  = Registry::DAO::Enrollment->payment_fits_session(
+            $db, $other, $session->id );
+        is $fits ? 0 : 1, $seated,
+            "payment_fits_session: '$status' " . ( $seated ? 'fills' : 'leaves free' )
+            . ' the only seat';
+
+        # Consumer 3: demotability.
+        my $demoted = Registry::DAO::Enrollment->demote_to_waitlisted($db, {
+            session_id => $session->id, student_id => $child->id,
+            family_member_id => $child->id, parent_id => $parent->id,
+            payment_id => $payment->id });
+        my $now = $db->select('enrollments', ['status'],
+            { session_id => $session->id, student_id => $child->id,
+              payment_id => $payment->id })->hash->{status};
+        is $now eq 'waitlisted' && $status ne 'waitlisted' ? 1 : 0, $seated,
+            "demote_to_waitlisted: '$status' is " . ( $seated ? '' : 'not ' ) . 'demotable';
+    }
+};
+
+done_testing;


### PR DESCRIPTION
Small, and a prerequisite. Three functions in the settlement path each carried
their own copy of one rule; they now read one owner.

## The problem

`cart_seat_state`, `payment_fits_session` and `demote_to_waitlisted` each
hard-coded `('active','pending')` — the set of enrollment statuses that occupy
a seat. They agreed, which is the most fragile state a duplicated rule can be
in: nothing failed if one drifted, and every way of drifting is a money defect.

- `cart_seat_state` drifts → the cart misreads its own occupancy, and a sibling
  is waitlisted and refunded for a seat that was free.
- `payment_fits_session` drifts → the session oversells, or refunds a child
  whose seat existed.
- `demote_to_waitlisted` drifts → an admin's cancellation is un-done and its
  share re-owed on every redelivery.

This is not hypothetical. Leg 0's third review round found **three separate
disagreements between these same three functions** about how to treat
`cancelled`.

## The change

One sub, `Enrollment::seat_holding_statuses`, and three consumers that read it.
Production change is one file.

## Deviation from the spec

`docs/superpowers/specs/2026-08-18-payment-settlement-state-machine.md` §2.4
proposes a sub returning **counts by category**. What landed shares the **list**.

The three consumers ask genuinely different questions — one child's state,
everyone else's occupancy, and demotability — so a shared counts object would
have to be reshaped at each call site. The duplication was never the counting;
it was the literal appearing three times. Sharing the list gets the whole
benefit for a fraction of the diff. Recorded in the spec.

Deliberately **out of scope**: `get_dashboard_stats_for_parent` and the
family-enrollment query also count `('active','pending')`, but they answer
"what is this family signed up for" rather than "who holds a seat" — the same
answer today for a different reason. Coupling a display concern to the
settlement predicate would be worse than the duplication.

## Test evidence

Full suite: `Files=276, Tests=2374, Result: PASS`.

`t/dao/enrollment-seat-vocabulary.t` walks every status
`enrollments_status_check` permits and asserts all three consumers agree on
each one. **Mutation-verified four ways** — narrowing any single consumer fails
it, and so does narrowing the owner:

| Mutation | Result |
|---|---|
| `cart_seat_state` → `active` only | FAIL |
| `payment_fits_session` → `active` only | FAIL |
| `demote_to_waitlisted` → `active` only | FAIL |
| the owner itself → `active` only | FAIL |
| restored | PASS |

The test also reads the CHECK constraint at runtime and fails if the vocabulary
grows without a decision here — a new status would otherwise land in
`cart_seat_state`'s `closed` default silently, which is the safe direction only
by luck.

`t/stripe-live/` and `t/playwright/` were not run.

## Why this is a prerequisite

§2.2's `CHECK (refund_owed_cents <= amount_cents)` must not land before this.
The ordering is load-bearing: with a vocabulary disagreement still present, the
CHECK converts an overpayment into a **hard failure inside the settlement
transaction** — the debt re-accumulates on each redelivery until one violates
the constraint, throws, and rolls back `mark_completed` and the enrollments
with it. 500 to Stripe, retry into the same wall, family gets nothing.

Next after this is §2.3's conditional UPDATE, which is what lifts the
no-live-card gate carried by #317.

https://claude.ai/code/session_01UMLwCP8cMNQ2kc4LnfeVc2