### PR TITLE
PriceOps 2.3: every single-row write carries its own legality

### DIFF
--- a/lib/Registry/Controller/Webhooks.pm
+++ b/lib/Registry/Controller/Webhooks.pm
@@ -319,9 +319,17 @@ class Registry::Controller::Webhooks :isa(Registry::Controller) {
         # path: re-completed, re-demoted by the capacity gate below, and refunded
         # again. Redelivery makes this reachable without any concurrency, because
         # a retry carries a different event id and the dedup claim lets it past.
-        unless ( Registry::DAO::Payment->_money_has_moved( $payment->status ) ) {
-            $payment->mark_completed($db, $intent->{id});
-        }
+        # The write decides, and says so if it refuses. The _money_has_moved
+        # test above it and mark_completed's own predicate answer the same
+        # question, and agreeing by coincidence is exactly the two-classifiers
+        # shape this leg exists to remove -- so the guard is gone and the
+        # statement is the authority.
+        #
+        # payment_method is passed because save() used to carry that column and
+        # nothing else writes it.
+        $payment->mark_completed( $db, $intent->{id}, $intent->{payment_method} )
+            or $self->app->log->info(
+                "payment $payment_id not completed from status @{[ $payment->status ]}");
 
         # Non-zero when the capacity gate demoted someone: the caller refunds
         # after the COMMIT. Returns the payment id rather than the amount so the

--- a/lib/Registry/DAO/Payment.pm
+++ b/lib/Registry/DAO/Payment.pm
@@ -8,6 +8,7 @@ class Registry::DAO::Payment :isa(Registry::DAO::Object) {
 use Registry::Service::Stripe;
 use Registry::PriceOps::RevenueShare;
 use Mojo::JSON qw(encode_json decode_json);
+use experimental 'keyword_any';
 
 field $id :param :reader = undef;
 field $user_id :param :reader = undef;
@@ -253,10 +254,18 @@ field $_stripe_client = undef;
     # Every place that used to ask "is this completed?" to mean "has this been
     # settled?" has to ask this instead, or a later delivery walks a refunded
     # row back to completed and settles it again.
+    # The statuses in which money has moved, as a list the SQL can bind.
+    # _money_has_moved is the same set as a predicate; this is the same set as
+    # data. Two conditional writes were carrying it as a hardcoded SQL literal,
+    # which is a fifth and sixth encoding of "settled" in a file whose whole
+    # point is that there were already too many.
+    sub _settled_statuses ($class) {
+        return [qw( completed refunded partially_refunded refund_pending )];
+    }
+
     sub _money_has_moved ($class, $status) {
-        return ( $status // '' )
-            =~ /\A (?: completed | refunded | partially_refunded | refund_pending ) \z/x
-            ? 1 : 0;
+        my $s = $status // '';
+        return ( any { $_ eq $s } @{ $class->_settled_statuses } ) ? 1 : 0;
     }
 
     method _record_retrieval_failure ($db, $error) {
@@ -404,8 +413,17 @@ field $_stripe_client = undef;
                 };
             }
 
-            $stripe_payment_method_id = $intent->{payment_method};
-            $self->mark_completed($db, $stripe_payment_intent_id // $intent->{id});
+            # Branch on the write, not past it. Reporting success for a write
+            # the database refused is how a captured charge ends up recorded as
+            # something else while the caller carries on enrolling children.
+            unless ( $self->mark_completed( $db,
+                        $stripe_payment_intent_id // $intent->{id},
+                        $intent->{payment_method} ) ) {
+                return {
+                    success => 0,
+                    error   => "Payment could not be completed from status '$status'",
+                };
+            }
 
             return { success => 1, payment => $self };
         } elsif ($intent->{status} eq 'processing') {
@@ -918,35 +936,7 @@ SQL
         return $items;
     }
     
-    # Persist the current in-memory field values back to the database row.
-    # Called by state-mutation methods (refund, process_payment) after they
-    # update fields like $status, $metadata, $completed_at, and $error_message.
-    #
-    # Intentionally bypasses the inherited Registry::DAO::Object::update(), which
-    # silently carps and continues on database errors. Refund and payment state
-    # must fail loudly: a Stripe refund that succeeds but whose DB record was not
-    # updated would leave money in an inconsistent state.
-    method save ($db) {
-        $db = $db->db if $db isa Registry::DAO;
-        $db->update($self->table, {
-            status                   => $status,
-            stripe_payment_intent_id => $stripe_payment_intent_id,
-            stripe_payment_method_id => $stripe_payment_method_id,
-            metadata                 => { -json => ($metadata // {}) },
-            completed_at             => $completed_at,
-            error_message            => $error_message,
-        }, { id => $id });
-    }
 
-    # The one way a payment reaches 'completed'.  Both settlement paths call it,
-    # so a webhook-settled payment and a callback-settled one end up the same
-    # shape -- before this, only the callback path stamped completed_at and the
-    # webhook left it NULL on an otherwise identical row.
-    #
-    # Not a swap for the intent-recording writes: _record_intent stamps an id on
-    # a still-pending row and _record_intent_failure marks a failure.  Neither
-    # completes anything, and routing them through here would complete a payment
-    # at intent-creation time and again on failure.
     # status = 'failed', with its legality in the WHERE. Three call sites wrote
     # this: the two intent-creation failures and the retrieval failure. Each
     # guarded it differently -- one with _guard_settled_write, one with
@@ -988,17 +978,25 @@ SQL
     method _record_intent_id ($db, $intent_id) {
         $db = $db->db if $db isa Registry::DAO;
 
-        my $moved = $db->query( <<'SQL', $intent_id, $id )->rows;
+        my $moved = $db->query( <<'SQL', $intent_id, $id, __CLASS__->_settled_statuses )->rows;
             UPDATE payments SET stripe_payment_intent_id = ?
-             WHERE id = ?
-               AND status NOT IN ('completed','refunded','partially_refunded','refund_pending')
+             WHERE id = ? AND NOT (status = ANY(?))
 SQL
         return 0 unless $moved;
         $stripe_payment_intent_id = $intent_id;
         return 1;
     }
 
-    method mark_completed ($db, $payment_intent_id) {
+    # The one way a payment reaches 'completed'.  Both settlement paths call it,
+    # so a webhook-settled payment and a callback-settled one end up the same
+    # shape -- before this, only the callback path stamped completed_at and the
+    # webhook left it NULL on an otherwise identical row.
+    #
+    # Not a swap for the intent-recording writes: _record_intent stamps an id on
+    # a still-pending row and _record_intent_failure marks a failure.  Neither
+    # completes anything, and routing them through here would complete a payment
+    # at intent-creation time and again on failure.
+    method mark_completed ($db, $payment_intent_id, $payment_method_id = undef) {
         $db = $db->db if $db isa Registry::DAO;
 
         # Names three columns and carries its own legality. Zero rows is the
@@ -1007,10 +1005,17 @@ SQL
         # the in-memory object, so a walk-back was a restore of whatever that
         # object last held.
         my $from  = __CLASS__->_legal_predecessors('completed');
-        my $moved = $db->query( <<'SQL', $payment_intent_id, $id, $from )->rows;
+        # All binds on the <<'SQL' line: a continuation line after it is
+        # swallowed into the heredoc body.
+        my @bind = ( $payment_intent_id, $payment_method_id, $id, $from );
+        my $moved = $db->query( <<'SQL', @bind )->rows;
             UPDATE payments
                SET status = 'completed',
                    stripe_payment_intent_id = ?,
+                   -- COALESCE, so a caller with no method in hand does not
+                   -- erase one already recorded. save() carried this column and
+                   -- the first conversion dropped it entirely, silently.
+                   stripe_payment_method_id = COALESCE(?, stripe_payment_method_id),
                    completed_at = NOW()
              WHERE id = ?
                AND status = ANY(?)
@@ -1019,6 +1024,7 @@ SQL
 
         $status                   = 'completed';
         $stripe_payment_intent_id = $payment_intent_id;
+        $stripe_payment_method_id = $payment_method_id if $payment_method_id;
         return $self;
     }
 
@@ -1035,12 +1041,11 @@ SQL
         # row -- rather than read, decide, then save six columns from an object
         # that may have gone stale in between. Returns the new token, or undef
         # if the row was settled.
-        my $row = $db->query( <<'SQL', $id )->hash;
+        my $row = $db->query( <<'SQL', $id, __CLASS__->_settled_statuses )->hash;
             UPDATE payments
                SET metadata = jsonb_set( COALESCE(metadata, '{}'::jsonb),
                        '{idempotency_token}', to_jsonb(gen_random_uuid()::text) )
-             WHERE id = ?
-               AND status NOT IN ('completed','refunded','partially_refunded','refund_pending')
+             WHERE id = ? AND NOT (status = ANY(?))
          RETURNING metadata->>'idempotency_token' AS token
 SQL
         return unless $row;
@@ -1119,24 +1124,43 @@ SQL
     # undone safely: if such a state ever does arise, a gate that refuses to
     # adjudicate strands a paid-for child with no seat and no refund. Leaving
     # the row adjudicable is a no-op in every path we can find.
-    # Which statuses may precede which. The one place a state is added, and the
-    # WHERE clause of every status write is built from it.
+    # Which statuses may precede which, for the writes on the intent path.
+    #
+    # It covers those three and no more. An earlier version listed
+    # refund_pending, refunded and partially_refunded too, which no writer
+    # consulted and which contradicted the predicates the real refund writers
+    # use -- record_capacity_obligation and _apply_refund_result carry headroom
+    # and increment conditions this table cannot express. A table that is half
+    # documentation and half false is worse than a smaller true one, in the
+    # place a future author will trust.
     #
     # This is what section 2.3 of the settlement spec keeps from the state
     # table: a pure predicate, not a god-method taking an untyped column bag
     # through which {status => 'completed'} would bypass the machine entirely.
     # Each write still names its own columns; only legality is shared.
     sub _legal_predecessors ($class, $to = undef) {
+        # 'failed' is NOT terminal here, and treating it as such strands
+        # captured money. _apply_intent writes 'failed' for any intent status it
+        # does not recognise -- including requires_action, an ordinary 3DS
+        # payment mid-authentication -- and the decline-retry path deliberately
+        # reuses the same row rather than orphaning it. Both legitimately reach
+        # completed when the money lands. Refusing that leaves a charge Stripe
+        # took sitting at 'failed' with completed_at NULL, outside
+        # _refundable_status and so unrefundable forever, while
+        # finalize_enrollment still seats the child.
+        #
+        # failed -> failed is legal because each decline must record its own
+        # reason; refusing it showed the parent the previous card's error.
         state $graph = {
-            processing         => [qw( pending )],
-            completed          => [qw( pending processing )],
-            failed             => [qw( pending processing )],
-            refund_pending     => [qw( completed refund_pending )],
-            refunded           => [qw( refund_pending partially_refunded )],
-            partially_refunded => [qw( refund_pending )],
+            processing         => [qw( pending failed )],
+            completed          => [qw( pending processing failed )],
+            failed             => [qw( pending processing failed )],
         };
         return $graph unless defined $to;
-        return $graph->{$to} // [];
+        # die, not `// []`. An empty list makes `status = ANY('{}')` -- a writer
+        # that refuses every row, silently, which is the worst possible response
+        # to a typo in a status name.
+        return $graph->{$to} // die "no transition rule for status '$to'\n";
     }
 
     sub _money_returned ($class, $status) {

--- a/lib/Registry/DAO/Payment.pm
+++ b/lib/Registry/DAO/Payment.pm
@@ -209,38 +209,11 @@ field $_stripe_client = undef;
         };
     }
 
-    # Stamp the created intent onto the payment row and hand back the pair the
-    # checkout form needs.
-    # save rather than update: the inherited update() carps and continues on a
-    # database error, so a Stripe intent that exists but was never recorded
-    # would pass silently and the parent would be charged against a row that
-    # does not know its own intent id. Note this stays 'pending' -- recording an
-    # intent is not completing a payment.
-    # Every whole-row write to a payment takes the lock, re-reads under it, and
-    # refuses a row whose money has already moved.
-    #
-    # save() writes six columns from the in-memory object. From a stale object
-    # that is not a field update, it is a whole-row restore: the old status, a
-    # nulled completed_at, a superseded intent id. The decline-retry path
-    # produces exactly such an object -- it cancels the old intent over the
-    # network, outside any transaction, and a webhook can capture the payment
-    # while that round trip is in flight. The retry then walks the captured row
-    # back to pending and hands the parent a live card form for money already
-    # taken.
-    method _guard_settled_write ($db, $what) {
-        $self->_lock_and_refresh($db)
-            or die "$what: payment $id no longer exists\n";
-        return 0 if __CLASS__->_money_has_moved($status);
-        return 1;
-    }
 
     method _record_intent ($db, $intent) {
-        return { client_secret => $intent->{client_secret},
-                 payment_intent_id => $intent->{id} }
-            unless $self->_guard_settled_write( $db, '_record_intent' );
-
-        $stripe_payment_intent_id = $intent->{id};
-        $self->save($db);
+        # The refusal and the write are one statement now: no lock, no refresh,
+        # and no window between deciding and doing.
+        $self->_record_intent_id( $db, $intent->{id} );
 
         return {
             client_secret => $intent->{client_secret},
@@ -253,13 +226,7 @@ field $_stripe_client = undef;
     method _record_intent_failure ($db, $error) {
         # A row whose money has moved is not failed by a later decline: the
         # webhook that captured it wins over an in-flight retry.
-        unless ( $self->_guard_settled_write( $db, '_record_intent_failure' ) ) {
-            die "Failed to create payment intent: $error";
-        }
-
-        $error_message = $error;
-        $status = 'failed';
-        $self->save($db);
+        $self->_record_intent_failure_write( $db, $error );
         die "Failed to create payment intent: $error";
     }
 
@@ -310,9 +277,7 @@ field $_stripe_client = undef;
             };
         }
 
-        $error_message = $error;
-        $status = 'failed';
-        $self->save($db);
+        $self->_record_intent_failure_write( $db, $error );
         return { success => 0, error => $error };
     }
 
@@ -375,6 +340,11 @@ field $_stripe_client = undef;
     }
 
     method _apply_intent ($db, $intent, $payment_intent_id) {
+        # Still refreshed, for the READ decisions below -- the ownership check
+        # and the already-settled report both need current data to answer
+        # correctly. The WRITES no longer depend on it: each carries its own
+        # legality, so a decision made on stale data is refused by the statement
+        # rather than acted on. _guard_settled_write is gone with them.
         $self->_lock_and_refresh($db);
 
         # The posted intent id is client-controlled: only honor an intent that
@@ -439,14 +409,12 @@ field $_stripe_client = undef;
 
             return { success => 1, payment => $self };
         } elsif ($intent->{status} eq 'processing') {
-            $status = 'processing';
-            $self->save($db);
+            $self->_record_processing($db);
 
             return { success => 0, processing => 1 };
         } else {
-            $status = 'failed';
-            $error_message = $intent->{last_payment_error}->{message} // 'Payment failed';
-            $self->save($db);
+            $self->_record_intent_failure_write( $db,
+                $intent->{last_payment_error}->{message} // 'Payment failed' );
 
             # Surface the raw intent status: the caller must distinguish a true
             # decline (requires_payment_method) from a customer mid-3DS
@@ -979,27 +947,106 @@ SQL
     # a still-pending row and _record_intent_failure marks a failure.  Neither
     # completes anything, and routing them through here would complete a payment
     # at intent-creation time and again on failure.
+    # status = 'failed', with its legality in the WHERE. Three call sites wrote
+    # this: the two intent-creation failures and the retrieval failure. Each
+    # guarded it differently -- one with _guard_settled_write, one with
+    # _money_has_moved, one not at all -- which is how a failure branch once
+    # routed into the success path. One writer, one predicate.
+    method _record_intent_failure_write ($db, $error) {
+        $db = $db->db if $db isa Registry::DAO;
+
+        my $from  = __CLASS__->_legal_predecessors('failed');
+        my $moved = $db->query( <<'SQL', $error, $id, $from )->rows;
+            UPDATE payments
+               SET status = 'failed', error_message = ?
+             WHERE id = ? AND status = ANY(?)
+SQL
+        return 0 unless $moved;
+
+        $status        = 'failed';
+        $error_message = $error;
+        return 1;
+    }
+
+    # status = 'processing'. Same shape; only pending may precede it.
+    method _record_processing ($db) {
+        $db = $db->db if $db isa Registry::DAO;
+
+        my $from  = __CLASS__->_legal_predecessors('processing');
+        my $moved = $db->query( <<'SQL', $id, $from )->rows;
+            UPDATE payments SET status = 'processing'
+             WHERE id = ? AND status = ANY(?)
+SQL
+        return 0 unless $moved;
+        $status = 'processing';
+        return 1;
+    }
+
+    # The intent id, which is not a status transition: it is legal exactly while
+    # the money has not moved. Named alone, so it cannot restore five other
+    # columns from a stale object on its way past.
+    method _record_intent_id ($db, $intent_id) {
+        $db = $db->db if $db isa Registry::DAO;
+
+        my $moved = $db->query( <<'SQL', $intent_id, $id )->rows;
+            UPDATE payments SET stripe_payment_intent_id = ?
+             WHERE id = ?
+               AND status NOT IN ('completed','refunded','partially_refunded','refund_pending')
+SQL
+        return 0 unless $moved;
+        $stripe_payment_intent_id = $intent_id;
+        return 1;
+    }
+
     method mark_completed ($db, $payment_intent_id) {
+        $db = $db->db if $db isa Registry::DAO;
+
+        # Names three columns and carries its own legality. Zero rows is the
+        # refusal, by construction -- no lock, no prior read, and no return
+        # shape a caller can misread as success. save() wrote six columns from
+        # the in-memory object, so a walk-back was a restore of whatever that
+        # object last held.
+        my $from  = __CLASS__->_legal_predecessors('completed');
+        my $moved = $db->query( <<'SQL', $payment_intent_id, $id, $from )->rows;
+            UPDATE payments
+               SET status = 'completed',
+                   stripe_payment_intent_id = ?,
+                   completed_at = NOW()
+             WHERE id = ?
+               AND status = ANY(?)
+SQL
+        return 0 unless $moved;
+
         $status                   = 'completed';
         $stripe_payment_intent_id = $payment_intent_id;
-        $completed_at             = \'NOW()';
-        $self->save($db);
         return $self;
     }
 
     # Replace the idempotency token with a fresh UUID and persist immediately.
     # Call this before retrying a declined intent so the retry is a genuinely
     # new Stripe charge rather than a duplicate of the failed one.
+    # The token, alone. Legal exactly while the money has not moved -- and the
+    # refusal is the same statement as the write, so nothing can settle between
+    # the two.
     method rotate_idempotency_token ($db) {
-        # Rotating the token on a settled row would save() the stale object
-        # over a captured payment. Nothing to rotate once the money moved.
-        return unless $self->_guard_settled_write( $db, 'rotate_idempotency_token' );
-
         $db = $db->db if $db isa Registry::DAO;
-        $metadata->{idempotency_token} = $db->query(
-            'SELECT gen_random_uuid()::text AS uuid'
-        )->hash->{uuid};
-        $self->save($db);
+
+        # One statement: generate, merge into the jsonb, and refuse a settled
+        # row -- rather than read, decide, then save six columns from an object
+        # that may have gone stale in between. Returns the new token, or undef
+        # if the row was settled.
+        my $row = $db->query( <<'SQL', $id )->hash;
+            UPDATE payments
+               SET metadata = jsonb_set( COALESCE(metadata, '{}'::jsonb),
+                       '{idempotency_token}', to_jsonb(gen_random_uuid()::text) )
+             WHERE id = ?
+               AND status NOT IN ('completed','refunded','partially_refunded','refund_pending')
+         RETURNING metadata->>'idempotency_token' AS token
+SQL
+        return unless $row;
+
+        $metadata->{idempotency_token} = $row->{token};
+        return $row->{token};
     }
 
     # One child's share of a family cart.
@@ -1072,6 +1119,26 @@ SQL
     # undone safely: if such a state ever does arise, a gate that refuses to
     # adjudicate strands a paid-for child with no seat and no refund. Leaving
     # the row adjudicable is a no-op in every path we can find.
+    # Which statuses may precede which. The one place a state is added, and the
+    # WHERE clause of every status write is built from it.
+    #
+    # This is what section 2.3 of the settlement spec keeps from the state
+    # table: a pure predicate, not a god-method taking an untyped column bag
+    # through which {status => 'completed'} would bypass the machine entirely.
+    # Each write still names its own columns; only legality is shared.
+    sub _legal_predecessors ($class, $to = undef) {
+        state $graph = {
+            processing         => [qw( pending )],
+            completed          => [qw( pending processing )],
+            failed             => [qw( pending processing )],
+            refund_pending     => [qw( completed refund_pending )],
+            refunded           => [qw( refund_pending partially_refunded )],
+            partially_refunded => [qw( refund_pending )],
+        };
+        return $graph unless defined $to;
+        return $graph->{$to} // [];
+    }
+
     sub _money_returned ($class, $status) {
         return ( $status // '' )
             =~ /\A (?: refunded | partially_refunded ) \z/x

--- a/t/dao/payment-conditional-write.t
+++ b/t/dao/payment-conditional-write.t
@@ -42,9 +42,17 @@ subtest 'the transition graph is the one source of legality' => sub {
     my $g = Registry::DAO::Payment->_legal_predecessors;
 
     is ref $g, 'HASH', 'it is a table, not scattered literals';
-    is_deeply [ sort keys %$g ],
-        [ sort qw( processing completed failed refund_pending refunded partially_refunded ) ],
-        'covering every status the code writes';
+    is_deeply [ sort keys %$g ], [ sort qw( processing completed failed ) ],
+        'covering the intent path, and claiming no more than that';
+
+    # Deliberately NOT the refund statuses. Their writers carry headroom and
+    # increment predicates this table cannot express, and an earlier version
+    # listed them anyway -- unconsulted, and contradicting those writers in four
+    # of six cases. A table half documentation and half false is worse than a
+    # smaller true one, in the place a future author will trust.
+    my @refund_states = qw( refund_pending refunded partially_refunded );
+    is scalar( grep { exists $g->{$_} } @refund_states ), 0,
+        'and not claiming authority over the refund writers it does not govern';
 
     # Every status named as a predecessor must itself be a status the CHECK
     # permits, or the graph describes transitions the database refuses.
@@ -63,14 +71,21 @@ subtest 'the transition graph is the one source of legality' => sub {
 # success.
 subtest 'an illegal transition is refused, and the refusal is unambiguous' => sub {
     # completed <- pending|processing only. A refunded row must not be walked back.
-    for my $from (qw( refunded partially_refunded refund_pending completed failed )) {
+    for my $from (qw( refunded partially_refunded refund_pending completed )) {
         my $p = a_payment($from);
         ok !$p->mark_completed( $db, 'pi_walkback' ),
             "mark_completed refuses a '$from' row, and reports the refusal";
         is status_of($p), $from, "and '$from' is left alone";
     }
 
-    for my $from (qw( pending processing )) {
+    # 'failed' belongs here, not above. _apply_intent writes 'failed' for any
+    # intent status it does not recognise -- including requires_action, which is
+    # an ordinary 3DS payment mid-authentication -- and the decline-retry path
+    # deliberately reuses the same row. Both then legitimately reach completed
+    # when the money lands, and refusing that strands a CAPTURED payment at
+    # 'failed' with completed_at NULL and _refundable_status false: unrefundable
+    # forever, while finalize_enrollment still seats the child.
+    for my $from (qw( pending processing failed )) {
         my $p = a_payment($from);
         ok $p->mark_completed( $db, 'pi_ok' ), "mark_completed accepts '$from'";
         is status_of($p), 'completed', "and '$from' reaches completed";
@@ -105,6 +120,163 @@ subtest 'a write touches only the columns it names' => sub {
     is $row->{error_message}, 'set by someone else',
         'and a column it does not name is not restored from a stale object';
     is $row->{metadata}{keep}, 'me', 'nor is the metadata blob rewritten';
+};
+
+# The columns save() used to carry that the conditional writes must not drop.
+subtest 'completing a payment records the method it was paid with' => sub {
+    my $p = a_payment('pending');
+    $db->update('payments', { stripe_payment_method_id => undef }, { id => $p->id });
+
+    $p->mark_completed( $db, 'pi_pm', 'pm_card_visa' );
+
+    is $db->select('payments', ['stripe_payment_method_id'], { id => $p->id })
+        ->hash->{stripe_payment_method_id}, 'pm_card_visa',
+        'the payment method is written -- save() carried this column and the '
+        . 'first conversion dropped it silently';
+};
+
+# A refusal the caller discards is a caller reporting success for work that did
+# not happen.
+subtest 'a refused completion is reported to the caller, not swallowed' => sub {
+    my $p = a_payment('refunded');
+    my $out = $p->_apply_intent( $db,
+        { id => 'pi_refused', status => 'succeeded', amount => 10000,
+          metadata => { payment_id => $p->id } },
+        'pi_refused' );
+
+    ok !$out->{success}, 'the caller is told the settlement did not happen';
+    is status_of($p), 'refunded', 'and the row is untouched';
+};
+
+# Each decline must record its own reason. failed -> failed being illegal left
+# the second decline showing the first one's message.
+subtest 'a second decline records its own error, not the first one' => sub {
+    my $p = a_payment('pending');
+    $p->_record_intent_failure_write( $db, 'insufficient_funds' );
+    $p->_record_intent_failure_write( $db, 'expired_card' );
+
+    is $db->select('payments', ['error_message'], { id => $p->id })->hash->{error_message},
+        'expired_card',
+        'the parent is shown the card that just failed, not the previous one';
+};
+
+# The two routes that reach mark_completed from 'failed'. Neither was graded,
+# which is how a conversion that refuses both passed nineteen payment files.
+subtest '3DS: a row written failed by requires_action still completes' => sub {
+    my $p = a_payment('pending');
+
+    # _apply_intent writes 'failed' for any status it does not recognise, and
+    # requires_action is an ordinary 3DS payment mid-authentication.
+    my $out = $p->_apply_intent( $db,
+        { id => 'pi_3ds', status => 'requires_action', amount => 10000,
+          metadata => { payment_id => $p->id } }, 'pi_3ds' );
+    ok !$out->{success}, 'the intent is not settled yet';
+    is status_of($p), 'failed', 'and the row is written failed (pre-existing)';
+
+    # The parent authenticates off-site and Stripe fires payment_intent.succeeded.
+    my $fresh = Registry::DAO::Payment->find($db, { id => $p->id });
+    ok $fresh->mark_completed( $db, 'pi_3ds', 'pm_3ds' ),
+        'the later webhook completes it';
+    is status_of($p), 'completed',
+        'so a captured 3DS charge is not stranded at failed, unrefundable';
+};
+
+subtest 'decline then retry: the reused row still completes' => sub {
+    my $p = a_payment('pending');
+    $p->_record_intent_failure_write( $db, 'card_declined' );
+    is status_of($p), 'failed', 'the decline is recorded';
+
+    # WorkflowSteps/Payment reuses the same row rather than orphaning it.
+    my $fresh = Registry::DAO::Payment->find($db, { id => $p->id });
+    ok $fresh->mark_completed( $db, 'pi_retry', 'pm_good_card' ),
+        'the good card completes the same row';
+    is status_of($p), 'completed', 'and the parent is not charged into a failed row';
+};
+
+subtest 'a retry that goes to processing is not reported against a refused write' => sub {
+    my $p = a_payment('failed');
+    my $out = $p->_apply_intent( $db,
+        { id => 'pi_proc', status => 'processing', amount => 10000,
+          metadata => { payment_id => $p->id } }, 'pi_proc' );
+
+    is status_of($p), 'processing',
+        'the row really moves, so "please wait" is not shown against a dead row';
+    ok $out->{processing}, 'and the caller is told to wait';
+};
+
+# Eight of eighteen mutants survived the first pass here. These are them.
+#
+# The in-memory field updates were entirely ungraded: a writer could stop
+# refreshing $status and nothing noticed, leaving the object disagreeing with
+# the row it just wrote -- and callers read those fields to decide what to do
+# next.
+subtest 'a successful write leaves the object agreeing with the row' => sub {
+    my $p = a_payment('pending');
+    $p->mark_completed( $db, 'pi_mem', 'pm_mem' );
+    is $p->status, 'completed', 'mark_completed refreshes the status it wrote';
+    is $p->stripe_payment_intent_id, 'pi_mem', 'and the intent id';
+    is $p->stripe_payment_method_id, 'pm_mem', 'and the payment method';
+
+    my $q = a_payment('pending');
+    $q->_record_intent_failure_write( $db, 'declined_here' );
+    is $q->status, 'failed', 'the failure writer refreshes its status';
+    is $q->error_message, 'declined_here', 'and its message';
+
+    my $r = a_payment('pending');
+    $r->_record_processing($db);
+    is $r->status, 'processing', 'and the processing writer refreshes its status';
+
+    my $t = a_payment('pending');
+    $t->_record_intent_id( $db, 'pi_stamped' );
+    is $t->stripe_payment_intent_id, 'pi_stamped', 'as does the intent stamp';
+};
+
+# A refused write must NOT refresh the object -- that is how a caller comes to
+# believe a transition happened that the database rejected.
+subtest 'a refused write leaves the object alone' => sub {
+    my $p = a_payment('refunded');
+    $p->mark_completed( $db, 'pi_no', 'pm_no' );
+    is $p->status, 'refunded', 'the object still reports what the row holds';
+    isnt $p->stripe_payment_intent_id, 'pi_no', 'and did not take the refused id';
+};
+
+# _record_processing was new in this change and had no coverage of either its
+# predicate or its write.
+subtest 'processing is reachable only from pending or failed' => sub {
+    for my $from (qw( pending failed )) {
+        my $p = a_payment($from);
+        ok $p->_record_processing($db), "'$from' may move to processing";
+        is status_of($p), 'processing', "and '$from' does";
+    }
+    for my $from (qw( completed refunded partially_refunded )) {
+        my $p = a_payment($from);
+        ok !$p->_record_processing($db), "'$from' may not";
+        is status_of($p), $from, "and '$from' is untouched";
+    }
+};
+
+# rotate_idempotency_token's settled guard had no test at all: deleting it let a
+# completed row rotate its token, and the file that claims to grade this asserts
+# only columns rotate does not write.
+subtest 'a settled payment does not rotate its idempotency token' => sub {
+    for my $status (qw( completed refunded partially_refunded refund_pending )) {
+        my $p = a_payment($status);
+        my $before = $db->select('payments', ['metadata'], { id => $p->id })
+            ->expand->hash->{metadata}{idempotency_token};
+
+        ok !$p->rotate_idempotency_token($db),
+            "a '$status' row refuses to rotate, and says so";
+        is $db->select('payments', ['metadata'], { id => $p->id })
+            ->expand->hash->{metadata}{idempotency_token}, $before,
+            "and its token is unchanged ($status)";
+    }
+
+    my $p = a_payment('pending');
+    my $before = $db->select('payments', ['metadata'], { id => $p->id })
+        ->expand->hash->{metadata}{idempotency_token};
+    my $token = $p->rotate_idempotency_token($db);
+    ok $token, 'a pending row rotates and returns the new token';
+    isnt $token, $before, 'which is actually new';
 };
 
 done_testing;

--- a/t/dao/payment-conditional-write.t
+++ b/t/dao/payment-conditional-write.t
@@ -1,0 +1,110 @@
+#!/usr/bin/env perl
+# ABOUTME: Every single-row payment write carries its own legality in the WHERE clause.
+# ABOUTME: Zero rows is the refusal -- not a return shape a caller can misread.
+BEGIN { $ENV{EMAIL_SENDER_TRANSPORT} = 'Test' }
+
+use 5.42.0;
+use warnings;
+use lib qw(lib t/lib);
+use Test::More;
+use Test::Registry::DB;
+use Registry::DAO::Payment;
+
+local $ENV{STRIPE_SECRET_KEY} = 'sk_test_conditional_write';
+
+my $test_db = Test::Registry::DB->new;
+my $dao     = $test_db->db;
+my $db      = $dao->db;
+
+my $parent = $dao->create(User => {
+    username => 'cw_parent', name => 'CW Parent', user_type => 'parent',
+    email => 'cw@test.local' });
+
+my $n = 0;
+sub a_payment ($status = 'pending') {
+    $n++;
+    my $p = Registry::DAO::Payment->create($db, {
+        user_id => $parent->id, amount_cents => 10000, status => 'pending',
+        metadata => { enrollment_items => [], tenant_slug => undef } });
+    $db->update('payments',
+        { status => $status, stripe_payment_intent_id => "pi_cw_$n" },
+        { id => $p->id });
+    return Registry::DAO::Payment->find($db, { id => $p->id });
+}
+sub status_of ($p) {
+    $db->select('payments', ['status'], { id => $p->id })->hash->{status}
+}
+
+# The graph is the single place a state is added, and every status write builds
+# its WHERE from it. Asserted directly so a caller cannot quietly grow its own
+# opinion -- which is how this path accumulated two classifiers that disagreed.
+subtest 'the transition graph is the one source of legality' => sub {
+    my $g = Registry::DAO::Payment->_legal_predecessors;
+
+    is ref $g, 'HASH', 'it is a table, not scattered literals';
+    is_deeply [ sort keys %$g ],
+        [ sort qw( processing completed failed refund_pending refunded partially_refunded ) ],
+        'covering every status the code writes';
+
+    # Every status named as a predecessor must itself be a status the CHECK
+    # permits, or the graph describes transitions the database refuses.
+    my $allowed = $db->query(q{
+        SELECT pg_get_constraintdef(oid) FROM pg_constraint
+         WHERE conname = 'payments_status_check'})->array->[0];
+    my %in_db = map { $_ => 1 } ( $allowed =~ /'([a-z_]+)'::/g );
+    for my $to ( sort keys %$g ) {
+        my @unknown = grep { !$in_db{$_} } @{ $g->{$to} };
+        is scalar @unknown, 0, "every predecessor of '$to' is a real status";
+    }
+};
+
+# The point of the whole design: a write that is not legal moves nothing, and
+# says so by touching zero rows rather than by a return value shaped like
+# success.
+subtest 'an illegal transition is refused, and the refusal is unambiguous' => sub {
+    # completed <- pending|processing only. A refunded row must not be walked back.
+    for my $from (qw( refunded partially_refunded refund_pending completed failed )) {
+        my $p = a_payment($from);
+        ok !$p->mark_completed( $db, 'pi_walkback' ),
+            "mark_completed refuses a '$from' row, and reports the refusal";
+        is status_of($p), $from, "and '$from' is left alone";
+    }
+
+    for my $from (qw( pending processing )) {
+        my $p = a_payment($from);
+        ok $p->mark_completed( $db, 'pi_ok' ), "mark_completed accepts '$from'";
+        is status_of($p), 'completed', "and '$from' reaches completed";
+    }
+};
+
+subtest 'a completed row cannot be failed by a later decline' => sub {
+    my $p = a_payment('completed');
+    ok !$p->_record_intent_failure_write( $db, 'card_declined' ),
+        'the failure write is refused';
+    is status_of($p), 'completed', 'and the captured payment stands';
+
+    my $q = a_payment('pending');
+    ok $q->_record_intent_failure_write( $db, 'card_declined' ),
+        'while a pending row does fail';
+    is status_of($q), 'failed', 'and reaches failed';
+};
+
+# The columns a write does not name must survive it. save() wrote six columns
+# from the in-memory object, so any stale field silently restored an old value.
+subtest 'a write touches only the columns it names' => sub {
+    my $p = a_payment('pending');
+    $db->update('payments', {
+        error_message => 'set by someone else',
+        metadata      => { -json => { keep => 'me', enrollment_items => [] } },
+    }, { id => $p->id });
+
+    $p->mark_completed( $db, 'pi_narrow' );
+
+    my $row = $db->select('payments', '*', { id => $p->id })->expand->hash;
+    is $row->{status}, 'completed', 'the named column changed';
+    is $row->{error_message}, 'set by someone else',
+        'and a column it does not name is not restored from a stale object';
+    is $row->{metadata}{keep}, 'me', 'nor is the metadata blob rewritten';
+};
+
+done_testing;

--- a/t/dao/payment-lock-refresh.t
+++ b/t/dao/payment-lock-refresh.t
@@ -55,9 +55,10 @@ sub settle_after_concurrent_write ($payment, $writer) {
 }
 
 subtest 'a concurrent manual-review flag survives this settlement save' => sub {
-    # save() writes the whole metadata blob from the in-memory object, so a
-    # settlement that loaded the row before another pass wrote to metadata will
-    # clobber it. This used to seed refund_owed_cents, which no longer lives in
+    # Retained as a regression guard on the CONDITIONAL writes: none of them
+    # names metadata, so a flag written concurrently must survive. save() -- the
+    # whole-row write this once guarded against -- is gone, and if a future
+    # writer starts naming metadata again this is what notices. This used to seed refund_owed_cents, which no longer lives in
     # metadata -- the assertion still passed but graded nothing. The flag is
     # what save() can still destroy, and losing it loses the only record that a
     # share needs a human.

--- a/t/dao/payment-write-guards.t
+++ b/t/dao/payment-write-guards.t
@@ -80,11 +80,22 @@ subtest 'recording an intent failure does not fail a settled payment' => sub {
 subtest 'rotating the idempotency token does not resurrect a settled payment' => sub {
     my $stale = stale_after_settlement('completed');
 
-    eval { $stale->rotate_idempotency_token($db); 1 };
+    # ->expand, because row_of does not: metadata comes back as raw JSON text.
+    my $token_of = sub {
+        $db->select('payments', ['metadata'], { id => $stale->id })
+           ->expand->hash->{metadata}{idempotency_token};
+    };
+    my $before = $token_of->();
+    my $out = eval { $stale->rotate_idempotency_token($db) };
 
     my $row = row_of($stale);
-    is $row->{status}, 'completed', 'the settled status survives a token rotation';
-    ok defined $row->{completed_at}, 'and so does completed_at';
+    # Asserted on the column rotate actually writes. The status and completed_at
+    # assertions this replaces could not fail once rotate stopped writing six
+    # columns -- they passed whether or not the guard existed, which mutation
+    # proved by deleting it.
+    is $token_of->(), $before, 'the token is not rotated on a settled row';
+    ok !$out, 'and the refusal is reported to the caller';
+    is $row->{status}, 'completed', 'the settled status survives';
 };
 
 subtest 'a still-pending payment is unaffected by the guards' => sub {


### PR DESCRIPTION
The last piece before the no-live-card gate lifts, and the one that addresses
the property behind all **81 defects** the previous five review rounds found:
the settlement path had no state machine, so a write's safety depended on which
caller it arrived from.

Two files, +232/−55.

## The change

Every single-row payment write now names **only the columns it changes** and
carries its legality in the `WHERE`:

```sql
UPDATE payments SET status = 'completed', stripe_payment_intent_id = ?, completed_at = NOW()
 WHERE id = ? AND status = ANY(?)
```

`->rows == 0` is the refusal — by construction. No lock, no prior read, no
return shape a caller can misread as success.

**Seven `save()` sites converted. Zero whole-row writes remain on the payment
path.**

That matters because `save()` wrote six columns from the in-memory object, so
from a *stale* object it was a **restore, not an update** — a walk-back put back
whatever that object last held. A conditional UPDATE cannot do that; it names
three columns and touches nothing else.

## One shared thing

`_legal_predecessors` — a table of which statuses may precede which. Every
status write builds its `WHERE` from it, so there is one place to add a state.

This is what §2.3 keeps from the state table: a **pure predicate**, not the
god-method with an untyped `$changes` bag an earlier draft proposed, through
which `{status => 'completed'}` would have bypassed the machine entirely.

## Three copies of one rule became one

The `failed` write existed at three call sites, each guarded differently — one
with `_guard_settled_write`, one with `_money_has_moved`, one not at all. That
asymmetry is how a failure branch once routed into the success path.

## What was deleted

`_guard_settled_write` is gone. It is the mechanism these writes replace, and
`payment-write-guards.t` still passes because it grades *behaviour*, not the
method.

`_lock_and_refresh` survives only where it feeds **read** decisions — the
ownership check and the already-settled report need current data. The writes no
longer care: a decision made on stale data is refused by the statement rather
than acted on.

## Adversarial review: eleven findings in two files

I opened this describing it as "small and mostly deletion." Two lenses found
eleven defects, two of them money-critical, and both were the exact failure the
conversion invited: **a predicate too narrow refuses legitimate work.**

- **`failed` was treated as terminal**, but this codebase uses it as "retry on
  this row." `_apply_intent` writes `failed` for *any* intent status it does not
  recognise — including `requires_action`, an ordinary 3DS payment
  mid-authentication — and the decline path deliberately reuses the same row.
  Both legitimately reach `completed` when the money lands. `save()` on main
  wrote unconditionally and healed it; the conditional write refused. Stripe
  took the money, `finalize_enrollment` still seated the child, and the row sat
  at `failed` with `completed_at` NULL — outside `_refundable_status`, so
  **unrefundable forever.** Reproduced at the DAO level and through the real
  `/webhooks/stripe` route.
- **`stripe_payment_method_id` stopped being written by anything.** `save()`
  carried six columns; `mark_completed` named three, and `save()` is now dead.
  Straight happy path.
- **Both call sites discarded the refusal**, reporting `success => 1` for a
  write the database rejected.

Two more worth stating because they are about this PR's own thesis:

**It added two encodings of "settled" while claiming to consolidate them** — two
hardcoded `NOT IN ('completed','refunded','partially_refunded','refund_pending')`
SQL literals, a fifth and sixth encoding of one set. Both now bind
`_settled_statuses`, which `_money_has_moved` reads too.

**Half the transition graph was dead and contradicted the real writers.** The
refund entries were never consulted and disagreed with
`record_capacity_obligation` in four of six cases. Removed — the graph claims
the intent path and no more, because a table half documentation and half false
is worse than a smaller true one in the place a future author will trust.

### Eight of eighteen mutants survived the first pass

All now graded. The largest was `rotate_idempotency_token`'s settled guard:
deletable with the suite green, while the file claiming to grade it asserted
only columns that method no longer writes. **The conversion silently invalidated
older tests** — narrowing what each write touches made assertions on columns
those writes no longer name unfalsifiable. Nothing flags that class of rot; it
took mutation to find.

New coverage for the two routes that reach `mark_completed` from `failed` — 3DS
and decline-retry — the gap that let the critical through nineteen payment
files.

## Test evidence

Full suite: `Files=280, Tests=2412, Result: PASS`.

`t/dao/payment-conditional-write.t` asserts the graph is the single source of
legality, that every predecessor it names is a status `payments_status_check`
actually permits, that an illegal transition is refused unambiguously, and that
a write leaves columns it does not name alone.

Mutation-verified — all three fail:

| Mutation | |
|---|---|
| drop `mark_completed`'s `WHERE` predicate | FAIL |
| widen the graph so `completed` accepts anything | FAIL |
| drop the failure write's predicate | FAIL |

`t/stripe-live/` and `t/playwright/` were not run.

## The gate

With this and #321 merged, the two conditions the Leg 0 gate names are met: the
status CHECK constraint (#321) and the conditional-UPDATE write path (here).

I would not lift it on my own say-so. #321 went through five adversarial review
rounds in which **every critical defect was introduced by a previous round's
fix** — that history argues for a review of this PR before the gate comes off,
not for trusting a green suite.

## What this does not change

`finalize_enrollment` keeps its transaction and its session locks. It is
multi-row work — session locks, enrollment writes, the obligation — and
genuinely needs both. The conditional UPDATE replaces the *single-row* guards.

https://claude.ai/code/session_01UMLwCP8cMNQ2kc4LnfeVc2
