### PR TITLE
A seat held by another payment is visible to the cart adjudicating against it

### DIFF
--- a/lib/Registry/DAO/Enrollment.pm
+++ b/lib/Registry/DAO/Enrollment.pm
@@ -254,6 +254,7 @@ class Registry::DAO::Enrollment :isa(Registry::DAO::Object) {
     sub cart_seat_state ($class, $db, $payment_id, $session_id, $child_id) {
         $db = $db->db if $db isa Registry::DAO;
 
+        # Our own row first: its state is what this cart holds.
         my $row = $db->select(
             $class->table, ['status'],
             {   payment_id => $payment_id,
@@ -262,13 +263,34 @@ class Registry::DAO::Enrollment :isa(Registry::DAO::Object) {
             },
         )->hash;
 
-        return 'none' unless $row;
+        if ($row) {
+            my $status = $row->{status} // '';
+            return 'seated'
+                if any { $_ eq $status } @{ $class->seat_holding_statuses };
+            return 'waitlisted' if $status eq 'waitlisted';
+            return 'closed';
+        }
 
-        my $status = $row->{status} // '';
-        return 'seated'
-            if any { $_ eq $status } @{ $class->seat_holding_statuses };
-        return 'waitlisted' if $status eq 'waitlisted';
-        return 'closed';
+        # No row of ours -- but the child may already hold a live seat from a
+        # DIFFERENT payment: a free enrolment with payment_id IS NULL, an admin
+        # add, an earlier purchase. Scoping this lookup by payment_id made that
+        # read as 'none', so the caller adjudicated as though the child were
+        # unseated and tried to insert -- colliding with the live-only
+        # uniqueness rule inside a settlement Stripe had already captured.
+        #
+        # 'foreign', not 'seated': payment_fits_session already counts foreign
+        # rows in $taken, so crediting one to this cart's %granted would count
+        # the same seat twice and under-count the capacity left for the next
+        # sibling in the cart.
+        my $elsewhere = $db->select(
+            $class->table, ['status'],
+            {   session_id => $session_id,
+                student_id => $child_id,
+                status     => { -in => $class->seat_holding_statuses },
+            },
+        )->hash;
+
+        return $elsewhere ? 'foreign' : 'none';
     }
 
     # Move a paid child to the waitlist because the seat went while they paid.

--- a/lib/Registry/DAO/Payment.pm
+++ b/lib/Registry/DAO/Payment.pm
@@ -565,6 +565,28 @@ field $_stripe_client = undef;
             # prevent, reintroduced one item at a time.
             next if $held eq 'waitlisted';
 
+            # The child already holds a live seat from another payment, so there
+            # is nothing to seat -- and trying would collide with the live-only
+            # uniqueness rule, inside a settlement Stripe has already captured.
+            # This cart paid for a seat it did not need, so its share is owed
+            # back. Not demoted: there is no row of ours to demote, and the row
+            # that exists belongs to whoever paid for it first.
+            if ( $held eq 'foreign' ) {
+                try {
+                    $owed_cents += $self->refund_share_for(
+                        $db, $item->{child_id}, $session_id );
+                    push @owed_children, $item->{child_id};
+                }
+                catch ($e) {
+                    $self->flag_refund_manual_review(
+                        $db, $item->{child_id}, $session_id );
+                    warn "finalize_enrollment: unresolvable duplicate-seat share for "
+                       . "child $item->{child_id} in session $session_id "
+                       . "(payment $id): $e";
+                }
+                next;
+            }
+
             # The seat was checked before the parent paid and is granted after.
             # In between is a Stripe round trip, so it is re-checked here, under
             # the lock taken above, before anything is written.

--- a/t/dao/enrollment-foreign-seat.t
+++ b/t/dao/enrollment-foreign-seat.t
@@ -1,0 +1,155 @@
+#!/usr/bin/env perl
+# ABOUTME: A seat held by a DIFFERENT payment is visible to the cart adjudicating against it.
+# ABOUTME: Scoping the seat lookup by payment_id made a foreign row read as no row at all.
+BEGIN { $ENV{EMAIL_SENDER_TRANSPORT} = 'Test' }
+
+use 5.42.0;
+use warnings;
+use lib qw(lib t/lib);
+use Test::More;
+use Test::Registry::DB;
+use Registry::DAO::Enrollment;
+use Registry::DAO::Payment;
+
+local $ENV{STRIPE_SECRET_KEY} = 'sk_test_foreign_seat';
+
+my $test_db = Test::Registry::DB->new;
+my $dao     = $test_db->db;
+my $db      = $dao->db;
+
+my $parent = $dao->create(User => {
+    username => 'fs_parent', name => 'FS Parent', user_type => 'parent',
+    email => 'fs@test.local' });
+
+my $n = 0;
+sub a_child () {
+    $n++;
+    Registry::DAO::Family->add_child($db, $parent->id, {
+        child_name => "FS Kid $n", birth_date => '2015-01-01', grade => '4',
+        medical_info => {}, emergency_contact => { name => 'x', phone => '5' } });
+}
+sub a_session ($capacity = 10) {
+    $n++;
+    my $loc = Registry::DAO::Location->create($db, {
+        name => "FS Loc $n$$", slug => "fs_loc_$n$$", address_info => {}, metadata => {} });
+    my $proj = Registry::DAO::Project->create($db, {
+        name => "FS Proj $n$$", status => 'published',
+        program_type_slug => 'summer-camp', metadata => {} });
+    my $teacher = $dao->create(User => {
+        username => "fs_t_$n$$", name => 'FS T', user_type => 'staff',
+        email => "fs_t_$n$$\@test.local" });
+    my $event = Registry::DAO::Event->create($db, {
+        location_id => $loc->id, project_id => $proj->id, teacher_id => $teacher->id,
+        time => \'NOW()', duration => 60, capacity => $capacity, metadata => {} });
+    my $s = Registry::DAO::Session->create($db, {
+        name => "FS Session $n$$", status => 'published',
+        capacity => $capacity, metadata => {} });
+    $s->add_events($db, $event->id);
+    return $s;
+}
+sub a_paid_cart ($session, $child, $cents = 10000) {
+    my $p = Registry::DAO::Payment->create($db, {
+        user_id => $parent->id, amount_cents => $cents, status => 'completed',
+        metadata => {
+            enrollment_items => [ { session_id => $session->id, child_id => $child->id } ],
+            tenant_slug      => undef } });
+    $db->insert('payment_items', {
+        payment_id => $p->id, description => 'seat', amount_cents => $cents,
+        metadata => { -json => { child_id => $child->id, session_id => $session->id } } });
+    return Registry::DAO::Payment->find($db, { id => $p->id });
+}
+
+# The gap, stated directly. cart_seat_state scoped its lookup by payment_id, so
+# a live seat held by ANOTHER payment read as 'none' -- the caller then
+# adjudicated as if the child were unseated and tried to insert, colliding with
+# enrollments_session_student_type_live inside a settlement Stripe had already
+# captured.
+subtest 'a seat held by another payment is visible, and distinct from our own' => sub {
+    my $session = a_session();
+    my $child   = a_child();
+    my $theirs  = a_paid_cart( $session, $child );
+    my $ours    = a_paid_cart( $session, $child );
+
+    Registry::DAO::Enrollment->create_for_payment($db, {
+        session_id => $session->id, family_member_id => $child->id,
+        parent_id => $parent->id, status => 'active', payment_id => $theirs->id });
+
+    is Registry::DAO::Enrollment->cart_seat_state(
+        $db, $theirs->id, $session->id, $child->id ), 'seated',
+        'the payment that holds it sees its own seat';
+
+    is Registry::DAO::Enrollment->cart_seat_state(
+        $db, $ours->id, $session->id, $child->id ), 'foreign',
+        'and another cart sees it as foreign -- not as no seat at all';
+};
+
+# 'foreign' has to be its own category rather than 'seated'.
+# payment_fits_session already counts foreign rows in $taken, so crediting one
+# to %granted would count the same seat twice and under-count the capacity left
+# for the next sibling in the cart.
+subtest 'a foreign seat is not credited to this cart' => sub {
+    my $session = a_session(2);
+    my $kid_a   = a_child();
+    my $kid_b   = a_child();
+    my $theirs  = a_paid_cart( $session, $kid_a );
+
+    Registry::DAO::Enrollment->create_for_payment($db, {
+        session_id => $session->id, family_member_id => $kid_a->id,
+        parent_id => $parent->id, status => 'active', payment_id => $theirs->id });
+
+    # Our cart names both children; kid_a is already seated by $theirs.
+    my $ours = Registry::DAO::Payment->create($db, {
+        user_id => $parent->id, amount_cents => 20000, status => 'completed',
+        metadata => { tenant_slug => undef, enrollment_items => [
+            { session_id => $session->id, child_id => $kid_a->id },
+            { session_id => $session->id, child_id => $kid_b->id } ] } });
+    for my $kid ( $kid_a, $kid_b ) {
+        $db->insert('payment_items', {
+            payment_id => $ours->id, description => 'seat', amount_cents => 10000,
+            metadata => { -json => { child_id => $kid->id, session_id => $session->id } } });
+    }
+
+    my $err = do {
+        local $@;
+        eval { Registry::DAO::Payment->find($db, { id => $ours->id })
+                   ->finalize_enrollment($db); 1 };
+        $@;
+    };
+    is $err, '', 'the settlement does not raise on the collision';
+
+    my $seated_b = $db->query(
+        q{SELECT COUNT(*) FROM enrollments
+           WHERE session_id = ? AND student_id = ? AND payment_id = ?
+             AND status IN ('active','pending')},
+        $session->id, $kid_b->id, $ours->id)->array->[0];
+    is $seated_b, 1,
+        'the sibling who needed a seat gets one -- the foreign seat did not '
+        . 'consume the capacity twice';
+
+    my $live_a = $db->query(
+        q{SELECT COUNT(*) FROM enrollments
+           WHERE session_id = ? AND student_id = ? AND status <> 'cancelled'},
+        $session->id, $kid_a->id)->array->[0];
+    is $live_a, 1, 'and the already-seated child still holds exactly one seat';
+};
+
+# The parent paid for a seat their child already had. That money is owed back.
+subtest 'a cart that paid for a seat the child already holds is owed a refund' => sub {
+    my $session = a_session();
+    my $child   = a_child();
+    my $theirs  = a_paid_cart( $session, $child );
+    my $ours    = a_paid_cart( $session, $child, 7500 );
+
+    Registry::DAO::Enrollment->create_for_payment($db, {
+        session_id => $session->id, family_member_id => $child->id,
+        parent_id => $parent->id, status => 'active', payment_id => $theirs->id });
+
+    Registry::DAO::Payment->find($db, { id => $ours->id })->finalize_enrollment($db);
+
+    my $row = $db->select('payments', '*', { id => $ours->id })->expand->hash;
+    is $row->{refund_owed_cents}, 7500,
+        'the duplicate payment owes its share back rather than keeping it';
+    is $row->{status}, 'refund_pending', 'and the row says so';
+};
+
+done_testing;


### PR DESCRIPTION
Closes the first and largest gap in #319 — which turned out to be a **money
defect**, not only a coverage one.

## The bug

`cart_seat_state` scoped its lookup by `payment_id`, so a live seat held by a
**different** payment read as `'none'`:

- a free enrolment with `payment_id IS NULL`
- an admin add
- an earlier purchase

The caller then adjudicated as though the child were unseated and tried to
insert — colliding with the uniqueness rule **inside a settlement Stripe had
already captured**. The transaction rolls back, the `die` releases the webhook
dedup claim by design, and every redelivery reproduces it.

Same failure as #315, reached through a different door.

## The fix

A fourth state, **`foreign`**, and it is deliberately *not* `seated`.

`payment_fits_session` already counts foreign rows in `$taken`, so crediting one
to this cart's `%granted` would count the same seat **twice** and under-count
the capacity left for the next sibling. The second subtest pins exactly that:
two children, one already seated by another payment, and the sibling who
genuinely needs a seat still gets one.

**A cart that paid for a seat the child already holds is owed its share back.**
There is nothing to seat and nothing of ours to demote — the row that exists
belongs to whoever paid for it first — but the parent paid. It goes through the
same `refund_share_for` path as a lost seat, with the same manual-review
fallback when the share cannot be computed.

## Why nothing caught it

The conjunction trap #319 describes. Three mechanisms shape "one seat per child
per session" — this filter, `payment_fits_session`'s payment exclusion, and the
uniqueness rule — and **every fixture in the suite creates its enrollment rows
from the cart under test**, so all three agree and the tests grade only their
aggregate. Removing the filter left four files green.

## Test evidence

Full suite: `Files=281, Tests=2415, Result: PASS`. Mutation-verified three ways
— all fail now:

| Mutation | |
|---|---|
| drop the `payment_id` filter | FAIL |
| report a foreign row as `seated` | FAIL |
| take the foreign branch without owing the refund | FAIL |

`t/stripe-live/` and `t/playwright/` were not run.

## Sequencing

This branch is off `main`, so **#324's partial-index migration is not in it**.
The collision the test reproduces is against the total constraint; after #324 it
is against the live-only index. Same collision for an *active* foreign row, so
the fix holds either way — but the two want a rebase check before both land.

https://claude.ai/code/session_01UMLwCP8cMNQ2kc4LnfeVc2